### PR TITLE
Handle roundtrip for `{"<<": []}`

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -84,6 +84,12 @@ var unmarshalTests = []struct {
 	}, {
 		"v: -.1",
 		map[string]interface{}{"v": -0.1},
+	}, {
+		"\"<<\": []\n",
+		map[string]interface{}{"<<": []interface{}{}},
+	}, {
+		"foo: \"<<\"\n",
+		map[string]interface{}{"foo": "<<"},
 	},
 
 	// Simple values.

--- a/encode.go
+++ b/encode.go
@@ -321,6 +321,10 @@ func isOldBool(s string) (result bool) {
 	}
 }
 
+func looksLikeMerge(s string) (result bool) {
+	return s == "<<"
+}
+
 func (e *encoder) stringv(tag string, in reflect.Value) {
 	var style yaml_scalar_style_t
 	s := in.String()
@@ -342,7 +346,7 @@ func (e *encoder) stringv(tag string, in reflect.Value) {
 		// tag when encoded unquoted. If it doesn't,
 		// there's no need to quote it.
 		rtag, _ := resolve("", s)
-		canUsePlain = rtag == strTag && !(isBase60Float(s) || isOldBool(s))
+		canUsePlain = rtag == strTag && !(isBase60Float(s) || isOldBool(s) || looksLikeMerge(s))
 	}
 	// Note: it's possible for user code to emit invalid YAML
 	// if they explicitly specify a tag and a string containing

--- a/encode_test.go
+++ b/encode_test.go
@@ -427,6 +427,12 @@ var marshalTests = []struct {
 	{
 		map[string]string{"a": "\tB\n\tC\n"},
 		"a: |\n    \tB\n    \tC\n",
+	}, {
+		map[string]interface{}{"<<": []string{}},
+		"\"<<\": []\n",
+	}, {
+		map[string]interface{}{"foo": "<<"},
+		"foo: \"<<\"\n",
 	},
 
 	// Ensure that strings do not wrap

--- a/node_test.go
+++ b/node_test.go
@@ -393,6 +393,63 @@ var nodeTests = []struct {
 			}},
 		},
 	}, {
+		"\"<<\": []\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.MappingNode,
+				Value:  "",
+				Tag:    "!!map",
+				Line:   1,
+				Column: 1,
+				Content: []*yaml.Node{{
+					Kind:   yaml.ScalarNode,
+					Style:  yaml.DoubleQuotedStyle,
+					Value:  "<<",
+					Tag:    "!!str",
+					Line:   1,
+					Column: 1,
+				}, {
+					Kind:   yaml.SequenceNode,
+					Style:  yaml.FlowStyle,
+					Value:  "",
+					Tag:    "!!seq",
+					Line:   1,
+					Column: 7,
+				}},
+			}},
+		},
+	}, {
+		"foo: \"<<\"\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.MappingNode,
+				Value:  "",
+				Tag:    "!!map",
+				Line:   1,
+				Column: 1,
+				Content: []*yaml.Node{{
+					Kind:   yaml.ScalarNode,
+					Value:  "foo",
+					Tag:    "!!str",
+					Line:   1,
+					Column: 1,
+				}, {
+					Kind:   yaml.ScalarNode,
+					Style:  yaml.DoubleQuotedStyle,
+					Value:  "<<",
+					Tag:    "!!str",
+					Line:   1,
+					Column: 6,
+				}},
+			}},
+		},
+	}, {
 		"a:\n  b: c\n  d: e\n",
 		yaml.Node{
 			Kind:   yaml.DocumentNode,


### PR DESCRIPTION
This fixes a go-yaml issue where the string `<<` was encoded unquoted and treated as a merge key when decoded.

Before
```
~/c/go-yaml-2 (main)> go run x/b.go
Initial value: map[string]interface {}{"<<":[]interface {}{}}

Encoded into YAML:
<<: []
Decoded into Go: map[string]interface {}{}
```

After
```
carlos@hk-carlos ~/c/go-yaml-2 (main)> git checkout fix-merge-key
Switched to branch 'fix-merge-key'
carlos@hk-carlos ~/c/go-yaml-2 (fix-merge-key)> go run x/b.go
Initial value: map[string]interface {}{"<<":[]interface {}{}}

Encoded into YAML:
"<<": []
Decoded into Go: map[string]interface {}{"<<":[]interface {}{}}
```

Source
```
carlos@hk-carlos ~/c/go-yaml-2 (fix-merge-key)> cat x/b.go
package main

import (
	"fmt"
	"log"

	"go.yaml.in/yaml/v3"
)

func main() {
	initial := map[string]interface{}{"<<": []interface{}{}}
	fmt.Printf("Initial value: %#v\n", initial)

	out, err := yaml.Marshal(initial)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println("\nEncoded into YAML:")
	fmt.Print(string(out))

	var f map[string]interface{}
	if err := yaml.Unmarshal([]byte(out), &f); err != nil {
		log.Fatal(err)
	}
	fmt.Printf("Decoded into Go: %#v\n", f)
}
```