### PR TITLE
Forbid unmarshaling non-scalars into a TextUnmarshaler

### DIFF
--- a/testdata/decode.yaml
+++ b/testdata/decode.yaml
@@ -1301,3 +1301,51 @@
     want:
       foo:
         key: value
+
+# TextUnmarshaler success cases
+
+- decode:
+    name: Scalar string into TextUnmarshaler (value field)
+    yaml: 'a: hello world'
+    type: testStructA_TextUnmarshaler
+    want:
+      a:
+        value: hello world
+
+- decode:
+    name: Scalar string into TextUnmarshaler (pointer field)
+    yaml: 'a: hello world'
+    type: testStructA_TextUnmarshalerPtr
+    want:
+      a:
+        value: hello world
+
+- decode:
+    name: Scalar string into TextUnmarshaler (pointer-pointer field)
+    yaml: 'a: hello world'
+    type: testStructA_TextUnmarshalerPtrPtr
+    want:
+      a:
+        value: hello world
+
+- decode:
+    name: Null into TextUnmarshaler (value field)
+    yaml: 'a: null'
+    type: testStructA_TextUnmarshaler
+    want:
+      a:
+        value: ''
+
+- decode:
+    name: Null into TextUnmarshaler (pointer field)
+    yaml: 'a: null'
+    type: testStructA_TextUnmarshalerPtr
+    want:
+      a: null
+
+- decode:
+    name: Null into TextUnmarshaler (pointer-pointer field)
+    yaml: 'a: null'
+    type: testStructA_TextUnmarshalerPtrPtr
+    want:
+      a: null

--- a/testdata/unmarshal_errors.yaml
+++ b/testdata/unmarshal_errors.yaml
@@ -158,3 +158,53 @@
       h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
       i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]
     want: 'yaml: document contains excessive aliasing'
+
+# TextUnmarshaler validation errors
+
+- unmarshal-error:
+    name: Mapping into TextUnmarshaler (value field)
+    type: testStructA_TextUnmarshaler
+    yaml: 'a: {foo: bar}'
+    want: |-
+      yaml: unmarshal errors:
+        line 1: cannot unmarshal !!map into yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+
+- unmarshal-error:
+    name: Sequence into TextUnmarshaler (value field)
+    type: testStructA_TextUnmarshaler
+    yaml: 'a: [foo, bar]'
+    want: |-
+      yaml: unmarshal errors:
+        line 1: cannot unmarshal !!seq into yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+
+- unmarshal-error:
+    name: Mapping into TextUnmarshaler (pointer field)
+    type: testStructA_TextUnmarshalerPtr
+    yaml: 'a: {foo: bar}'
+    want: |-
+      yaml: unmarshal errors:
+        line 1: cannot unmarshal !!map into *yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+
+- unmarshal-error:
+    name: Sequence into TextUnmarshaler (pointer field)
+    type: testStructA_TextUnmarshalerPtr
+    yaml: 'a: [foo, bar]'
+    want: |-
+      yaml: unmarshal errors:
+        line 1: cannot unmarshal !!seq into *yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+
+- unmarshal-error:
+    name: Mapping into TextUnmarshaler (pointer-pointer field)
+    type: testStructA_TextUnmarshalerPtrPtr
+    yaml: 'a: {foo: bar}'
+    want: |-
+      yaml: unmarshal errors:
+        line 1: cannot unmarshal !!map into **yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+
+- unmarshal-error:
+    name: Sequence into TextUnmarshaler (pointer-pointer field)
+    type: testStructA_TextUnmarshalerPtrPtr
+    yaml: 'a: [foo, bar]'
+    want: |-
+      yaml: unmarshal errors:
+        line 1: cannot unmarshal !!seq into **yaml_test.simpleTextUnmarshaler (TextUnmarshaler)


### PR DESCRIPTION
This is a breaking change.

Previously an attempt to unmarshal a YAML mapping into a struct implementing `encoding.TextUnmarshaler` would succeed, but likely do the wrong thing.

Consider this example:

    type Foo struct {
        IP netip.Addr `yaml:"ip"`
    }

`netip.Addr` is a struct type implementing `TextUnmarshaler`, but containing no exported fields. So unmarshaling `{"ip": "127.0.0.1"}` would use `TextUnmarshaler` (as expected), but `{"ip": {"whatever": 123}}` would silently do nothing.

With this commit, it will now result in a type error.

`encoding/json/v2` documentation states:

> If the value type implements encoding.TextUnmarshaler, then the input
> is decoded as a JSON string and the UnmarshalText method is called with
> the decoded string value. This fails with a SemanticError if the input
> is not a JSON string.

`encoding/json` documentation is somewhat ambiguous on this, but it also behaves the same way (https://go.dev/play/p/z9okIXkUzvQ).