### PR TITLE
Tighten encoding style rules for literal scalars

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -92,6 +92,9 @@ var unmarshalTests = []struct {
 		"v: -0\n",
 		map[string]interface{}{"v": negativeZero},
 	}, {
+		"a: \"\\t\\n\\t\\n\"\n",
+		map[string]string{"a": "\t\n\t\n"},
+	}, {
 		"\"<<\": []\n",
 		map[string]interface{}{"<<": []interface{}{}},
 	}, {
@@ -106,6 +109,9 @@ var unmarshalTests = []struct {
 	}, {
 		"-0",
 		negativeZero,
+	}, {
+		"\"\\t\\n\"\n",
+		"\t\n",
 	},
 
 	// Floats from spec

--- a/encode.go
+++ b/encode.go
@@ -360,7 +360,7 @@ func (e *encoder) stringv(tag string, in reflect.Value) {
 	// text that's incompatible with that tag.
 	switch {
 	case strings.Contains(s, "\n"):
-		if e.flow {
+		if e.flow || !shouldUseLiteralStyle(s) {
 			style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
 		} else {
 			style = yaml_LITERAL_SCALAR_STYLE

--- a/encode_test.go
+++ b/encode_test.go
@@ -1056,6 +1056,16 @@ func TestScalarStyleRules(t *testing.T) {
 			"|-\n    a\n    b\n",
 			"Two chars with newline - should be literal (3 chars, has content)",
 		},
+		{
+			" a\n",
+			"|4\n     a\n",
+			"Space + char + newline - should be literal (3 chars, has content)",
+		},
+		{
+			"\ta\n",
+			"|\n    \ta\n",
+			"Tab + char + newline - should be literal (3 chars, has content)",
+		},
 	}
 
 	for i, testCase := range testCases {
@@ -1158,7 +1168,7 @@ func TestWhitespaceWithContent(t *testing.T) {
 		{
 			" hello\n",
 			"|4\n     hello\n",
-			"Space + text + newline - should be literal (has non-ws chars, >= 6 chars)",
+			"Space + text + newline - should be literal (has non-ws chars)",
 		},
 		{
 			" \nhello",
@@ -1168,7 +1178,7 @@ func TestWhitespaceWithContent(t *testing.T) {
 		{
 			"\thello\n",
 			"|\n    \thello\n",
-			"Tab + text + newline - should be literal (has non-ws chars, >= 6 chars)",
+			"Tab + text + newline - should be literal (has non-ws chars)",
 		},
 		{
 			"\t\nhello",

--- a/encode_test.go
+++ b/encode_test.go
@@ -1220,3 +1220,210 @@ func TestWhitespaceWithContent(t *testing.T) {
 		})
 	}
 }
+
+func TestUnicodeWhitespaceHandling(t *testing.T) {
+	// Test cases for Unicode whitespace characters that should be properly handled
+	// by the shouldUseLiteralStyle function using unicode.IsSpace()
+	testCases := []struct {
+		input    string
+		expected string
+		desc     string
+	}{
+		// Unicode whitespace characters
+		{
+			"hello\u00A0\n", // non-breaking space
+			"|\n    hello\u00A0\n",
+			"Non-breaking space with content - should use literal style",
+		},
+		{
+			"\u00A0\n", // non-breaking space
+			"\"\u00A0\\n\"\n",
+			"Non-breaking space only - should not use literal style",
+		},
+		{
+			"hello\u2000\n", // en quad
+			"|\n    hello\u2000\n",
+			"En quad with content - should use literal style",
+		},
+		{
+			"\u2000\n", // en quad
+			"\"\u2000\\n\"\n",
+			"En quad only - should not use literal style",
+		},
+		{
+			"hello\u2001\n", // em quad
+			"|\n    hello\u2001\n",
+			"Em quad with content - should use literal style",
+		},
+		{
+			"\u2001\n", // em quad
+			"\"\u2001\\n\"\n",
+			"Em quad only - should not use literal style",
+		},
+		{
+			"hello\u2002\n", // en space
+			"|\n    hello\u2002\n",
+			"En space with content - should use literal style",
+		},
+		{
+			"\u2002\n", // en space
+			"\"\u2002\\n\"\n",
+			"En space only - should not use literal style",
+		},
+		{
+			"hello\u2003\n", // em space
+			"|\n    hello\u2003\n",
+			"Em space with content - should use literal style",
+		},
+		{
+			"\u2003\n", // em space
+			"\"\u2003\\n\"\n",
+			"Em space only - should not use literal style",
+		},
+		{
+			"hello\u2004\n", // three-per-em space
+			"|\n    hello\u2004\n",
+			"Three-per-em space with content - should use literal style",
+		},
+		{
+			"\u2004\n", // three-per-em space
+			"\"\u2004\\n\"\n",
+			"Three-per-em space only - should not use literal style",
+		},
+		{
+			"hello\u2005\n", // four-per-em space
+			"|\n    hello\u2005\n",
+			"Four-per-em space with content - should use literal style",
+		},
+		{
+			"\u2005\n", // four-per-em space
+			"\"\u2005\\n\"\n",
+			"Four-per-em space only - should not use literal style",
+		},
+		{
+			"hello\u2006\n", // six-per-em space
+			"|\n    hello\u2006\n",
+			"Six-per-em space with content - should use literal style",
+		},
+		{
+			"\u2006\n", // six-per-em space
+			"\"\u2006\\n\"\n",
+			"Six-per-em space only - should not use literal style",
+		},
+		{
+			"hello\u2007\n", // figure space
+			"|\n    hello\u2007\n",
+			"Figure space with content - should use literal style",
+		},
+		{
+			"\u2007\n", // figure space
+			"\"\u2007\\n\"\n",
+			"Figure space only - should not use literal style",
+		},
+		{
+			"hello\u2008\n", // punctuation space
+			"|\n    hello\u2008\n",
+			"Punctuation space with content - should use literal style",
+		},
+		{
+			"\u2008\n", // punctuation space
+			"\"\u2008\\n\"\n",
+			"Punctuation space only - should not use literal style",
+		},
+		{
+			"hello\u2009\n", // thin space
+			"|\n    hello\u2009\n",
+			"Thin space with content - should use literal style",
+		},
+		{
+			"\u2009\n", // thin space
+			"\"\u2009\\n\"\n",
+			"Thin space only - should not use literal style",
+		},
+		{
+			"hello\u200A\n", // hair space
+			"|\n    hello\u200A\n",
+			"Hair space with content - should use literal style",
+		},
+		{
+			"\u200A\n", // hair space
+			"\"\u200A\\n\"\n",
+			"Hair space only - should not use literal style",
+		},
+		// Other Unicode whitespace
+		{
+			"hello\u2028\n", // line separator
+			"|+\n    hello\u2028\n",
+			"Line separator with content - should use literal style",
+		},
+		{
+			"\u2028\n", // line separator
+			"\"\\L\\n\"\n",
+			"Line separator only - should not use literal style",
+		},
+		{
+			"hello\u2029\n", // paragraph separator
+			"|+\n    hello\u2029\n",
+			"Paragraph separator with content - should use literal style",
+		},
+		{
+			"\u2029\n", // paragraph separator
+			"\"\\P\\n\"\n",
+			"Paragraph separator only - should not use literal style",
+		},
+		{
+			"hello\u205F\n", // medium mathematical space
+			"|\n    hello\u205F\n",
+			"Medium mathematical space with content - should use literal style",
+		},
+		{
+			"\u205F\n", // medium mathematical space
+			"\"\u205F\\n\"\n",
+			"Medium mathematical space only - should not use literal style",
+		},
+		{
+			"hello\u3000\n", // ideographic space
+			"|\n    hello\u3000\n",
+			"Ideographic space with content - should use literal style",
+		},
+		{
+			"\u3000\n", // ideographic space
+			"\"\u3000\\n\"\n",
+			"Ideographic space only - should not use literal style",
+		},
+		// Mixed Unicode whitespace
+		{
+			"hello\u00A0\u2000\u2001\n", // mixed Unicode spaces
+			"|\n    hello\u00A0\u2000\u2001\n",
+			"Mixed Unicode spaces with content - should use literal style",
+		},
+		{
+			"\u00A0\u2000\u2001\n", // mixed Unicode spaces
+			"\"\u00A0\u2000\u2001\\n\"\n",
+			"Mixed Unicode spaces only - should not use literal style",
+		},
+		// Unicode whitespace with ASCII whitespace
+		{
+			"hello \u00A0\t\n", // ASCII + Unicode spaces
+			"|\n    hello \u00A0\t\n",
+			"ASCII + Unicode spaces with content - should use literal style",
+		},
+		{
+			" \u00A0\t\n", // ASCII + Unicode spaces
+			"\" \u00A0\\t\\n\"\n",
+			"ASCII + Unicode spaces only - should not use literal style",
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("test_%d_%s", i, testCase.desc), func(t *testing.T) {
+			data, err := yaml.Marshal(testCase.input)
+			if err != nil {
+				t.Fatalf("Marshal() returned error: %v", err)
+			}
+			if string(data) != testCase.expected {
+				t.Fatalf("Marshal() returned\n%q\nbut expected\n%q", string(data), testCase.expected)
+			}
+		})
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -137,6 +137,9 @@ var marshalTests = []struct {
 	}, {
 		negativeZero,
 		"-0\n",
+	}, {
+		"\t\n",
+		"\"\\t\\n\"\n",
 	},
 
 	// Structures
@@ -432,6 +435,9 @@ var marshalTests = []struct {
 	{
 		map[string]string{"a": "\tB\n\tC\n"},
 		"a: |\n    \tB\n    \tC\n",
+	}, {
+		map[string]string{"a": "\t\n\t\n"},
+		"a: \"\\t\\n\\t\\n\"\n",
 	}, {
 		map[string]interface{}{"<<": []string{}},
 		"\"<<\": []\n",

--- a/node_test.go
+++ b/node_test.go
@@ -253,6 +253,21 @@ var nodeTests = []struct {
 			}},
 		},
 	}, {
+		"\"\\t\\n\"\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.ScalarNode,
+				Style:  yaml.DoubleQuotedStyle,
+				Value:  "\t\n",
+				Tag:    "!!str",
+				Line:   1,
+				Column: 1,
+			}},
+		},
+	}, {
 		"|\n  foo\n  bar\n",
 		yaml.Node{
 			Kind:   yaml.DocumentNode,

--- a/yaml.go
+++ b/yaml.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -529,7 +530,7 @@ func shouldUseLiteralStyle(s string) bool {
 	}
 	// Must contain at least one non-whitespace character
 	for _, r := range s {
-		if r != ' ' && r != '\t' && r != '\n' && r != '\r' {
+		if !unicode.IsSpace(r) {
 			return true
 		}
 	}

--- a/yaml.go
+++ b/yaml.go
@@ -522,15 +522,9 @@ func (n *Node) indicatedString() bool {
 // shouldUseLiteralStyle determines if a string should use literal style.
 // It returns true if the string contains newlines AND meets additional criteria:
 // - is at least 2 characters long
-// - if it starts with whitespace, it must be at least 6 characters long
 // - contains at least one non-whitespace character
 func shouldUseLiteralStyle(s string) bool {
 	if !strings.Contains(s, "\n") || len(s) < 2 {
-		return false
-	}
-	// If it starts with whitespace, require it to be longer to use literal style
-	// Any longer than 6 characters breaks a lot of the current tests
-	if (s[0] == ' ' || s[0] == '\t') && len(s) < 6 {
 		return false
 	}
 	// Must contain at least one non-whitespace character


### PR DESCRIPTION
Fixes the problem identified in:\
https://github.com/yaml/go-yaml/pull/46