### PR TITLE
Run GHA workflows on main and vX branches

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,11 +2,11 @@ name: CodeQL Advanced
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, v4, v3, v2, v1 ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, v4, v3, v2, v1 ]
   schedule:
-    - cron: 17 13 * * 3
+  - cron: 17 13 * * 3
 
 jobs:
   analyze:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ main, v3, v2 ]
+    branches: [ main, v4, v3, v2, v1 ]
   pull_request:
-    branches: [ main, v3, v2 ]
+    branches: [ main, v4, v3, v2, v1 ]
 
 jobs:
   fmt:


### PR DESCRIPTION
This is needed to allow GH to merge PRs according to the rulesets in place.