### PR TITLE
Handle TextUnmarshaler errors as type errors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -603,7 +603,12 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 			}
 			err := u.UnmarshalText(text)
 			if err != nil {
-				fail(err)
+				d.terrors = append(d.terrors, &UnmarshalError{
+					Err:    err,
+					Line:   n.Line,
+					Column: n.Column,
+				})
+				return false
 			}
 			return true
 		}


### PR DESCRIPTION
Previously, errors returned by `UnmarshalText` were handled as hard immediate errors, aborting unmarshaling immediately. Now they're treated as `TypeErrors`, just like similar error conditions.

This is a follow-up to #19 which introduced `TypeError`. That PR had `yaml.Unmarshaler` support contributed by me, but I forgot about `encoding.TextUnmarshaler`. This commit amends that oversight.