### PR TITLE
bug: fix handling of '?' in unquoted values

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -815,6 +815,39 @@ var unmarshalTests = []struct {
 			"c": []interface{}{"d", "e"},
 		},
 	},
+	// bug: question mark in value
+	{
+		"foo: {ba?r: a?bc}",
+		map[string]interface{}{
+			"foo": map[string]interface{}{"ba?r": "a?bc"},
+		},
+	}, {
+		"foo: {?bar: ?abc}",
+		map[string]interface{}{
+			"foo": map[string]interface{}{"?bar": "?abc"},
+		},
+	}, {
+		"foo: {bar?: abc?}",
+		map[string]interface{}{
+			"foo": map[string]interface{}{"bar?": "abc?"},
+		},
+	}, {
+		"foo: {? key: value}",
+		map[string]interface{}{
+			"foo": map[string]interface{}{"key": "value"},
+		},
+	}, {
+		`---
+foo:
+  ? complex key
+  : complex value
+ba?r: a?bc
+`,
+		map[string]interface{}{
+			"foo":  map[string]interface{}{"complex key": "complex value"},
+			"ba?r": "a?bc",
+		},
+	},
 }
 
 type M map[string]interface{}

--- a/encode_test.go
+++ b/encode_test.go
@@ -500,6 +500,13 @@ var marshalTests = []struct {
 		},
 		"value: !!seq []\n",
 	},
+	// bug: question mark in value
+	{
+		map[string]interface{}{
+			"foo": map[string]interface{}{"bar": "a?bc"},
+		},
+		"foo:\n    bar: a?bc\n",
+	},
 }
 
 func (s *S) TestMarshal(c *C) {

--- a/node_test.go
+++ b/node_test.go
@@ -527,6 +527,45 @@ var nodeTests = []struct {
 			}},
 		},
 	}, {
+		"[decode]foo: {b?r: a?bc}\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.MappingNode,
+				Tag:    "!!map",
+				Line:   1,
+				Column: 1,
+				Content: []*yaml.Node{{
+					Kind:   yaml.ScalarNode,
+					Value:  "foo",
+					Tag:    "!!str",
+					Line:   1,
+					Column: 1,
+				}, {
+					Kind:   yaml.MappingNode,
+					Style:  yaml.FlowStyle,
+					Tag:    "!!map",
+					Line:   1,
+					Column: 6,
+					Content: []*yaml.Node{{
+						Kind:   yaml.ScalarNode,
+						Value:  "b?r",
+						Tag:    "!!str",
+						Line:   1,
+						Column: 7,
+					}, {
+						Kind:   yaml.ScalarNode,
+						Value:  "a?bc",
+						Tag:    "!!str",
+						Line:   1,
+						Column: 12,
+					}},
+				}},
+			}},
+		},
+	}, {
 		"a: # AI\n  - b\nc:\n  - d\n",
 		yaml.Node{
 			Kind:   yaml.DocumentNode,

--- a/scannerc.go
+++ b/scannerc.go
@@ -793,7 +793,7 @@ func yaml_parser_fetch_next_token(parser *yaml_parser_t) (ok bool) {
 	}
 
 	// Is it the key indicator?
-	if parser.buffer[parser.buffer_pos] == '?' && (parser.flow_level > 0 || is_blankz(parser.buffer, parser.buffer_pos+1)) {
+	if parser.buffer[parser.buffer_pos] == '?' && is_blankz(parser.buffer, parser.buffer_pos+1) {
 		return yaml_parser_fetch_key(parser)
 	}
 
@@ -868,8 +868,7 @@ func yaml_parser_fetch_next_token(parser *yaml_parser_t) (ok bool) {
 		parser.buffer[parser.buffer_pos] == '"' || parser.buffer[parser.buffer_pos] == '%' ||
 		parser.buffer[parser.buffer_pos] == '@' || parser.buffer[parser.buffer_pos] == '`') ||
 		(parser.buffer[parser.buffer_pos] == '-' && !is_blank(parser.buffer, parser.buffer_pos+1)) ||
-		(parser.flow_level == 0 &&
-			(parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == ':') &&
+		((parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == ':') &&
 			!is_blankz(parser.buffer, parser.buffer_pos+1)) {
 		return yaml_parser_fetch_plain_scalar(parser)
 	}
@@ -2728,7 +2727,8 @@ func yaml_parser_scan_plain_scalar(parser *yaml_parser_t, token *yaml_token_t) b
 			if (parser.buffer[parser.buffer_pos] == ':' && is_blankz(parser.buffer, parser.buffer_pos+1)) ||
 				(parser.flow_level > 0 &&
 					(parser.buffer[parser.buffer_pos] == ',' ||
-						parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == '[' ||
+						(parser.buffer[parser.buffer_pos] == '?' && is_blankz(parser.buffer, parser.buffer_pos+1)) ||
+						parser.buffer[parser.buffer_pos] == '[' ||
 						parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '{' ||
 						parser.buffer[parser.buffer_pos] == '}')) {
 				break


### PR DESCRIPTION
closes #36

Fix the conditions for considering `?` as key indicator.

Before
```
~/c/go-yaml-2 (main)> go run x/a.go
Initial value: "foo: {bar: a?bc}"
2025/06/28 08:20:26 yaml: did not find expected ',' or '}'
exit status 1
```

After
```
~/c/go-yaml-2 (main) [1]> git checkout fix-question-mark-value 
Switched to branch 'fix-question-mark-value'
~/c/go-yaml-2 (fix-question-mark-value)> go run x/a.go
Initial value: "foo: {bar: a?bc}"
Decoded into Go: map[string]interface {}{"foo":map[string]interface {}{"bar":"a?bc"}}

Re-encoded YAML:
foo:
    bar: a?bc
```

Source
```
~/c/go-yaml-2 (fix-question-mark-value)> cat x/a.go
package main

import (
	"fmt"
	"log"

	"go.yaml.in/yaml/v3"
)

func main() {
	input := []byte("foo: {bar: a?bc}")
	fmt.Printf("Initial value: %q\n", input)
	var f map[string]interface{}
	if err := yaml.Unmarshal(input, &f); err != nil {
		log.Fatal(err)
	}
	fmt.Printf("Decoded into Go: %#v\n", f)

	out, err := yaml.Marshal(f)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println("\nRe-encoded YAML:")
	fmt.Print(string(out))
}
```