### PR TITLE
Downgrade the go version number in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module go.yaml.in/yaml/v3
 
-go 1.22
+go 1.16
 
 require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405


### PR DESCRIPTION
The go.mod in the current version is set to 1.22, which will make it impossible for projects that need to be compiled with an older version of golang to reference the package.

It is recommended to downgrade the go line back to 1.12 in the original version so that more projects can switch to the new fork.