### PR TITLE
Allow unwrapping of non-terminal TypeErrors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"math"
 	"reflect"
-	"strconv"
 	"time"
 )
 
@@ -110,7 +109,6 @@ func (p *parser) peek() yaml_event_type_t {
 }
 
 func (p *parser) fail() {
-	var where string
 	var line int
 	if p.parser.context_mark.line != 0 {
 		line = p.parser.context_mark.line
@@ -125,16 +123,13 @@ func (p *parser) fail() {
 			line++
 		}
 	}
-	if line != 0 {
-		where = "line " + strconv.Itoa(line) + ": "
-	}
 	var msg string
 	if len(p.parser.problem) > 0 {
 		msg = p.parser.problem
 	} else {
 		msg = "unknown problem parsing YAML content"
 	}
-	failf("%s%s", where, msg)
+	fail(&ParserError{msg, line})
 }
 
 func (p *parser) anchor(n *Node, anchor []byte) {
@@ -313,7 +308,7 @@ func (p *parser) mapping() *Node {
 type decoder struct {
 	doc     *Node
 	aliases map[*Node]bool
-	terrors []string
+	terrors []*UnmarshalError
 
 	stringMapType  reflect.Type
 	generalMapType reflect.Type
@@ -357,19 +352,29 @@ func (d *decoder) terror(n *Node, tag string, out reflect.Value) {
 			value = " `" + value + "`"
 		}
 	}
-	d.terrors = append(d.terrors, fmt.Sprintf("line %d: cannot unmarshal %s%s into %s", n.Line, shortTag(tag), value, out.Type()))
+	d.terrors = append(d.terrors, &UnmarshalError{
+		Err:    fmt.Errorf("cannot unmarshal %s%s into %s", shortTag(tag), value, out.Type()),
+		Line:   n.Line,
+		Column: n.Column,
+	})
 }
 
 func (d *decoder) callUnmarshaler(n *Node, u Unmarshaler) (good bool) {
 	err := u.UnmarshalYAML(n)
-	if e, ok := err.(*TypeError); ok {
+	switch e := err.(type) {
+	case nil:
+		return true
+	case *TypeError:
 		d.terrors = append(d.terrors, e.Errors...)
 		return false
+	default:
+		d.terrors = append(d.terrors, &UnmarshalError{
+			Err:    err,
+			Line:   n.Line,
+			Column: n.Column,
+		})
+		return false
 	}
-	if err != nil {
-		fail(err)
-	}
-	return true
 }
 
 func (d *decoder) callObsoleteUnmarshaler(n *Node, u obsoleteUnmarshaler) (good bool) {
@@ -384,14 +389,20 @@ func (d *decoder) callObsoleteUnmarshaler(n *Node, u obsoleteUnmarshaler) (good 
 		}
 		return nil
 	})
-	if e, ok := err.(*TypeError); ok {
+	switch e := err.(type) {
+	case nil:
+		return true
+	case *TypeError:
 		d.terrors = append(d.terrors, e.Errors...)
 		return false
+	default:
+		d.terrors = append(d.terrors, &UnmarshalError{
+			Err:    err,
+			Line:   n.Line,
+			Column: n.Column,
+		})
+		return false
 	}
-	if err != nil {
-		fail(err)
-	}
-	return true
 }
 
 // d.prepare initializes and dereferences pointers and calls UnmarshalYAML
@@ -763,7 +774,11 @@ func (d *decoder) mapping(n *Node, out reflect.Value) (good bool) {
 			for j := i + 2; j < l; j += 2 {
 				nj := n.Content[j]
 				if ni.Kind == nj.Kind && ni.Value == nj.Value {
-					d.terrors = append(d.terrors, fmt.Sprintf("line %d: mapping key %#v already defined at line %d", nj.Line, nj.Value, ni.Line))
+					d.terrors = append(d.terrors, &UnmarshalError{
+						Err:    fmt.Errorf("mapping key %#v already defined at line %d", nj.Value, ni.Line),
+						Line:   nj.Line,
+						Column: nj.Column,
+					})
 				}
 			}
 		}
@@ -911,7 +926,11 @@ func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 		if info, ok := sinfo.FieldsMap[sname]; ok {
 			if d.uniqueKeys {
 				if doneFields[info.Id] {
-					d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s already set in type %s", ni.Line, name.String(), out.Type()))
+					d.terrors = append(d.terrors, &UnmarshalError{
+						Err:    fmt.Errorf("field %s already set in type %s", name.String(), out.Type()),
+						Line:   ni.Line,
+						Column: ni.Column,
+					})
 					continue
 				}
 				doneFields[info.Id] = true
@@ -931,7 +950,11 @@ func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 			d.unmarshal(n.Content[i+1], value)
 			inlineMap.SetMapIndex(name, value)
 		} else if d.knownFields {
-			d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s not found in type %s", ni.Line, name.String(), out.Type()))
+			d.terrors = append(d.terrors, &UnmarshalError{
+				Err:    fmt.Errorf("field %s not found in type %s", name.String(), out.Type()),
+				Line:   ni.Line,
+				Column: ni.Column,
+			})
 		}
 	}
 


### PR DESCRIPTION
This PR combines https://github.com/go-yaml/yaml/pull/901 and https://github.com/andig/yaml to allow:

- retrieving location of parser errors through new `ParserError`
- retrieving location though the Go errors mechanism by adding `UnmarshalError`and making `TypeError` unwrappable

It was never merged upstream but got positive feedback.