### PR TITLE
Handle roundtrip of "\t\n"

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -84,12 +84,18 @@ var unmarshalTests = []struct {
 	}, {
 		"v: -.1",
 		map[string]interface{}{"v": -0.1},
+	}, {
+		"a: |\n    \t\n    \t\n",
+		map[string]string{"a": "\t\n\t\n"},
 	},
 
 	// Simple values.
 	{
 		"123",
 		&unmarshalIntTest,
+	}, {
+		"|\n    \t\n",
+		"\t\n",
 	},
 
 	// Floats from spec

--- a/encode_test.go
+++ b/encode_test.go
@@ -132,6 +132,9 @@ var marshalTests = []struct {
 	{
 		&marshalIntTest,
 		"123\n",
+	}, {
+		"\t\n",
+		"|\n    \t\n",
 	},
 
 	// Structures
@@ -427,6 +430,9 @@ var marshalTests = []struct {
 	{
 		map[string]string{"a": "\tB\n\tC\n"},
 		"a: |\n    \tB\n    \tC\n",
+	}, {
+		map[string]string{"a": "\t\n\t\n"},
+		"a: |\n    \t\n    \t\n",
 	},
 
 	// Ensure that strings do not wrap

--- a/node_test.go
+++ b/node_test.go
@@ -252,6 +252,21 @@ var nodeTests = []struct {
 			}},
 		},
 	}, {
+		"|\n  \t\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.ScalarNode,
+				Style:  yaml.LiteralStyle,
+				Value:  "\t\n",
+				Tag:    "!!str",
+				Line:   1,
+				Column: 1,
+			}},
+		},
+	}, {
 		"|\n  foo\n  bar\n",
 		yaml.Node{
 			Kind:   yaml.DocumentNode,

--- a/scannerc.go
+++ b/scannerc.go
@@ -2401,7 +2401,7 @@ func yaml_parser_scan_block_scalar_breaks(parser *yaml_parser_t, indent *int, br
 		}
 
 		// Check for a tab character messing the indentation.
-		if (*indent == 0 || parser.mark.column < *indent) && is_tab(parser.buffer, parser.buffer_pos) {
+		if (parser.mark.column < *indent) && is_tab(parser.buffer, parser.buffer_pos) {
 			return yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
 				start_mark, "found a tab character where an indentation space is expected")
 		}


### PR DESCRIPTION
This fixes a go-yaml issue where strings like `\t\n` could be encoded but not decoded properly.

Before
```
~/c/go-yaml-2 (main)> go run x/b.go
Initial string: "\t\n"

Encoded into YAML:
|
        
2025/06/27 00:54:57 yaml: line 2: found a tab character where an indentation space is expected
exit status 1

~/c/go-yaml-2 (main) [1]>
```

After
```
~/c/go-yaml-2 (main) [1]> git checkout handle-tab-string
Switched to branch 'handle-tab-string'

carlos@hk-carlos ~/c/go-yaml-2 (handle-tab-string)> go run x/b.go
Initial string: "\t\n"

Encoded into YAML:
|
        
Decoded into Go: "\t\n"

```

Source
```
~/c/go-yaml-2 (handle-tab-string)> cat x/b.go 
package main

import (
	"fmt"
	"log"

	"go.yaml.in/yaml/v3"
)

func main() {
	initial := "\t\n"
	fmt.Printf("Initial string: %q\n", initial)

	out, err := yaml.Marshal(initial)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println("\nEncoded into YAML:")
	fmt.Print(string(out))

	var f string
	if err := yaml.Unmarshal([]byte(out), &f); err != nil {
		log.Fatal(err)
	}
	fmt.Printf("Decoded into Go: %#v\n", f)
}
```