### PR TITLE
Add fuzzer: FuzzEncodeFromJSON which signals roundtripping issues

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,74 @@
+//go:build go1.18
+// +build go1.18
+
+package yaml_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// FuzzEncodeFromJSON checks that any JSON encoded value can also be encoded as YAML... and decoded.
+func FuzzEncodeFromJSON(f *testing.F) {
+	f.Add(`null`)
+	f.Add(`""`)
+	f.Add(`0`)
+	f.Add(`true`)
+	f.Add(`false`)
+	f.Add(`{}`)
+	f.Add(`[]`)
+	f.Add(`[[]]`)
+	f.Add(`{"a":[]}`)
+
+	f.Fuzz(func(t *testing.T, s string) {
+
+		var v interface{}
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			t.Skip("not valid JSON")
+		}
+
+		t.Logf("JSON %q", s)
+		t.Logf("Go   %q <%[1]x>", v)
+
+		// Encode as YAML
+		b, err := yaml.Marshal(v)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("YAML %q <%[1]x>", b)
+
+		// Decode as YAML
+		var v2 interface{}
+		if err := yaml.Unmarshal(b, &v2); err != nil {
+			t.Error(err)
+		}
+
+		t.Logf("Go   %q <%[1]x>", v2)
+
+		/*
+			// Handling of number is different, so we can't have universal exact matching
+			if !reflect.DeepEqual(v2, v) {
+				t.Errorf("mismatch:\n-      got: %#v\n- expected: %#v", v2, v)
+			}
+		*/
+
+		b2, err := yaml.Marshal(v2)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("YAML %q <%[1]x>", b2)
+
+		if !bytes.Equal(b, b2) {
+			t.Errorf("Marshal->Unmarshal->Marshal mismatch:\n- expected: %q\n- got:      %q", b, b2)
+		}
+
+	})
+}
+
+func TestEncodeString(t *testing.T) {
+	b, _ := yaml.Marshal(`\n`)
+	t.Logf("%q <%[1]x>", string(b))
+}


### PR DESCRIPTION
Add fuzzing for roundtripping by using JSON documents as input.

The principle: YAML is a superset of JSON, so any data structure serialisable as a JSON document should be serializable with a YAML serializer and that document should give back the original structure after deserialisation. The fuzzer uses JSON documents as input. 

This fuzzer detects issues such as https://github.com/go-yaml/yaml/issues/1004.

Note: this is a port of go-yaml/yaml#1024 which I have also submitted as kubernetes-sigs/yaml#110 and goccy/go-yaml#742.

```console
$ go test -fuzz FuzzEncodeFromJSON
OK: 50 passed
fuzz: elapsed: 0s, gathering baseline coverage: 0/9 completed
fuzz: elapsed: 0s, gathering baseline coverage: 9/9 completed, now fuzzing with 8 workers
fuzz: elapsed: 0s, execs: 4829 (25353/sec), new interesting: 34 (total: 43)
--- FAIL: FuzzEncodeFromJSON (0.20s)
    --- FAIL: FuzzEncodeFromJSON (0.00s)
        fuzz_test.go:33: JSON "-0"
        fuzz_test.go:34: Go   %!q(float64=-0) <-0x0p+00>
        fuzz_test.go:41: YAML "-0\n" <2d300a>
        fuzz_test.go:49: Go   '\x00' <0>
        fuzz_test.go:62: YAML "0\n" <300a>
        fuzz_test.go:65: Marshal->Unmarshal->Marshal mismatch:
            - expected: "-0\n"
            - got:      "0\n"
    
    Failing input written to testdata/fuzz/FuzzEncodeFromJSON/c64b69bf2c432100
    To re-run:
    go test -run=FuzzEncodeFromJSON/c64b69bf2c432100
FAIL
exit status 1
FAIL	go.yaml.in/yaml/v3	4.168s
```