### PR TITLE
Handle decoding of `-0` from YAML

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -31,6 +31,11 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+// negativeZero represents -0.0 for YAML test cases
+// this is needed because Go constants cannot express -0.0
+// https://staticcheck.dev/docs/checks/#SA4026
+var negativeZero = math.Copysign(0.0, -1.0)
+
 var unmarshalIntTest = 123
 
 var unmarshalTests = []struct {
@@ -84,12 +89,18 @@ var unmarshalTests = []struct {
 	}, {
 		"v: -.1",
 		map[string]interface{}{"v": -0.1},
+	}, {
+		"v: -0\n",
+		map[string]interface{}{"v": negativeZero},
 	},
 
 	// Simple values.
 	{
 		"123",
 		&unmarshalIntTest,
+	}, {
+		"-0",
+		negativeZero,
 	},
 
 	// Floats from spec

--- a/encode_test.go
+++ b/encode_test.go
@@ -126,12 +126,18 @@ var marshalTests = []struct {
 	}, {
 		map[string]interface{}{"a": "-"},
 		"a: '-'\n",
+	}, {
+		map[string]interface{}{"v": negativeZero},
+		"v: -0\n",
 	},
 
 	// Simple values.
 	{
 		&marshalIntTest,
 		"123\n",
+	}, {
+		negativeZero,
+		"-0\n",
 	},
 
 	// Structures

--- a/node_test.go
+++ b/node_test.go
@@ -351,6 +351,34 @@ var nodeTests = []struct {
 			}},
 		},
 	}, {
+		"-0\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.ScalarNode,
+				Value:  "-0",
+				Tag:    "!!float",
+				Line:   1,
+				Column: 1,
+			}},
+		},
+	}, {
+		"-0.0\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.ScalarNode,
+				Value:  "-0.0",
+				Tag:    "!!float",
+				Line:   1,
+				Column: 1,
+			}},
+		},
+	}, {
 		"{}\n",
 		yaml.Node{
 			Kind:   yaml.DocumentNode,

--- a/resolve.go
+++ b/resolve.go
@@ -56,6 +56,7 @@ func init() {
 		{math.Inf(+1), floatTag, []string{".inf", ".Inf", ".INF"}},
 		{math.Inf(+1), floatTag, []string{"+.inf", "+.Inf", "+.INF"}},
 		{math.Inf(-1), floatTag, []string{"-.inf", "-.Inf", "-.INF"}},
+		{negativeZero, floatTag, []string{"-0", "-0.0"}},
 		{"<<", mergeTag, []string{"<<"}},
 	}
 
@@ -79,6 +80,11 @@ const (
 	binaryTag    = "!!binary"
 	mergeTag     = "!!merge"
 )
+
+// negativeZero represents -0.0 for YAML encoding/decoding
+// this is needed because Go constants cannot express -0.0
+// https://staticcheck.dev/docs/checks/#SA4026
+var negativeZero = math.Copysign(0.0, -1.0)
 
 var longTags = make(map[string]string)
 var shortTags = make(map[string]string)


### PR DESCRIPTION
This change is necessary because Go constants cannot represent `-0.0`: https://staticcheck.dev/docs/checks/#SA4026

As a result, when parsing `-0` or `-0.0`, the value ends up as `0` or `0.0` in Go.

Before:
```go
> go run a.go
Decoded into Go: 0

Re-encoded YAML:
0
```

After:
```go
> go run x/a.go
Decoded into Go: -0

Re-encoded YAML:
-0
```

Source:
```go
package main

import (
	"fmt"
	"log"

	"go.yaml.in/yaml/v3"
)

func main() {
	input := []byte("-0\n")

	var f float64
	if err := yaml.Unmarshal(input, &f); err != nil {
		log.Fatal(err)
	}
	fmt.Printf("Decoded into Go: %#v\n", f)

	out, err := yaml.Marshal(f)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println("\nRe-encoded YAML:")
	fmt.Print(string(out))
}
```