### PR TITLE
feat: Use Go 1.18 as minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ func main() {
 	}
 	fmt.Printf("--- t dump:\n%s\n\n", string(d))
 
-	m := make(map[interface{}]interface{})
+	m := make(map[any]any)
 
 	err = yaml.Unmarshal([]byte(data), &m)
 	if err != nil {

--- a/decode.go
+++ b/decode.go
@@ -319,14 +319,14 @@ type decoder struct {
 	aliasCount  int
 	aliasDepth  int
 
-	mergedFields map[interface{}]bool
+	mergedFields map[any]bool
 }
 
 var (
 	nodeType       = reflect.TypeOf(Node{})
 	durationType   = reflect.TypeOf(time.Duration(0))
-	stringMapType  = reflect.TypeOf(map[string]interface{}{})
-	generalMapType = reflect.TypeOf(map[interface{}]interface{}{})
+	stringMapType  = reflect.TypeOf(map[string]any{})
+	generalMapType = reflect.TypeOf(map[any]any{})
 	ifaceType      = generalMapType.Elem()
 )
 
@@ -379,7 +379,7 @@ func (d *decoder) callUnmarshaler(n *Node, u Unmarshaler) (good bool) {
 
 func (d *decoder) callObsoleteUnmarshaler(n *Node, u obsoleteUnmarshaler) (good bool) {
 	terrlen := len(d.terrors)
-	err := u.UnmarshalYAML(func(v interface{}) (err error) {
+	err := u.UnmarshalYAML(func(v any) (err error) {
 		defer handleErr(&err)
 		d.unmarshal(n, reflect.ValueOf(v))
 		if len(d.terrors) > terrlen {
@@ -565,7 +565,7 @@ func (d *decoder) null(out reflect.Value) bool {
 
 func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 	var tag string
-	var resolved interface{}
+	var resolved any
 	if n.indicatedString() {
 		tag = strTag
 		resolved = n.Value
@@ -725,7 +725,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 	return false
 }
 
-func settableValueOf(i interface{}) reflect.Value {
+func settableValueOf(i any) reflect.Value {
 	v := reflect.ValueOf(i)
 	sv := reflect.New(v.Type()).Elem()
 	sv.Set(v)
@@ -746,7 +746,7 @@ func (d *decoder) sequence(n *Node, out reflect.Value) (good bool) {
 	case reflect.Interface:
 		// No type hints. Will have to use a generic sequence.
 		iface = out
-		out = settableValueOf(make([]interface{}, l))
+		out = settableValueOf(make([]any, l))
 	default:
 		d.terror(n, seqTag, out)
 		return false
@@ -974,7 +974,7 @@ func failWantMap() {
 	failf("map merge requires map or sequence of maps as the value")
 }
 
-func (d *decoder) setPossiblyUnhashableKey(m map[interface{}]bool, key interface{}, value bool) {
+func (d *decoder) setPossiblyUnhashableKey(m map[any]bool, key any, value bool) {
 	defer func() {
 		if err := recover(); err != nil {
 			failf("%v", err)
@@ -983,7 +983,7 @@ func (d *decoder) setPossiblyUnhashableKey(m map[interface{}]bool, key interface
 	m[key] = value
 }
 
-func (d *decoder) getPossiblyUnhashableKey(m map[interface{}]bool, key interface{}) bool {
+func (d *decoder) getPossiblyUnhashableKey(m map[any]bool, key any) bool {
 	defer func() {
 		if err := recover(); err != nil {
 			failf("%v", err)
@@ -995,7 +995,7 @@ func (d *decoder) getPossiblyUnhashableKey(m map[interface{}]bool, key interface
 func (d *decoder) merge(parent *Node, merge *Node, out reflect.Value) {
 	mergedFields := d.mergedFields
 	if mergedFields == nil {
-		d.mergedFields = make(map[interface{}]bool)
+		d.mergedFields = make(map[any]bool)
 		for i := 0; i < len(parent.Content); i += 2 {
 			k := reflect.New(ifaceType).Elem()
 			if d.unmarshal(parent.Content[i], k) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -40,7 +40,7 @@ var unmarshalIntTest = 123
 
 var unmarshalTests = []struct {
 	data  string
-	value interface{}
+	value any
 }{
 	{
 		"",
@@ -52,55 +52,55 @@ var unmarshalTests = []struct {
 		"v: hi",
 		map[string]string{"v": "hi"},
 	}, {
-		"v: hi", map[string]interface{}{"v": "hi"},
+		"v: hi", map[string]any{"v": "hi"},
 	}, {
 		"v: true",
 		map[string]string{"v": "true"},
 	}, {
 		"v: true",
-		map[string]interface{}{"v": true},
+		map[string]any{"v": true},
 	}, {
 		"v: 10",
-		map[string]interface{}{"v": 10},
+		map[string]any{"v": 10},
 	}, {
 		"v: 0b10",
-		map[string]interface{}{"v": 2},
+		map[string]any{"v": 2},
 	}, {
 		"v: 0xA",
-		map[string]interface{}{"v": 10},
+		map[string]any{"v": 10},
 	}, {
 		"v: 4294967296",
 		map[string]int64{"v": 4294967296},
 	}, {
 		"v: 0.1",
-		map[string]interface{}{"v": 0.1},
+		map[string]any{"v": 0.1},
 	}, {
 		"v: .1",
-		map[string]interface{}{"v": 0.1},
+		map[string]any{"v": 0.1},
 	}, {
 		"v: .Inf",
-		map[string]interface{}{"v": math.Inf(+1)},
+		map[string]any{"v": math.Inf(+1)},
 	}, {
 		"v: -.Inf",
-		map[string]interface{}{"v": math.Inf(-1)},
+		map[string]any{"v": math.Inf(-1)},
 	}, {
 		"v: -10",
-		map[string]interface{}{"v": -10},
+		map[string]any{"v": -10},
 	}, {
 		"v: -.1",
-		map[string]interface{}{"v": -0.1},
+		map[string]any{"v": -0.1},
 	}, {
 		"v: -0\n",
-		map[string]interface{}{"v": negativeZero},
+		map[string]any{"v": negativeZero},
 	}, {
 		"a: \"\\t\\n\\t\\n\"\n",
 		map[string]string{"a": "\t\n\t\n"},
 	}, {
 		"\"<<\": []\n",
-		map[string]interface{}{"<<": []interface{}{}},
+		map[string]any{"<<": []any{}},
 	}, {
 		"foo: \"<<\"\n",
-		map[string]interface{}{"foo": "<<"},
+		map[string]any{"foo": "<<"},
 	},
 
 	// Simple values.
@@ -118,42 +118,42 @@ var unmarshalTests = []struct {
 	// Floats from spec
 	{
 		"canonical: 6.8523e+5",
-		map[string]interface{}{"canonical": 6.8523e+5},
+		map[string]any{"canonical": 6.8523e+5},
 	}, {
 		"expo: 685.230_15e+03",
-		map[string]interface{}{"expo": 685.23015e+03},
+		map[string]any{"expo": 685.23015e+03},
 	}, {
 		"fixed: 685_230.15",
-		map[string]interface{}{"fixed": 685230.15},
+		map[string]any{"fixed": 685230.15},
 	}, {
 		"neginf: -.inf",
-		map[string]interface{}{"neginf": math.Inf(-1)},
+		map[string]any{"neginf": math.Inf(-1)},
 	}, {
 		"fixed: 685_230.15",
 		map[string]float64{"fixed": 685230.15},
 	},
-	//{"sexa: 190:20:30.15", map[string]interface{}{"sexa": 0}}, // Unsupported
-	//{"notanum: .NaN", map[string]interface{}{"notanum": math.NaN()}}, // Equality of NaN fails.
+	//{"sexa: 190:20:30.15", map[string]any{"sexa": 0}}, // Unsupported
+	//{"notanum: .NaN", map[string]any{"notanum": math.NaN()}}, // Equality of NaN fails.
 
 	// Bools are per 1.2 spec.
 	{
 		"canonical: true",
-		map[string]interface{}{"canonical": true},
+		map[string]any{"canonical": true},
 	}, {
 		"canonical: false",
-		map[string]interface{}{"canonical": false},
+		map[string]any{"canonical": false},
 	}, {
 		"bool: True",
-		map[string]interface{}{"bool": true},
+		map[string]any{"bool": true},
 	}, {
 		"bool: False",
-		map[string]interface{}{"bool": false},
+		map[string]any{"bool": false},
 	}, {
 		"bool: TRUE",
-		map[string]interface{}{"bool": true},
+		map[string]any{"bool": true},
 	}, {
 		"bool: FALSE",
-		map[string]interface{}{"bool": false},
+		map[string]any{"bool": false},
 	},
 	// For backwards compatibility with 1.1, decoding old strings into typed values still works.
 	{
@@ -175,54 +175,54 @@ var unmarshalTests = []struct {
 	// Ints from spec
 	{
 		"canonical: 685230",
-		map[string]interface{}{"canonical": 685230},
+		map[string]any{"canonical": 685230},
 	}, {
 		"decimal: +685_230",
-		map[string]interface{}{"decimal": 685230},
+		map[string]any{"decimal": 685230},
 	}, {
 		"octal: 02472256",
-		map[string]interface{}{"octal": 685230},
+		map[string]any{"octal": 685230},
 	}, {
 		"octal: -02472256",
-		map[string]interface{}{"octal": -685230},
+		map[string]any{"octal": -685230},
 	}, {
 		"octal: 0o2472256",
-		map[string]interface{}{"octal": 685230},
+		map[string]any{"octal": 685230},
 	}, {
 		"octal: -0o2472256",
-		map[string]interface{}{"octal": -685230},
+		map[string]any{"octal": -685230},
 	}, {
 		"hexa: 0x_0A_74_AE",
-		map[string]interface{}{"hexa": 685230},
+		map[string]any{"hexa": 685230},
 	}, {
 		"bin: 0b1010_0111_0100_1010_1110",
-		map[string]interface{}{"bin": 685230},
+		map[string]any{"bin": 685230},
 	}, {
 		"bin: -0b101010",
-		map[string]interface{}{"bin": -42},
+		map[string]any{"bin": -42},
 	}, {
 		"bin: -0b1000000000000000000000000000000000000000000000000000000000000000",
-		map[string]interface{}{"bin": -9223372036854775808},
+		map[string]any{"bin": -9223372036854775808},
 	}, {
 		"decimal: +685_230",
 		map[string]int{"decimal": 685230},
 	},
 
-	//{"sexa: 190:20:30", map[string]interface{}{"sexa": 0}}, // Unsupported
+	//{"sexa: 190:20:30", map[string]any{"sexa": 0}}, // Unsupported
 
 	// Nulls from spec
 	{
 		"empty:",
-		map[string]interface{}{"empty": nil},
+		map[string]any{"empty": nil},
 	}, {
 		"canonical: ~",
-		map[string]interface{}{"canonical": nil},
+		map[string]any{"canonical": nil},
 	}, {
 		"english: null",
-		map[string]interface{}{"english": nil},
+		map[string]any{"english": nil},
 	}, {
 		"~: null key",
-		map[interface{}]string{nil: "null key"},
+		map[any]string{nil: "null key"},
 	}, {
 		"empty:",
 		map[string]*bool{"empty": nil},
@@ -231,7 +231,7 @@ var unmarshalTests = []struct {
 	// Flow sequence
 	{
 		"seq: [A,B]",
-		map[string]interface{}{"seq": []interface{}{"A", "B"}},
+		map[string]any{"seq": []any{"A", "B"}},
 	}, {
 		"seq: [A,B,C,]",
 		map[string][]string{"seq": []string{"A", "B", "C"}},
@@ -243,12 +243,12 @@ var unmarshalTests = []struct {
 		map[string][]int{"seq": []int{1}},
 	}, {
 		"seq: [A,1,C]",
-		map[string]interface{}{"seq": []interface{}{"A", 1, "C"}},
+		map[string]any{"seq": []any{"A", 1, "C"}},
 	},
 	// Block sequence
 	{
 		"seq:\n - A\n - B",
-		map[string]interface{}{"seq": []interface{}{"A", "B"}},
+		map[string]any{"seq": []any{"A", "B"}},
 	}, {
 		"seq:\n - A\n - B\n - C",
 		map[string][]string{"seq": []string{"A", "B", "C"}},
@@ -260,7 +260,7 @@ var unmarshalTests = []struct {
 		map[string][]int{"seq": []int{1}},
 	}, {
 		"seq:\n - A\n - 1\n - C",
-		map[string]interface{}{"seq": []interface{}{"A", 1, "C"}},
+		map[string]any{"seq": []any{"A", 1, "C"}},
 	},
 
 	// Literal block scalar
@@ -278,12 +278,12 @@ var unmarshalTests = []struct {
 	// Map inside interface with no type hints.
 	{
 		"a: {b: c}",
-		map[interface{}]interface{}{"a": map[string]interface{}{"b": "c"}},
+		map[any]any{"a": map[string]any{"b": "c"}},
 	},
 	// Non-string map inside interface with no type hints.
 	{
 		"a: {b: c, 1: d}",
-		map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": "c", 1: "d"}},
+		map[any]any{"a": map[any]any{"b": "c", 1: "d"}},
 	},
 
 	// Structs and type conversions.
@@ -475,7 +475,7 @@ var unmarshalTests = []struct {
 	// Quoted values.
 	{
 		"'1': '\"2\"'",
-		map[interface{}]interface{}{"1": "\"2\""},
+		map[any]any{"1": "\"2\""},
 	}, {
 		"v:\n- A\n- 'B\n\n  C'\n",
 		map[string][]string{"v": []string{"A", "B\nC"}},
@@ -484,25 +484,25 @@ var unmarshalTests = []struct {
 	// Explicit tags.
 	{
 		"v: !!float '1.1'",
-		map[string]interface{}{"v": 1.1},
+		map[string]any{"v": 1.1},
 	}, {
 		"v: !!float 0",
-		map[string]interface{}{"v": float64(0)},
+		map[string]any{"v": float64(0)},
 	}, {
 		"v: !!float -1",
-		map[string]interface{}{"v": float64(-1)},
+		map[string]any{"v": float64(-1)},
 	}, {
 		"v: !!null ''",
-		map[string]interface{}{"v": nil},
+		map[string]any{"v": nil},
 	}, {
 		"%TAG !y! tag:yaml.org,2002:\n---\nv: !y!int '1'",
-		map[string]interface{}{"v": 1},
+		map[string]any{"v": 1},
 	},
 
 	// Non-specific tag (Issue #75)
 	{
 		"v: ! test",
-		map[string]interface{}{"v": "test"},
+		map[string]any{"v": "test"},
 	},
 
 	// Anchors and aliases.
@@ -536,7 +536,7 @@ var unmarshalTests = []struct {
 		map[string]string{"foo": ""},
 	}, {
 		"foo: null",
-		map[string]interface{}{"foo": nil},
+		map[string]any{"foo": nil},
 	},
 
 	// Support for ~
@@ -548,7 +548,7 @@ var unmarshalTests = []struct {
 		map[string]string{"foo": ""},
 	}, {
 		"foo: ~",
-		map[string]interface{}{"foo": nil},
+		map[string]any{"foo": nil},
 	},
 
 	// Ignored field
@@ -617,27 +617,27 @@ var unmarshalTests = []struct {
 	// bug 1243827
 	{
 		"a: -b_c",
-		map[string]interface{}{"a": "-b_c"},
+		map[string]any{"a": "-b_c"},
 	},
 	{
 		"a: +b_c",
-		map[string]interface{}{"a": "+b_c"},
+		map[string]any{"a": "+b_c"},
 	},
 	{
 		"a: 50cent_of_dollar",
-		map[string]interface{}{"a": "50cent_of_dollar"},
+		map[string]any{"a": "50cent_of_dollar"},
 	},
 
 	// issue #295 (allow scalars with colons in flow mappings and sequences)
 	{
 		"a: {b: https://github.com/go-yaml/yaml}",
-		map[string]interface{}{"a": map[string]interface{}{
+		map[string]any{"a": map[string]any{
 			"b": "https://github.com/go-yaml/yaml",
 		}},
 	},
 	{
 		"a: [https://github.com/go-yaml/yaml]",
-		map[string]interface{}{"a": []interface{}{"https://github.com/go-yaml/yaml"}},
+		map[string]any{"a": []any{"https://github.com/go-yaml/yaml"}},
 	},
 
 	// Duration
@@ -673,7 +673,7 @@ var unmarshalTests = []struct {
 	// Issue #39.
 	{
 		"a:\n b:\n  c: d\n",
-		map[string]struct{ B interface{} }{"a": {map[string]interface{}{"c": "d"}}},
+		map[string]struct{ B any }{"a": {map[string]any{"c": "d"}}},
 	},
 
 	// Custom map type.
@@ -723,17 +723,17 @@ var unmarshalTests = []struct {
 	//	{
 	//		// space separated with time zone
 	//		"a: 2001-12-14 21:59:43.10 -5",
-	//		map[string]interface{}{"a": time.Date(2001, 12, 14, 21, 59, 43, .1e9, time.UTC)},
+	//		map[string]any{"a": time.Date(2001, 12, 14, 21, 59, 43, .1e9, time.UTC)},
 	//	},
 	//	{
 	//		// arbitrary whitespace between fields
 	//		"a: 2001-12-14 \t\t \t21:59:43.10 \t Z",
-	//		map[string]interface{}{"a": time.Date(2001, 12, 14, 21, 59, 43, .1e9, time.UTC)},
+	//		map[string]any{"a": time.Date(2001, 12, 14, 21, 59, 43, .1e9, time.UTC)},
 	//	},
 	{
 		// explicit string tag
 		"a: !!str 2015-01-01",
-		map[string]interface{}{"a": "2015-01-01"},
+		map[string]any{"a": "2015-01-01"},
 	},
 	{
 		// explicit timestamp tag on quoted string
@@ -748,17 +748,17 @@ var unmarshalTests = []struct {
 	{
 		// quoted string that's a valid timestamp
 		"a: \"2015-01-01\"",
-		map[string]interface{}{"a": "2015-01-01"},
+		map[string]any{"a": "2015-01-01"},
 	},
 	{
 		// explicit timestamp tag into interface.
 		"a: !!timestamp \"2015-01-01\"",
-		map[string]interface{}{"a": time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)},
+		map[string]any{"a": time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)},
 	},
 	{
 		// implicit timestamp tag into interface.
 		"a: 2015-01-01",
-		map[string]interface{}{"a": time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)},
+		map[string]any{"a": time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)},
 	},
 
 	// Encode empty lists as zero-length slices.
@@ -800,7 +800,7 @@ var unmarshalTests = []struct {
 	// yaml-test-suite 3GZX: Spec Example 7.1. Alias Nodes
 	{
 		"First occurrence: &anchor Foo\nSecond occurrence: *anchor\nOverride anchor: &anchor Bar\nReuse anchor: *anchor\n",
-		map[string]interface{}{
+		map[string]any{
 			"First occurrence":  "Foo",
 			"Second occurrence": "Foo",
 			"Override anchor":   "Bar",
@@ -825,31 +825,31 @@ var unmarshalTests = []struct {
 	// CRLF
 	{
 		"a: b\r\nc:\r\n- d\r\n- e\r\n",
-		map[string]interface{}{
+		map[string]any{
 			"a": "b",
-			"c": []interface{}{"d", "e"},
+			"c": []any{"d", "e"},
 		},
 	},
 	// bug: question mark in value
 	{
 		"foo: {ba?r: a?bc}",
-		map[string]interface{}{
-			"foo": map[string]interface{}{"ba?r": "a?bc"},
+		map[string]any{
+			"foo": map[string]any{"ba?r": "a?bc"},
 		},
 	}, {
 		"foo: {?bar: ?abc}",
-		map[string]interface{}{
-			"foo": map[string]interface{}{"?bar": "?abc"},
+		map[string]any{
+			"foo": map[string]any{"?bar": "?abc"},
 		},
 	}, {
 		"foo: {bar?: abc?}",
-		map[string]interface{}{
-			"foo": map[string]interface{}{"bar?": "abc?"},
+		map[string]any{
+			"foo": map[string]any{"bar?": "abc?"},
 		},
 	}, {
 		"foo: {? key: value}",
-		map[string]interface{}{
-			"foo": map[string]interface{}{"key": "value"},
+		map[string]any{
+			"foo": map[string]any{"key": "value"},
 		},
 	}, {
 		`---
@@ -858,14 +858,14 @@ foo:
   : complex value
 ba?r: a?bc
 `,
-		map[string]interface{}{
-			"foo":  map[string]interface{}{"complex key": "complex value"},
+		map[string]any{
+			"foo":  map[string]any{"complex key": "complex value"},
 			"ba?r": "a?bc",
 		},
 	},
 }
 
-type M map[string]interface{}
+type M map[string]any
 
 type inlineB struct {
 	B       int
@@ -899,7 +899,7 @@ func TestUnmarshalFullTimestamp(t *testing.T) {
 	// Full timestamp in same format as encoded. This is confirmed to be
 	// properly decoded by Python as a timestamp as well.
 	var str = "2015-02-24T18:19:39.123456789-03:00"
-	var tm interface{}
+	var tm any
 	err := yaml.Unmarshal([]byte(str), &tm)
 	assert.NoError(t, err)
 	expectedTime := time.Date(2015, 2, 24, 18, 19, 39, 123456789, tm.(time.Time).Location())
@@ -929,23 +929,23 @@ func TestDecoderSingleDocument(t *testing.T) {
 
 var decoderTests = []struct {
 	data   string
-	values []interface{}
+	values []any
 }{{
 	"",
 	nil,
 }, {
 	"a: b",
-	[]interface{}{
-		map[string]interface{}{"a": "b"},
+	[]any{
+		map[string]any{"a": "b"},
 	},
 }, {
 	"---\na: b\n...\n",
-	[]interface{}{
-		map[string]interface{}{"a": "b"},
+	[]any{
+		map[string]any{"a": "b"},
 	},
 }, {
 	"---\n'hello'\n...\n---\ngoodbye\n...\n",
-	[]interface{}{
+	[]any{
 		"hello",
 		"goodbye",
 	},
@@ -954,10 +954,10 @@ var decoderTests = []struct {
 func TestDecoder(t *testing.T) {
 	for i, item := range decoderTests {
 		t.Run(fmt.Sprintf("test %d: %q", i, item.data), func(t *testing.T) {
-			var values []interface{}
+			var values []any
 			dec := yaml.NewDecoder(strings.NewReader(item.data))
 			for {
-				var value interface{}
+				var value any
 				err := dec.Decode(&value)
 				if err == io.EOF {
 					break
@@ -982,7 +982,7 @@ func TestDecoderReadError(t *testing.T) {
 }
 
 func TestUnmarshalNaN(t *testing.T) {
-	value := map[string]interface{}{}
+	value := map[string]any{}
 	err := yaml.Unmarshal([]byte("notanum: .NaN"), &value)
 	assert.NoError(t, err)
 	assert.True(t, math.IsNaN(value["notanum"].(float64)))
@@ -1031,7 +1031,7 @@ var unmarshalErrorTests = []struct {
 func TestUnmarshalErrors(t *testing.T) {
 	for i, item := range unmarshalErrorTests {
 		t.Run(fmt.Sprintf("test %d: %q", i, item.data), func(t *testing.T) {
-			var value interface{}
+			var value any
 			err := yaml.Unmarshal([]byte(item.data), &value)
 			assert.ErrorMatchesf(t, item.error, err, "Partial unmarshal: %#v", value)
 		})
@@ -1041,7 +1041,7 @@ func TestUnmarshalErrors(t *testing.T) {
 func TestDecoderErrors(t *testing.T) {
 	for i, item := range unmarshalErrorTests {
 		t.Run(fmt.Sprintf("test %d: %q", i, item.data), func(t *testing.T) {
-			var value interface{}
+			var value any
 			err := yaml.NewDecoder(strings.NewReader(item.data)).Decode(&value)
 			assert.ErrorMatchesf(t, item.error, err, "Partial unmarshal: %#v", value)
 		})
@@ -1067,10 +1067,10 @@ func TestParserError(t *testing.T) {
 
 var unmarshalerTests = []struct {
 	data, tag string
-	value     interface{}
+	value     any
 }{
-	{"_: {hi: there}", "!!map", map[string]interface{}{"hi": "there"}},
-	{"_: [1,A]", "!!seq", []interface{}{1, "A"}},
+	{"_: {hi: there}", "!!map", map[string]any{"hi": "there"}},
+	{"_: [1,A]", "!!seq", []any{1, "A"}},
 	{"_: 10", "!!int", 10},
 	{"_: null", "!!null", nil},
 	{`_: BAR!`, "!!str", "BAR!"},
@@ -1082,7 +1082,7 @@ var unmarshalerTests = []struct {
 var unmarshalerResult = map[int]error{}
 
 type unmarshalerType struct {
-	value interface{}
+	value any
 }
 
 func (o *unmarshalerType) UnmarshalYAML(value *yaml.Node) error {
@@ -1111,10 +1111,10 @@ type unmarshalerInlinedTwice struct {
 }
 
 type obsoleteUnmarshalerType struct {
-	value interface{}
+	value any
 }
 
-func (o *obsoleteUnmarshalerType) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+func (o *obsoleteUnmarshalerType) UnmarshalYAML(unmarshal func(v any) error) error {
 	if err := unmarshal(&o.value); err != nil {
 		return err
 	}
@@ -1174,20 +1174,20 @@ func TestUnmarshalerInlinedField(t *testing.T) {
 	err := yaml.Unmarshal([]byte("_: a\ninlined: b\n"), obj)
 	assert.NoError(t, err)
 	assert.DeepEqual(t, &unmarshalerType{"a"}, obj.Field)
-	assert.DeepEqual(t, unmarshalerType{map[string]interface{}{"_": "a", "inlined": "b"}}, obj.Inlined)
+	assert.DeepEqual(t, unmarshalerType{map[string]any{"_": "a", "inlined": "b"}}, obj.Inlined)
 
 	twc := &unmarshalerInlinedTwice{}
 	err = yaml.Unmarshal([]byte("_: a\ninlined: b\n"), twc)
 	assert.NoError(t, err)
 	assert.DeepEqual(t, &unmarshalerType{"a"}, twc.InlinedTwice.Field)
-	assert.DeepEqual(t, unmarshalerType{map[string]interface{}{"_": "a", "inlined": "b"}}, twc.InlinedTwice.Inlined)
+	assert.DeepEqual(t, unmarshalerType{map[string]any{"_": "a", "inlined": "b"}}, twc.InlinedTwice.Inlined)
 }
 
 func TestUnmarshalerWholeDocument(t *testing.T) {
 	obj := &obsoleteUnmarshalerType{}
 	err := yaml.Unmarshal([]byte(unmarshalerTests[0].data), obj)
 	assert.NoError(t, err)
-	value, ok := obj.value.(map[string]interface{})
+	value, ok := obj.value.(map[string]any)
 	assert.Truef(t, ok, "value: %#v", obj.value)
 	assert.DeepEqual(t, unmarshalerTests[0].value, value["_"])
 }
@@ -1298,7 +1298,7 @@ func TestUnmarshalerTypeErrorProxying(t *testing.T) {
 
 type obsoleteProxyTypeError struct{}
 
-func (v *obsoleteProxyTypeError) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *obsoleteProxyTypeError) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	var a int32
 	var b int64
@@ -1365,7 +1365,7 @@ func TestUnmarshalerError(t *testing.T) {
 
 type obsoleteFailingUnmarshaler struct{}
 
-func (ft *obsoleteFailingUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ft *obsoleteFailingUnmarshaler) UnmarshalYAML(unmarshal func(any) error) error {
 	return failingErr
 }
 
@@ -1450,7 +1450,7 @@ func TestUnmarshalerRetry(t *testing.T) {
 
 type obsoleteSliceUnmarshaler []int
 
-func (su *obsoleteSliceUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (su *obsoleteSliceUnmarshaler) UnmarshalYAML(unmarshal func(any) error) error {
 	var slice []int
 	err := unmarshal(&slice)
 	if err == nil {
@@ -1536,19 +1536,19 @@ inlineSequenceMap:
 `
 
 func TestMerge(t *testing.T) {
-	var want = map[string]interface{}{
+	var want = map[string]any{
 		"x":     1,
 		"y":     2,
 		"r":     10,
 		"label": "center/big",
 	}
 
-	wantStringMap := make(map[string]interface{})
+	wantStringMap := make(map[string]any)
 	for k, v := range want {
 		wantStringMap[fmt.Sprintf("%v", k)] = v
 	}
 
-	var m map[interface{}]interface{}
+	var m map[any]any
 	err := yaml.Unmarshal([]byte(mergeTests), &m)
 	assert.NoError(t, err)
 	for name, test := range m {
@@ -1659,10 +1659,10 @@ func TestMergeNestedStruct(t *testing.T) {
 
 	// Repeat test with a map.
 
-	var testm map[string]interface{}
-	var wantm = map[string]interface{}{
+	var testm map[string]any
+	var wantm = map[string]any{
 		"f": 60,
-		"inner": map[string]interface{}{
+		"inner": map[string]any{
 			"a": 10,
 		},
 		"d": 40,
@@ -1676,43 +1676,43 @@ func TestMergeNestedStruct(t *testing.T) {
 
 var unmarshalNullTests = []struct {
 	input              string
-	pristine, expected func() interface{}
+	pristine, expected func() any
 }{{
 	"null",
-	func() interface{} { var v interface{}; v = "v"; return &v },
-	func() interface{} { var v interface{}; v = nil; return &v },
+	func() any { var v any; v = "v"; return &v },
+	func() any { var v any; v = nil; return &v },
 }, {
 	"null",
-	func() interface{} { var s = "s"; return &s },
-	func() interface{} { var s = "s"; return &s },
+	func() any { var s = "s"; return &s },
+	func() any { var s = "s"; return &s },
 }, {
 	"null",
-	func() interface{} { var s = "s"; sptr := &s; return &sptr },
-	func() interface{} { var sptr *string; return &sptr },
+	func() any { var s = "s"; sptr := &s; return &sptr },
+	func() any { var sptr *string; return &sptr },
 }, {
 	"null",
-	func() interface{} { var i = 1; return &i },
-	func() interface{} { var i = 1; return &i },
+	func() any { var i = 1; return &i },
+	func() any { var i = 1; return &i },
 }, {
 	"null",
-	func() interface{} { var i = 1; iptr := &i; return &iptr },
-	func() interface{} { var iptr *int; return &iptr },
+	func() any { var i = 1; iptr := &i; return &iptr },
+	func() any { var iptr *int; return &iptr },
 }, {
 	"null",
-	func() interface{} { var m = map[string]int{"s": 1}; return &m },
-	func() interface{} { var m map[string]int; return &m },
+	func() any { var m = map[string]int{"s": 1}; return &m },
+	func() any { var m map[string]int; return &m },
 }, {
 	"null",
-	func() interface{} { var m = map[string]int{"s": 1}; return m },
-	func() interface{} { var m = map[string]int{"s": 1}; return m },
+	func() any { var m = map[string]int{"s": 1}; return m },
+	func() any { var m = map[string]int{"s": 1}; return m },
 }, {
 	"s2: null\ns3: null",
-	func() interface{} { var m = map[string]int{"s1": 1, "s2": 2}; return m },
-	func() interface{} { var m = map[string]int{"s1": 1, "s2": 2, "s3": 0}; return m },
+	func() any { var m = map[string]int{"s1": 1, "s2": 2}; return m },
+	func() any { var m = map[string]int{"s1": 1, "s2": 2, "s3": 0}; return m },
 }, {
 	"s2: null\ns3: null",
-	func() interface{} { var m = map[string]interface{}{"s1": 1, "s2": 2}; return m },
-	func() interface{} { var m = map[string]interface{}{"s1": 1, "s2": nil, "s3": nil}; return m },
+	func() any { var m = map[string]any{"s1": 1, "s2": 2}; return m },
+	func() any { var m = map[string]any{"s1": 1, "s2": nil, "s3": nil}; return m },
 }}
 
 func TestUnmarshalNull(t *testing.T) {
@@ -1757,7 +1757,7 @@ var unmarshalStrictTests = []struct {
 	known  bool
 	unique bool
 	data   string
-	value  interface{}
+	value  any
 	error  string
 }{{
 	known: true,
@@ -1806,10 +1806,10 @@ var unmarshalStrictTests = []struct {
 	data:   "c: 1\na: 1\nb: 2\nc: 3\n",
 	value: struct {
 		A int
-		M map[string]interface{} `yaml:",inline"`
+		M map[string]any `yaml:",inline"`
 	}{
 		A: 1,
-		M: map[string]interface{}{
+		M: map[string]any{
 			"b": 2,
 			"c": 3,
 		},
@@ -1818,7 +1818,7 @@ var unmarshalStrictTests = []struct {
 }, {
 	unique: true,
 	data:   "a: 1\n9: 2\nnull: 3\n9: 4",
-	value: map[interface{}]interface{}{
+	value: map[any]any{
 		"a": 1,
 		nil: 3,
 		9:   4,
@@ -1881,7 +1881,7 @@ func TestFuzzCrashers(t *testing.T) {
 		"? \ufeff: \ufeff\n",
 	}
 	for _, data := range cases {
-		var v interface{}
+		var v any
 		_ = yaml.Unmarshal([]byte(data), &v)
 	}
 }
@@ -1895,7 +1895,7 @@ a:
 -
 `)
 
-	x := map[string]interface{}{}
+	x := map[string]any{}
 	err := yaml.Unmarshal([]byte(data), &x)
 	if err == nil {
 		t.Errorf("expected error, got none")
@@ -1914,7 +1914,7 @@ a:
 //func (s *S) BenchmarkUnmarshal(c *C) {
 //	var err error
 //	for i := 0; i < c.N; i++ {
-//		var v map[string]interface{}
+//		var v map[string]any
 //		err = yaml.Unmarshal(data, &v)
 //	}
 //	if err != nil {
@@ -1923,7 +1923,7 @@ a:
 //}
 //
 //func (s *S) BenchmarkMarshal(c *C) {
-//	var v map[string]interface{}
+//	var v map[string]any
 //	yaml.Unmarshal(data, &v)
 //	c.ResetTimer()
 //	for i := 0; i < c.N; i++ {

--- a/encode_test.go
+++ b/encode_test.go
@@ -33,7 +33,7 @@ import (
 var marshalIntTest = 123
 
 var marshalTests = []struct {
-	value interface{}
+	value any
 	data  string
 }{
 	{
@@ -49,7 +49,7 @@ var marshalTests = []struct {
 		map[string]string{"v": "hi"},
 		"v: hi\n",
 	}, {
-		map[string]interface{}{"v": "hi"},
+		map[string]any{"v": "hi"},
 		"v: hi\n",
 	}, {
 		map[string]string{"v": "true"},
@@ -58,22 +58,22 @@ var marshalTests = []struct {
 		map[string]string{"v": "false"},
 		"v: \"false\"\n",
 	}, {
-		map[string]interface{}{"v": true},
+		map[string]any{"v": true},
 		"v: true\n",
 	}, {
-		map[string]interface{}{"v": false},
+		map[string]any{"v": false},
 		"v: false\n",
 	}, {
-		map[string]interface{}{"v": 10},
+		map[string]any{"v": 10},
 		"v: 10\n",
 	}, {
-		map[string]interface{}{"v": -10},
+		map[string]any{"v": -10},
 		"v: -10\n",
 	}, {
 		map[string]uint{"v": 42},
 		"v: 42\n",
 	}, {
-		map[string]interface{}{"v": int64(4294967296)},
+		map[string]any{"v": int64(4294967296)},
 		"v: 4294967296\n",
 	}, {
 		map[string]int64{"v": int64(4294967296)},
@@ -82,34 +82,34 @@ var marshalTests = []struct {
 		map[string]uint64{"v": 4294967296},
 		"v: 4294967296\n",
 	}, {
-		map[string]interface{}{"v": "10"},
+		map[string]any{"v": "10"},
 		"v: \"10\"\n",
 	}, {
-		map[string]interface{}{"v": 0.1},
+		map[string]any{"v": 0.1},
 		"v: 0.1\n",
 	}, {
-		map[string]interface{}{"v": float64(0.1)},
+		map[string]any{"v": float64(0.1)},
 		"v: 0.1\n",
 	}, {
-		map[string]interface{}{"v": float32(0.99)},
+		map[string]any{"v": float32(0.99)},
 		"v: 0.99\n",
 	}, {
-		map[string]interface{}{"v": -0.1},
+		map[string]any{"v": -0.1},
 		"v: -0.1\n",
 	}, {
-		map[string]interface{}{"v": math.Inf(+1)},
+		map[string]any{"v": math.Inf(+1)},
 		"v: .inf\n",
 	}, {
-		map[string]interface{}{"v": math.Inf(-1)},
+		map[string]any{"v": math.Inf(-1)},
 		"v: -.inf\n",
 	}, {
-		map[string]interface{}{"v": math.NaN()},
+		map[string]any{"v": math.NaN()},
 		"v: .nan\n",
 	}, {
-		map[string]interface{}{"v": nil},
+		map[string]any{"v": nil},
 		"v: null\n",
 	}, {
-		map[string]interface{}{"v": ""},
+		map[string]any{"v": ""},
 		"v: \"\"\n",
 	}, {
 		map[string][]string{"v": []string{"A", "B"}},
@@ -118,16 +118,16 @@ var marshalTests = []struct {
 		map[string][]string{"v": []string{"A", "B\nC"}},
 		"v:\n    - A\n    - |-\n      B\n      C\n",
 	}, {
-		map[string][]interface{}{"v": []interface{}{"A", 1, map[string][]int{"B": []int{2, 3}}}},
+		map[string][]any{"v": []any{"A", 1, map[string][]int{"B": []int{2, 3}}}},
 		"v:\n    - A\n    - 1\n    - B:\n        - 2\n        - 3\n",
 	}, {
-		map[string]interface{}{"a": map[interface{}]interface{}{"b": "c"}},
+		map[string]any{"a": map[any]any{"b": "c"}},
 		"a:\n    b: c\n",
 	}, {
-		map[string]interface{}{"a": "-"},
+		map[string]any{"a": "-"},
 		"a: '-'\n",
 	}, {
-		map[string]interface{}{"v": negativeZero},
+		map[string]any{"v": negativeZero},
 		"v: -0\n",
 	},
 
@@ -428,7 +428,7 @@ var marshalTests = []struct {
 
 	// Check indentation of maps inside sequences inside maps.
 	{
-		map[string]interface{}{"a": map[string]interface{}{"b": []map[string]int{{"c": 1, "d": 2}}}},
+		map[string]any{"a": map[string]any{"b": []map[string]int{{"c": 1, "d": 2}}}},
 		"a:\n    b:\n        - c: 1\n          d: 2\n",
 	},
 
@@ -440,10 +440,10 @@ var marshalTests = []struct {
 		map[string]string{"a": "\t\n\t\n"},
 		"a: \"\\t\\n\\t\\n\"\n",
 	}, {
-		map[string]interface{}{"<<": []string{}},
+		map[string]any{"<<": []string{}},
 		"\"<<\": []\n",
 	}, {
-		map[string]interface{}{"foo": "<<"},
+		map[string]any{"foo": "<<"},
 		"foo: \"<<\"\n",
 	},
 
@@ -514,8 +514,8 @@ var marshalTests = []struct {
 	},
 	// bug: question mark in value
 	{
-		map[string]interface{}{
-			"foo": map[string]interface{}{"bar": "a?bc"},
+		map[string]any{
+			"foo": map[string]any{"bar": "a?bc"},
 		},
 		"foo:\n    bar: a?bc\n",
 	},
@@ -573,7 +573,7 @@ func (errorWriter) Write([]byte) (int, error) {
 }
 
 var marshalErrorTests = []struct {
-	value interface{}
+	value any
 	error string
 	panic string
 }{{
@@ -621,24 +621,24 @@ func TestMarshalTypeCache(t *testing.T) {
 
 var marshalerTests = []struct {
 	data  string
-	value interface{}
+	value any
 }{
-	{"_:\n    hi: there\n", map[interface{}]interface{}{"hi": "there"}},
-	{"_:\n    - 1\n    - A\n", []interface{}{1, "A"}},
+	{"_:\n    hi: there\n", map[any]any{"hi": "there"}},
+	{"_:\n    - 1\n    - A\n", []any{1, "A"}},
 	{"_: 10\n", 10},
 	{"_: null\n", nil},
 	{"_: BAR!\n", "BAR!"},
 }
 
 type marshalerType struct {
-	value interface{}
+	value any
 }
 
 func (o marshalerType) MarshalText() ([]byte, error) {
 	panic("MarshalText called on type with MarshalYAML")
 }
 
-func (o marshalerType) MarshalYAML() (interface{}, error) {
+func (o marshalerType) MarshalYAML() (any, error) {
 	return o.value, nil
 }
 
@@ -668,7 +668,7 @@ func TestMarshalerWholeDocument(t *testing.T) {
 
 type failingMarshaler struct{}
 
-func (ft *failingMarshaler) MarshalYAML() (interface{}, error) {
+func (ft *failingMarshaler) MarshalYAML() (any, error) {
 	return nil, failingErr
 }
 
@@ -681,7 +681,7 @@ func TestSetIndent(t *testing.T) {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(8)
-	err := enc.Encode(map[string]interface{}{"a": map[string]interface{}{"b": map[string]string{"c": "d"}}})
+	err := enc.Encode(map[string]any{"a": map[string]any{"b": map[string]string{"c": "d"}}})
 	assert.NoError(t, err)
 	err = enc.Close()
 	assert.NoError(t, err)
@@ -689,7 +689,7 @@ func TestSetIndent(t *testing.T) {
 }
 
 func TestSortedOutput(t *testing.T) {
-	order := []interface{}{
+	order := []any{
 		false,
 		true,
 		1,
@@ -737,7 +737,7 @@ func TestSortedOutput(t *testing.T) {
 		"e4b",
 		"e21a",
 	}
-	m := make(map[interface{}]int)
+	m := make(map[any]int)
 	for _, k := range order {
 		m[k] = 1
 	}
@@ -771,7 +771,7 @@ func TestCompactSeqIndentDefault(t *testing.T) {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.CompactSeqIndent()
-	err := enc.Encode(map[string]interface{}{"a": []string{"b", "c"}})
+	err := enc.Encode(map[string]any{"a": []string{"b", "c"}})
 	assert.NoError(t, err)
 	err = enc.Close()
 	assert.NoError(t, err)
@@ -787,7 +787,7 @@ func TestCompactSequenceWithSetIndent(t *testing.T) {
 	enc := yaml.NewEncoder(&buf)
 	enc.CompactSeqIndent()
 	enc.SetIndent(2)
-	err := enc.Encode(map[string]interface{}{"a": []string{"b", "c"}})
+	err := enc.Encode(map[string]any{"a": []string{"b", "c"}})
 	assert.NoError(t, err)
 	err = enc.Close()
 	assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.yaml.in/yaml/v4
 
-go 1.16
+go 1.18

--- a/internal/testutil/assert/assert.go
+++ b/internal/testutil/assert/assert.go
@@ -9,12 +9,12 @@ import (
 
 type miniTB interface {
 	Helper()
-	Fatalf(string, ...interface{})
+	Fatalf(string, ...any)
 }
 
 // formatSuffix builds an optional suffix from a printf-style format and args.
 // If msgFormat is empty, an empty string is returned.
-func formatSuffix(msgFormat string, args ...interface{}) string {
+func formatSuffix(msgFormat string, args ...any) string {
 	if msgFormat == "" {
 		return ""
 	}
@@ -22,12 +22,12 @@ func formatSuffix(msgFormat string, args ...interface{}) string {
 }
 
 // Comparable types (numbers, strings, pointers to the same object, etc.).
-func Equal(tb miniTB, want, got interface{}) {
+func Equal(tb miniTB, want, got any) {
 	tb.Helper()
 	Equalf(tb, want, got, "")
 }
 
-func Equalf(tb miniTB, want, got interface{}, msgFormat string, args ...interface{}) {
+func Equalf(tb miniTB, want, got any, msgFormat string, args ...any) {
 	tb.Helper()
 	if got != want {
 		suffix := formatSuffix(msgFormat, args...)
@@ -36,12 +36,12 @@ func Equalf(tb miniTB, want, got interface{}, msgFormat string, args ...interfac
 }
 
 // Anything else (slices, maps, structs with slices...).
-func DeepEqual(tb miniTB, want, got interface{}) {
+func DeepEqual(tb miniTB, want, got any) {
 	tb.Helper()
 	DeepEqualf(tb, want, got, "")
 }
 
-func DeepEqualf(tb miniTB, want, got interface{}, msgFormat string, args ...interface{}) {
+func DeepEqualf(tb miniTB, want, got any, msgFormat string, args ...any) {
 	tb.Helper()
 	if !reflect.DeepEqual(got, want) {
 		suffix := formatSuffix(msgFormat, args...)
@@ -54,7 +54,7 @@ func ErrorMatches(tb miniTB, pattern string, err error) {
 	ErrorMatchesf(tb, pattern, err, "")
 }
 
-func ErrorMatchesf(tb miniTB, pattern string, err error, msgFormat string, args ...interface{}) {
+func ErrorMatchesf(tb miniTB, pattern string, err error, msgFormat string, args ...any) {
 	tb.Helper()
 	if err == nil {
 		suffix := formatSuffix(msgFormat, args...)
@@ -84,7 +84,7 @@ func NoError(tb miniTB, err error) {
 	NoErrorf(tb, err, "")
 }
 
-func NoErrorf(tb miniTB, err error, msgFormat string, args ...interface{}) {
+func NoErrorf(tb miniTB, err error, msgFormat string, args ...any) {
 	tb.Helper()
 	if err != nil {
 		suffix := formatSuffix(msgFormat, args...)
@@ -92,12 +92,12 @@ func NoErrorf(tb miniTB, err error, msgFormat string, args ...interface{}) {
 	}
 }
 
-func IsNil(tb miniTB, v interface{}) {
+func IsNil(tb miniTB, v any) {
 	tb.Helper()
 	IsNilf(tb, v, "")
 }
 
-func IsNilf(tb miniTB, v interface{}, msgFormat string, args ...interface{}) {
+func IsNilf(tb miniTB, v any, msgFormat string, args ...any) {
 	tb.Helper()
 	if !isNil(v) {
 		suffix := formatSuffix(msgFormat, args...)
@@ -105,12 +105,12 @@ func IsNilf(tb miniTB, v interface{}, msgFormat string, args ...interface{}) {
 	}
 }
 
-func NotNil(tb miniTB, v interface{}) {
+func NotNil(tb miniTB, v any) {
 	tb.Helper()
 	NotNilf(tb, v, "")
 }
 
-func NotNilf(tb miniTB, v interface{}, msgFormat string, args ...interface{}) {
+func NotNilf(tb miniTB, v any, msgFormat string, args ...any) {
 	tb.Helper()
 	if isNil(v) {
 		suffix := formatSuffix(msgFormat, args...)
@@ -123,7 +123,7 @@ func True(tb miniTB, got bool) {
 	Truef(tb, got, "")
 }
 
-func Truef(tb miniTB, got bool, msgFormat string, args ...interface{}) {
+func Truef(tb miniTB, got bool, msgFormat string, args ...any) {
 	tb.Helper()
 	if !got {
 		suffix := formatSuffix(msgFormat, args...)
@@ -136,7 +136,7 @@ func False(tb miniTB, got bool) {
 	Falsef(tb, got, "")
 }
 
-func Falsef(tb miniTB, got bool, msgFormat string, args ...interface{}) {
+func Falsef(tb miniTB, got bool, msgFormat string, args ...any) {
 	tb.Helper()
 	if got {
 		suffix := formatSuffix(msgFormat, args...)
@@ -149,9 +149,9 @@ func PanicMatches(tb miniTB, pattern string, f func()) {
 	PanicMatchesf(tb, pattern, f, "")
 }
 
-func PanicMatchesf(tb miniTB, pattern string, f func(), msgFormat string, args ...interface{}) {
+func PanicMatchesf(tb miniTB, pattern string, f func(), msgFormat string, args ...any) {
 	tb.Helper()
-	var pan interface{}
+	var pan any
 	func() {
 		defer func() { pan = recover() }()
 		f()
@@ -182,7 +182,7 @@ func PanicMatchesf(tb miniTB, pattern string, f func(), msgFormat string, args .
 	}
 }
 
-func isNil(v interface{}) bool {
+func isNil(v any) bool {
 	if v == nil {
 		return true
 	}

--- a/internal/testutil/assert/assert_test.go
+++ b/internal/testutil/assert/assert_test.go
@@ -80,7 +80,7 @@ type fakeTB struct {
 
 func (f *fakeTB) Helper() {}
 
-func (f *fakeTB) Fatalf(format string, args ...interface{}) {
+func (f *fakeTB) Fatalf(format string, args ...any) {
 	f.failed = true
 	f.msg = fmt.Sprintf(format, args...)
 }

--- a/limit_test.go
+++ b/limit_test.go
@@ -47,7 +47,7 @@ func TestLimits(t *testing.T) {
 		return
 	}
 	for _, tc := range limitTests {
-		var v interface{}
+		var v any
 		err := yaml.Unmarshal(tc.data, &v)
 		if len(tc.error) > 0 {
 			assert.ErrorMatchesf(t, tc.error, err, "testcase: %s", tc.name)
@@ -106,7 +106,7 @@ func benchmark(b *testing.B, name string) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			var v interface{}
+			var v any
 			err := yaml.Unmarshal(t.data, &v)
 			if len(t.error) > 0 {
 				assert.ErrorMatches(b, t.error, err)

--- a/node_test.go
+++ b/node_test.go
@@ -2926,7 +2926,7 @@ func TestSetString(t *testing.T) {
 }
 
 var nodeEncodeDecodeTests = []struct {
-	value interface{}
+	value any
 	yaml  string
 	node  yaml.Node
 }{{
@@ -2955,7 +2955,7 @@ var nodeEncodeDecodeTests = []struct {
 		Tag:   "!!int",
 	},
 }, {
-	[]interface{}{1, 2},
+	[]any{1, 2},
 	"[1, 2]",
 	yaml.Node{
 		Kind: yaml.SequenceNode,
@@ -2971,7 +2971,7 @@ var nodeEncodeDecodeTests = []struct {
 		}},
 	},
 }, {
-	map[string]interface{}{"a": "b"},
+	map[string]any{"a": "b"},
 	"a: b",
 	yaml.Node{
 		Kind: yaml.MappingNode,
@@ -2992,7 +2992,7 @@ func TestNodeEncodeDecode(t *testing.T) {
 	for i, item := range nodeEncodeDecodeTests {
 		t.Logf("Encode/Decode test value #%d: %#v", i, item.value)
 
-		var v interface{}
+		var v any
 		err := item.node.Decode(&v)
 		assert.NoError(t, err)
 		assert.DeepEqual(t, item.value, v)

--- a/resolve.go
+++ b/resolve.go
@@ -25,7 +25,7 @@ import (
 )
 
 type resolveMapItem struct {
-	value interface{}
+	value any
 	tag   string
 }
 
@@ -45,7 +45,7 @@ func init() {
 	t[int('.')] = '.' // Float (potentially in map)
 
 	var resolveMapList = []struct {
-		v   interface{}
+		v   any
 		tag string
 		l   []string
 	}{
@@ -129,7 +129,7 @@ func resolvableTag(tag string) bool {
 
 var yamlStyleFloat = regexp.MustCompile(`^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$`)
 
-func resolve(tag string, in string) (rtag string, out interface{}) {
+func resolve(tag string, in string) (rtag string, out any) {
 	tag = shortTag(tag)
 	if !resolvableTag(tag) {
 		return tag, in

--- a/scannerc.go
+++ b/scannerc.go
@@ -645,10 +645,10 @@ func yaml_parser_set_scanner_tag_error(parser *yaml_parser_t, directive bool, co
 	return yaml_parser_set_scanner_error(parser, context, context_mark, problem)
 }
 
-func trace(args ...interface{}) func() {
-	pargs := append([]interface{}{"+++"}, args...)
+func trace(args ...any) func() {
+	pargs := append([]any{"+++"}, args...)
 	fmt.Println(pargs...)
-	pargs = append([]interface{}{"---"}, args...)
+	pargs = append([]any{"---"}, args...)
 	return func() { fmt.Println(pargs...) }
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -39,7 +39,7 @@ type Unmarshaler interface {
 }
 
 type obsoleteUnmarshaler interface {
-	UnmarshalYAML(unmarshal func(interface{}) error) error
+	UnmarshalYAML(unmarshal func(any) error) error
 }
 
 // The Marshaler interface may be implemented by types to customize their
@@ -49,7 +49,7 @@ type obsoleteUnmarshaler interface {
 // If an error is returned by MarshalYAML, the marshaling procedure stops
 // and returns with the provided error.
 type Marshaler interface {
-	MarshalYAML() (interface{}, error)
+	MarshalYAML() (any, error)
 }
 
 // Unmarshal decodes the first document found within the in byte slice
@@ -85,7 +85,7 @@ type Marshaler interface {
 //
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
-func Unmarshal(in []byte, out interface{}) (err error) {
+func Unmarshal(in []byte, out any) (err error) {
 	return unmarshal(in, out, false)
 }
 
@@ -116,7 +116,7 @@ func (dec *Decoder) KnownFields(enable bool) {
 //
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
-func (dec *Decoder) Decode(v interface{}) (err error) {
+func (dec *Decoder) Decode(v any) (err error) {
 	d := newDecoder()
 	d.knownFields = dec.knownFields
 	defer handleErr(&err)
@@ -139,7 +139,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 //
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
-func (n *Node) Decode(v interface{}) (err error) {
+func (n *Node) Decode(v any) (err error) {
 	d := newDecoder()
 	defer handleErr(&err)
 	out := reflect.ValueOf(v)
@@ -153,7 +153,7 @@ func (n *Node) Decode(v interface{}) (err error) {
 	return nil
 }
 
-func unmarshal(in []byte, out interface{}, strict bool) (err error) {
+func unmarshal(in []byte, out any, strict bool) (err error) {
 	defer handleErr(&err)
 	d := newDecoder()
 	p := newParser(in)
@@ -214,7 +214,7 @@ func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 //	}
 //	yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
 //	yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
-func Marshal(in interface{}) (out []byte, err error) {
+func Marshal(in any) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()
 	defer e.destroy()
@@ -245,7 +245,7 @@ func NewEncoder(w io.Writer) *Encoder {
 //
 // See the documentation for Marshal for details about the conversion of Go
 // values to YAML.
-func (e *Encoder) Encode(v interface{}) (err error) {
+func (e *Encoder) Encode(v any) (err error) {
 	defer handleErr(&err)
 	e.encoder.marshalDoc("", reflect.ValueOf(v))
 	return nil
@@ -255,7 +255,7 @@ func (e *Encoder) Encode(v interface{}) (err error) {
 //
 // See the documentation for Marshal for details about the
 // conversion of Go values into YAML.
-func (n *Node) Encode(v interface{}) (err error) {
+func (n *Node) Encode(v any) (err error) {
 	defer handleErr(&err)
 	e := newEncoder()
 	defer e.destroy()
@@ -313,7 +313,7 @@ func fail(err error) {
 	panic(&yamlError{err})
 }
 
-func failf(format string, args ...interface{}) {
+func failf(format string, args ...any) {
 	panic(&yamlError{fmt.Errorf("yaml: "+format, args...)})
 }
 
@@ -383,7 +383,7 @@ func (e *TypeError) Is(target error) bool {
 // As checks if the error is equal to any of the errors in the TypeError.
 //
 // [errors.As] will call this method when unwrapping errors.
-func (e *TypeError) As(target interface{}) bool {
+func (e *TypeError) As(target any) bool {
 	for _, err := range e.Errors {
 		if errors.As(err, target) {
 			return true

--- a/yts/test_suite_test.go
+++ b/yts/test_suite_test.go
@@ -115,7 +115,7 @@ func runTest(t *testing.T, testPath string) {
 	_, err = os.Stat(errorPath)
 	expectError := err == nil
 
-	var unmarshaledValue interface{}
+	var unmarshaledValue any
 	var unmarshalErr error
 
 	t.Run("UnmarshalTest", func(t *testing.T) {
@@ -168,7 +168,7 @@ func runTest(t *testing.T, testPath string) {
 
 	t.Run("MarshalTest", func(t *testing.T) {
 		shouldSkipTest(t)
-		var currentUnmarshaledValue interface{}
+		var currentUnmarshaledValue any
 
 		currentUnmarshalErr := yaml.Unmarshal(inYAML, &currentUnmarshaledValue)
 
@@ -189,13 +189,13 @@ func runTest(t *testing.T, testPath string) {
 			t.Errorf("Test: %s\nDescription: %s\nError: Failed to read out.yaml: %v", testPath, testDescription, err)
 			return
 		}
-		var expectedUnmarshaledValue interface{}
+		var expectedUnmarshaledValue any
 		err = yaml.Unmarshal(expectedOutYAML, &expectedUnmarshaledValue)
 		if err != nil {
 			t.Errorf("Test: %s\nDescription: %s\nError: Failed to unmarshal out.yaml: %v", testPath, testDescription, err)
 			return
 		}
-		var reUnmarshaledValue interface{}
+		var reUnmarshaledValue any
 		err = yaml.Unmarshal(marshaledYAML, &reUnmarshaledValue)
 		if err != nil {
 			t.Errorf("Test: %s\nDescription: %s\nError: Failed to re-unmarshal marshaled YAML: %v", testPath, testDescription, err)
@@ -207,7 +207,7 @@ func runTest(t *testing.T, testPath string) {
 
 	t.Run("JSONComparisonTest", func(t *testing.T) {
 		shouldSkipTest(t)
-		var currentUnmarshaledValue interface{}
+		var currentUnmarshaledValue any
 
 		currentUnmarshalErr := yaml.Unmarshal(inYAML, &currentUnmarshaledValue)
 
@@ -223,7 +223,7 @@ func runTest(t *testing.T, testPath string) {
 			t.Errorf("Test: %s\nDescription: %s\nError: Failed to read in.json: %v", testPath, testDescription, err)
 			return
 		}
-		var jsonValue interface{}
+		var jsonValue any
 		jsonErr := json.Unmarshal(inJSON, &jsonValue)
 		if jsonErr != nil {
 			t.Errorf("Test: %s\nDescription: %s\nError: Failed to unmarshal in.json: %v", testPath, testDescription, jsonErr)


### PR DESCRIPTION
Use Go 1.18 as the minimum version for this project to take advantage of
the new features and improvements in the language.

We inherited Go 1.16 from old repository.

The last version of Go is 1.25, using Go 1.18 is reasonable.
