### PR TITLE
Basic linter configuration, and a lint action for CI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -24,6 +24,17 @@ jobs:
           echo 'Run go fmt ./... and commit changes.'
           exit 1
         fi
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+    - uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.4
   build:
     strategy:
       matrix:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,22 @@
+version: '2'
+
+linters:
+  enable:
+  - govet
+  disable:
+  - errcheck
+  - ineffassign
+  - staticcheck
+  - unused
+  exclusions:
+    generated: lax
+    presets:
+    - comments
+    - common-false-positives
+    - legacy
+    - std-error-handling
+
+formatters:
+  enable: []
+  exclusions:
+    generated: lax


### PR DESCRIPTION
This adds minimal configuration for [golangci-lint](https://golangci-lint.run/). As of this PR, it runs none of the standard linters other than govet, which I chose to do as the first implementation because govet doesn't find any issues with it. I have also ensured that the formatter configuration is disabled.

This also configures a new workflow action named `lint` which runs with the others. It makes use of the latest [golangci/golangci-lint-action@v8] action, which uses the Github output format thing that inserts any problems found into the code tab for review.

This technically resolves issue #4 in the most lukewarm way possible. Followup PRs can expand the linters run and fix the problems identified.