### PR TITLE
Add staticcheck to the Linter configuration

### DIFF
--- a/resolve.go
+++ b/resolve.go
@@ -198,7 +198,7 @@ func resolve(tag string, in string) (rtag string, out any) {
 				}
 			}
 
-			plain := strings.Replace(in, "_", "", -1)
+			plain := strings.ReplaceAll(in, "_", "")
 			intv, err := strconv.ParseInt(plain, 0, 64)
 			if err == nil {
 				if intv == int64(int(intv)) {

--- a/yaml.go
+++ b/yaml.go
@@ -640,7 +640,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		info := fieldInfo{Num: i}
 
 		tag := field.Tag.Get("yaml")
-		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
+		if tag == "" && !strings.Contains(string(field.Tag), ":") {
 			tag = string(field.Tag)
 		}
 		if tag == "-" {
@@ -659,7 +659,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 				case "inline":
 					inline = true
 				default:
-					return nil, errors.New(fmt.Sprintf("unsupported flag %q in tag %q of type %s", flag, tag, st))
+					return nil, fmt.Errorf("unsupported flag %q in tag %q of type %s", flag, tag, st)
 				}
 			}
 			tag = fields[0]


### PR DESCRIPTION
This builds on the work in #26 and #27, so ensure those are merged first.

This is the first of these linter configs where the fixes might be controversial. It removes some unused code and applies De Morgan's law in a couple cases, removes some redundant parentheses, turns some if-else statements into switch statements (which is the preferred style in Go), changes one instance of `error.New(fmt.Sprintf(...))` to `fmt.Errorf(...)`, changes a use of `strings.Index` to `strings.Contains`, changing a use of `reflect.PtrTo` to the new `reflect.PointerTo` method, and things like that.

The controversial bit is all the cases where it suggests De Morgan's law be applied. I just added `//nolint:staticcheck` comments with explanations for the majority of these. Most of them are cases where the change would make no appreciable difference to readability or might actually make the expression less readable. At least, that was my judgement call on these.

I'd be happy to defer to the reviewer if the reviewer would prefer a different solution in any of these cases.