### PR TITLE
Switch to official vanity package name v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ C library to parse and generate YAML data quickly and reliably.
 Compatibility
 -------------
 
-The yaml package is almost compatible with YAML 1.1, including support for
-anchors, tags, etc. There are still a few missing bits, such as document
-merging, base-60 floats (huh?), and multi-document unmarshalling. These
-features are not hard to add, and will be introduced as necessary.
+The yaml package supports most of YAML 1.1 and 1.2, including support for
+anchors, tags, map merging, etc. Multi-document unmarshalling is not yet
+implemented, and base-60 floats from YAML 1.1 are purposefully not
+supported since they're a poor design and are gone in YAML 1.2.
 
 Installation and usage
 ----------------------

--- a/decode.go
+++ b/decode.go
@@ -544,7 +544,7 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 		d.unmarshal(n, out)
 	case sequenceNode:
 		// Step backwards as earlier nodes take precedence.
-		for i := len(n.children)-1; i >= 0; i-- {
+		for i := len(n.children) - 1; i >= 0; i-- {
 			ni := n.children[i]
 			if ni.kind == aliasNode {
 				an, ok := d.doc.anchors[ni.value]

--- a/decode_test.go
+++ b/decode_test.go
@@ -2,7 +2,7 @@ package yaml_test
 
 import (
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"go.yaml.in/yaml.v1"
 	"math"
 	"reflect"
 	"strings"

--- a/encode.go
+++ b/encode.go
@@ -57,6 +57,10 @@ func (e *encoder) must(ok bool) {
 }
 
 func (e *encoder) marshal(tag string, in reflect.Value) {
+	if !in.IsValid() {
+		e.nilv()
+		return
+	}
 	var value interface{}
 	if getter, ok := in.Interface().(Getter); ok {
 		tag, value = getter.GetYAML()

--- a/encode_test.go
+++ b/encode_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"go.yaml.in/yaml.v1"
 )
 
 var marshalIntTest = 123

--- a/encode_test.go
+++ b/encode_test.go
@@ -2,12 +2,13 @@ package yaml_test
 
 import (
 	"fmt"
-	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
 	"math"
 	"strconv"
 	"strings"
 	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v1"
 )
 
 var marshalIntTest = 123
@@ -17,6 +18,9 @@ var marshalTests = []struct {
 	data  string
 }{
 	{
+		nil,
+		"null\n",
+	}, {
 		&struct{}{},
 		"{}\n",
 	}, {

--- a/yaml.go
+++ b/yaml.go
@@ -75,7 +75,7 @@ type Getter interface {
 //         F int `yaml:"a,omitempty"`
 //         B int
 //     }
-//     var T t
+//     var t T
 //     yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
 //
 // See the documentation of Marshal for the format of tags and a list of


### PR DESCRIPTION
we forked from "gopkg.in/yaml.v1" and will be using a new url / package name - "go.yaml.in/yaml.v1"