### PR TITLE
YTS test instructs how to download test data

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,6 +45,8 @@ count ?= 1
 test: $(TEST-DEPS)
 	go test$(if $v, -v)
 
+test-data: $(YTS-DIR)
+
 test-all: test test-yts-all
 
 test-yts: $(TEST-DEPS)

--- a/yts/test_suite_test.go
+++ b/yts/test_suite_test.go
@@ -49,6 +49,11 @@ func shouldSkipTest(t *testing.T) {
 
 func TestYAMLSuite(t *testing.T) {
 	testDir := "./testdata/data-2022-01-17"
+	if _, err := os.Stat(testDir + "/229Q"); os.IsNotExist(err) {
+		t.Fatalf(`YTS tests require data files to be present at '%s'.
+Run 'make test-data' to download them first,
+or just run the tests with 'make test-all'.`, testDir)
+	}
 	runTestsInDir(t, testDir)
 }
 


### PR DESCRIPTION
In order to run the yaml test suite we need the data files to be present. A user with a fresh clone trying to run all tests will face an error. This makes the error message clear and provides the step needed to enable the tests to run.