### PR TITLE
bug: Fix error unmarshalling alias/anchor with non alphanumeric name

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -512,6 +512,9 @@ var unmarshalTests = []struct {
 	}, {
 		"a: &a [1, 2]\nb: *a",
 		&struct{ B []int }{[]int{1, 2}},
+	}, {
+		"a: &a.b1.c [1, 2]\nb: *a.b1.c",
+		&struct{ B []int }{[]int{1, 2}},
 	},
 
 	// Bug #1133337

--- a/emitterc.go
+++ b/emitterc.go
@@ -1252,10 +1252,10 @@ func yaml_emitter_analyze_anchor(emitter *yaml_emitter_t, anchor []byte, alias b
 		return yaml_emitter_set_emitter_error(emitter, problem)
 	}
 	for i := 0; i < len(anchor); i += width(anchor[i]) {
-		if !is_alpha(anchor, i) {
-			problem := "anchor value must contain alphanumerical characters only"
+		if !is_anchor_char(anchor, i) {
+			problem := "anchor value must contain valid characters only"
 			if alias {
-				problem = "alias value must contain alphanumerical characters only"
+				problem = "alias value must contain valid characters only"
 			}
 			return yaml_emitter_set_emitter_error(emitter, problem)
 		}

--- a/node_test.go
+++ b/node_test.go
@@ -1110,6 +1110,59 @@ var nodeTests = []struct {
 			}},
 		},
 	}, {
+		"a: &anchor(.!@#$%^&*+=?:;)name [1, 2]\nb: *anchor(.!@#$%^&*+=?:;)name\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.MappingNode,
+				Line:   1,
+				Column: 1,
+				Tag:    "!!map",
+				Content: []*yaml.Node{{
+					Kind:   yaml.ScalarNode,
+					Value:  "a",
+					Tag:    "!!str",
+					Line:   1,
+					Column: 1,
+				},
+					saveNode("anchor(.!@#$%^&*+=?:;)name", &yaml.Node{
+						Kind:   yaml.SequenceNode,
+						Style:  yaml.FlowStyle,
+						Tag:    "!!seq",
+						Anchor: "anchor(.!@#$%^&*+=?:;)name",
+						Line:   1,
+						Column: 4,
+						Content: []*yaml.Node{{
+							Kind:   yaml.ScalarNode,
+							Value:  "1",
+							Tag:    "!!int",
+							Line:   1,
+							Column: 33,
+						}, {
+							Kind:   yaml.ScalarNode,
+							Value:  "2",
+							Tag:    "!!int",
+							Line:   1,
+							Column: 36,
+						}},
+					}), {
+						Kind:   yaml.ScalarNode,
+						Value:  "b",
+						Tag:    "!!str",
+						Line:   2,
+						Column: 1,
+					}, {
+						Kind:   yaml.AliasNode,
+						Value:  "anchor(.!@#$%^&*+=?:;)name",
+						Alias:  dropNode("anchor(.!@#$%^&*+=?:;)name"),
+						Line:   2,
+						Column: 4,
+					}},
+			}},
+		},
+	}, {
 
 		"# One\n# Two\ntrue # Three\n# Four\n# Five\n",
 		yaml.Node{

--- a/scannerc.go
+++ b/scannerc.go
@@ -1908,7 +1908,7 @@ func yaml_parser_scan_anchor(parser *yaml_parser_t, token *yaml_token_t, typ yam
 		return false
 	}
 
-	for is_alpha(parser.buffer, parser.buffer_pos) {
+	for is_anchor_char(parser.buffer, parser.buffer_pos) {
 		s = read(parser, s)
 		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 			return false

--- a/yamlprivateh.go
+++ b/yamlprivateh.go
@@ -46,7 +46,33 @@ const (
 // Check if the character at the specified position is an alphabetical
 // character, a digit, '_', or '-'.
 func is_alpha(b []byte, i int) bool {
-	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'Z' || b[i] >= 'a' && b[i] <= 'z' || b[i] == '_' || b[i] == '-'
+	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'Z' ||
+		b[i] >= 'a' && b[i] <= 'z' || b[i] == '_' || b[i] == '-'
+}
+
+// Check if the character at the specified position is a flow indicator as
+// defined by spec production [23] c-flow-indicator ::=
+// c-collect-entry | c-sequence-start | c-sequence-end |
+// c-mapping-start | c-mapping-end
+func is_flow_indicator(b []byte, i int) bool {
+	return b[i] == '[' || b[i] == ']' ||
+		b[i] == '{' || b[i] == '}' || b[i] == ','
+}
+
+// Check if the character at the specified position is valid for anchor names
+// as defined by spec production [102] ns-anchor-char ::= ns-char -
+// c-flow-indicator.
+// This includes all printable characters except: CR, LF, BOM, space, tab, '[',
+// ']', '{', '}', ','.
+// We further limit it to ascii chars only, which is a subset of the spec
+// production but is usually what most people expect.
+func is_anchor_char(b []byte, i int) bool {
+	return is_printable(b, i) &&
+		!is_break(b, i) &&
+		!is_blank(b, i) &&
+		!is_bom(b, i) &&
+		!is_flow_indicator(b, i) &&
+		is_ascii(b, i)
 }
 
 // Check if the character at the specified position is a digit.
@@ -61,7 +87,8 @@ func as_digit(b []byte, i int) int {
 
 // Check if the character at the specified position is a hex-digit.
 func is_hex(b []byte, i int) bool {
-	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'F' || b[i] >= 'a' && b[i] <= 'f'
+	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'F' ||
+		b[i] >= 'a' && b[i] <= 'f'
 }
 
 // Get the value of a hex-digit.

--- a/yts/known-failing-tests
+++ b/yts/known-failing-tests
@@ -4,8 +4,6 @@ TestYAMLSuite/2JQS/UnmarshalTest
 TestYAMLSuite/2JQS/EventComparisonTest
 TestYAMLSuite/2LFX/UnmarshalTest
 TestYAMLSuite/2LFX/EventComparisonTest
-TestYAMLSuite/2SXE/UnmarshalTest
-TestYAMLSuite/2SXE/EventComparisonTest
 TestYAMLSuite/35KP/JSONComparisonTest
 TestYAMLSuite/3HFZ/UnmarshalTest
 TestYAMLSuite/3UYS/UnmarshalTest
@@ -187,8 +185,6 @@ TestYAMLSuite/01#15/UnmarshalTest
 TestYAMLSuite/01#15/EventComparisonTest
 TestYAMLSuite/W4TN/UnmarshalTest
 TestYAMLSuite/W4TN/EventComparisonTest
-TestYAMLSuite/W5VH/UnmarshalTest
-TestYAMLSuite/W5VH/EventComparisonTest
 TestYAMLSuite/WZ62/UnmarshalTest
 TestYAMLSuite/WZ62/EventComparisonTest
 TestYAMLSuite/X38W/UnmarshalTest
@@ -196,8 +192,6 @@ TestYAMLSuite/X38W/EventComparisonTest
 TestYAMLSuite/X4QW/UnmarshalTest
 TestYAMLSuite/X4QW/EventComparisonTest
 TestYAMLSuite/XW4D/UnmarshalTest
-TestYAMLSuite/Y2GN/EventComparisonTest
-TestYAMLSuite/Y2GN/JSONComparisonTest
 TestYAMLSuite/001/UnmarshalTest
 TestYAMLSuite/001/EventComparisonTest
 TestYAMLSuite/003/UnmarshalTest


### PR DESCRIPTION
closes #44

This addresses the parser being overly restrictive on acceptable anchor/alias names.


Before
```
~/c/go-yaml-2 (main)> go run x/a.go
2025/06/28 06:57:37 yaml: line 3: did not find expected alphabetic or numeric character
exit status 1
```

After
```
~/c/go-yaml-2 (main) [1]> git checkout fix-anchor-names 
Switched to branch 'fix-anchor-names'
~/c/go-yaml-2 (fix-anchor-names)> go run x/a.go
Decoded into Go: map[string]interface {}{"Message":[]interface {}{[]interface {}{map[string]interface {}{"payload":"./network/core/v1/Ping.yml", "type":"./network/enums/v1/MessageType.yml"}, map[string]interface {}{"payload":"./network/core/v1/Pong.yml", "type":"./network/enums/v1/MessageType.yml"}}}, "references":[]interface {}{"./network/core/v1/Ping.yml", "./network/core/v1/Pong.yml", "./network/enums/v1/MessageType.yml"}}

Re-encoded YAML:
Message:
    - - payload: ./network/core/v1/Ping.yml
        type: ./network/enums/v1/MessageType.yml
      - payload: ./network/core/v1/Pong.yml
        type: ./network/enums/v1/MessageType.yml
references:
    - ./network/core/v1/Ping.yml
    - ./network/core/v1/Pong.yml
    - ./network/enums/v1/MessageType.yml
```
Source
```
~/c/go-yaml-2 (fix-anchor-names)> cat x/a.go
package main

import (
	"fmt"
	"log"

	"go.yaml.in/yaml/v3"
)

func main() {
	input := []byte(`---
references:
    - &network.core.v1.Ping ./network/core/v1/Ping.yml
    - &network.core.v1.Pong ./network/core/v1/Pong.yml
    - &network.enums.v1.MessageType ./network/enums/v1/MessageType.yml
Message:
    - - type: *network.enums.v1.MessageType
        payload: *network.core.v1.Ping
      - type: *network.enums.v1.MessageType
        payload: *network.core.v1.Pong
`)
	var f map[string]interface{}
	if err := yaml.Unmarshal(input, &f); err != nil {
		log.Fatal(err)
	}
	fmt.Printf("Decoded into Go: %#v\n", f)

	out, err := yaml.Marshal(f)
	// out, err := yaml.Marshal("\t\n")
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println("\nRe-encoded YAML:")
	fmt.Print(string(out))
}
```