### PR TITLE
[v2] Switch to official vanity package name

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml.v2"
 )
 
 var unmarshalIntTest = 123

--- a/encode_test.go
+++ b/encode_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml.v2"
 )
 
 type jsonNumberT string

--- a/example_embedded_test.go
+++ b/example_embedded_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml.v2"
 )
 
 // An example showing how to unmarshal embedded

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/yaml.v2
+module go.yaml.in/yaml.v2
 
 go 1.15
 

--- a/limit_test.go
+++ b/limit_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml.v2"
 )
 
 var limitTests = []struct {


### PR DESCRIPTION
we forked from "gopkg.in/yaml.v2" and will be using a new url / package name - "go.yaml.in/yaml.v2"