### PR TITLE
[v3] Switch to official vanity package name

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -28,7 +28,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml.v3"
 )
 
 var unmarshalIntTest = 123

--- a/encode_test.go
+++ b/encode_test.go
@@ -27,7 +27,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml.v3"
 )
 
 var marshalIntTest = 123

--- a/example_embedded_test.go
+++ b/example_embedded_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"log"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml.v3"
 )
 
 // An example showing how to unmarshal embedded

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/yaml.v3
+module go.yaml.in/yaml.v3
 
 go 1.22
 

--- a/limit_test.go
+++ b/limit_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml.v3"
 )
 
 var limitTests = []struct {

--- a/node_test.go
+++ b/node_test.go
@@ -24,7 +24,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml.v3"
 )
 
 var nodeTests = []struct {


### PR DESCRIPTION
we forked from "gopkg.in/yaml.v3" and will be using a new url / package name - "go.yaml.in/yaml.v3"