### PR TITLE
Renamed types to match Go naming conventions

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -26,7 +26,7 @@ import (
 	"io"
 )
 
-func yaml_insert_token(parser *yaml_parser_t, pos int, token *yaml_token_t) {
+func yaml_insert_token(parser *yamlParser, pos int, token *yamlToken) {
 	//fmt.Println("yaml_insert_token", "pos:", pos, "typ:", token.typ, "head:", parser.tokens_head, "len:", len(parser.tokens))
 
 	// Check if we can move the queue at the beginning of the buffer.
@@ -46,8 +46,8 @@ func yaml_insert_token(parser *yaml_parser_t, pos int, token *yaml_token_t) {
 }
 
 // Create a new parser object.
-func yaml_parser_initialize(parser *yaml_parser_t) bool {
-	*parser = yaml_parser_t{
+func yaml_parser_initialize(parser *yamlParser) bool {
+	*parser = yamlParser{
 		raw_buffer: make([]byte, 0, input_raw_buffer_size),
 		buffer:     make([]byte, 0, input_buffer_size),
 	}
@@ -55,12 +55,12 @@ func yaml_parser_initialize(parser *yaml_parser_t) bool {
 }
 
 // Destroy a parser object.
-func yaml_parser_delete(parser *yaml_parser_t) {
-	*parser = yaml_parser_t{}
+func yaml_parser_delete(parser *yamlParser) {
+	*parser = yamlParser{}
 }
 
 // String read handler.
-func yaml_string_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err error) {
+func yaml_string_read_handler(parser *yamlParser, buffer []byte) (n int, err error) {
 	if parser.input_pos == len(parser.input) {
 		return 0, io.EOF
 	}
@@ -70,12 +70,12 @@ func yaml_string_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err 
 }
 
 // Reader read handler.
-func yaml_reader_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err error) {
+func yaml_reader_read_handler(parser *yamlParser, buffer []byte) (n int, err error) {
 	return parser.input_reader.Read(buffer)
 }
 
 // Set a string input.
-func yaml_parser_set_input_string(parser *yaml_parser_t, input []byte) {
+func yaml_parser_set_input_string(parser *yamlParser, input []byte) {
 	if parser.read_handler != nil {
 		panic("must set the input source only once")
 	}
@@ -85,7 +85,7 @@ func yaml_parser_set_input_string(parser *yaml_parser_t, input []byte) {
 }
 
 // Set a file input.
-func yaml_parser_set_input_reader(parser *yaml_parser_t, r io.Reader) {
+func yaml_parser_set_input_reader(parser *yamlParser, r io.Reader) {
 	if parser.read_handler != nil {
 		panic("must set the input source only once")
 	}
@@ -94,7 +94,7 @@ func yaml_parser_set_input_reader(parser *yaml_parser_t, r io.Reader) {
 }
 
 // Set the source encoding.
-func yaml_parser_set_encoding(parser *yaml_parser_t, encoding yaml_encoding_t) {
+func yaml_parser_set_encoding(parser *yamlParser, encoding yamlEncoding) {
 	if parser.encoding != yaml_ANY_ENCODING {
 		panic("must set the encoding only once")
 	}
@@ -102,36 +102,36 @@ func yaml_parser_set_encoding(parser *yaml_parser_t, encoding yaml_encoding_t) {
 }
 
 // Create a new emitter object.
-func yaml_emitter_initialize(emitter *yaml_emitter_t) {
-	*emitter = yaml_emitter_t{
+func yaml_emitter_initialize(emitter *yamlEmitter) {
+	*emitter = yamlEmitter{
 		buffer:     make([]byte, output_buffer_size),
 		raw_buffer: make([]byte, 0, output_raw_buffer_size),
-		states:     make([]yaml_emitter_state_t, 0, initial_stack_size),
-		events:     make([]yaml_event_t, 0, initial_queue_size),
+		states:     make([]yamlEmitterState, 0, initial_stack_size),
+		events:     make([]yamlEvent, 0, initial_queue_size),
 		best_width: -1,
 	}
 }
 
 // Destroy an emitter object.
-func yaml_emitter_delete(emitter *yaml_emitter_t) {
-	*emitter = yaml_emitter_t{}
+func yaml_emitter_delete(emitter *yamlEmitter) {
+	*emitter = yamlEmitter{}
 }
 
 // String write handler.
-func yaml_string_write_handler(emitter *yaml_emitter_t, buffer []byte) error {
+func yaml_string_write_handler(emitter *yamlEmitter, buffer []byte) error {
 	*emitter.output_buffer = append(*emitter.output_buffer, buffer...)
 	return nil
 }
 
 // yaml_writer_write_handler uses emitter.output_writer to write the
 // emitted text.
-func yaml_writer_write_handler(emitter *yaml_emitter_t, buffer []byte) error {
+func yaml_writer_write_handler(emitter *yamlEmitter, buffer []byte) error {
 	_, err := emitter.output_writer.Write(buffer)
 	return err
 }
 
 // Set a string output.
-func yaml_emitter_set_output_string(emitter *yaml_emitter_t, output_buffer *[]byte) {
+func yaml_emitter_set_output_string(emitter *yamlEmitter, output_buffer *[]byte) {
 	if emitter.write_handler != nil {
 		panic("must set the output target only once")
 	}
@@ -140,7 +140,7 @@ func yaml_emitter_set_output_string(emitter *yaml_emitter_t, output_buffer *[]by
 }
 
 // Set a file output.
-func yaml_emitter_set_output_writer(emitter *yaml_emitter_t, w io.Writer) {
+func yaml_emitter_set_output_writer(emitter *yamlEmitter, w io.Writer) {
 	if emitter.write_handler != nil {
 		panic("must set the output target only once")
 	}
@@ -149,7 +149,7 @@ func yaml_emitter_set_output_writer(emitter *yaml_emitter_t, w io.Writer) {
 }
 
 // Set the output encoding.
-func yaml_emitter_set_encoding(emitter *yaml_emitter_t, encoding yaml_encoding_t) {
+func yaml_emitter_set_encoding(emitter *yamlEmitter, encoding yamlEncoding) {
 	if emitter.encoding != yaml_ANY_ENCODING {
 		panic("must set the output encoding only once")
 	}
@@ -157,12 +157,12 @@ func yaml_emitter_set_encoding(emitter *yaml_emitter_t, encoding yaml_encoding_t
 }
 
 // Set the canonical output style.
-func yaml_emitter_set_canonical(emitter *yaml_emitter_t, canonical bool) {
+func yaml_emitter_set_canonical(emitter *yamlEmitter, canonical bool) {
 	emitter.canonical = canonical
 }
 
 // Set the indentation increment.
-func yaml_emitter_set_indent(emitter *yaml_emitter_t, indent int) {
+func yaml_emitter_set_indent(emitter *yamlEmitter, indent int) {
 	if indent < 2 || indent > 9 {
 		indent = 2
 	}
@@ -170,7 +170,7 @@ func yaml_emitter_set_indent(emitter *yaml_emitter_t, indent int) {
 }
 
 // Set the preferred line width.
-func yaml_emitter_set_width(emitter *yaml_emitter_t, width int) {
+func yaml_emitter_set_width(emitter *yamlEmitter, width int) {
 	if width < 0 {
 		width = -1
 	}
@@ -178,12 +178,12 @@ func yaml_emitter_set_width(emitter *yaml_emitter_t, width int) {
 }
 
 // Set if unescaped non-ASCII characters are allowed.
-func yaml_emitter_set_unicode(emitter *yaml_emitter_t, unicode bool) {
+func yaml_emitter_set_unicode(emitter *yamlEmitter, unicode bool) {
 	emitter.unicode = unicode
 }
 
 // Set the preferred line break character.
-func yaml_emitter_set_break(emitter *yaml_emitter_t, line_break yaml_break_t) {
+func yaml_emitter_set_break(emitter *yamlEmitter, line_break yamlBreak) {
 	emitter.line_break = line_break
 }
 
@@ -274,28 +274,28 @@ func yaml_emitter_set_break(emitter *yaml_emitter_t, line_break yaml_break_t) {
 //
 
 // Create STREAM-START.
-func yaml_stream_start_event_initialize(event *yaml_event_t, encoding yaml_encoding_t) {
-	*event = yaml_event_t{
+func yaml_stream_start_event_initialize(event *yamlEvent, encoding yamlEncoding) {
+	*event = yamlEvent{
 		typ:      yaml_STREAM_START_EVENT,
 		encoding: encoding,
 	}
 }
 
 // Create STREAM-END.
-func yaml_stream_end_event_initialize(event *yaml_event_t) {
-	*event = yaml_event_t{
+func yaml_stream_end_event_initialize(event *yamlEvent) {
+	*event = yamlEvent{
 		typ: yaml_STREAM_END_EVENT,
 	}
 }
 
 // Create DOCUMENT-START.
 func yaml_document_start_event_initialize(
-	event *yaml_event_t,
-	version_directive *yaml_version_directive_t,
-	tag_directives []yaml_tag_directive_t,
+	event *yamlEvent,
+	version_directive *yamlVersionDirective,
+	tag_directives []yamlTagDirective,
 	implicit bool,
 ) {
-	*event = yaml_event_t{
+	*event = yamlEvent{
 		typ:               yaml_DOCUMENT_START_EVENT,
 		version_directive: version_directive,
 		tag_directives:    tag_directives,
@@ -304,16 +304,16 @@ func yaml_document_start_event_initialize(
 }
 
 // Create DOCUMENT-END.
-func yaml_document_end_event_initialize(event *yaml_event_t, implicit bool) {
-	*event = yaml_event_t{
+func yaml_document_end_event_initialize(event *yamlEvent, implicit bool) {
+	*event = yamlEvent{
 		typ:      yaml_DOCUMENT_END_EVENT,
 		implicit: implicit,
 	}
 }
 
 // Create ALIAS.
-func yaml_alias_event_initialize(event *yaml_event_t, anchor []byte) bool {
-	*event = yaml_event_t{
+func yaml_alias_event_initialize(event *yamlEvent, anchor []byte) bool {
+	*event = yamlEvent{
 		typ:    yaml_ALIAS_EVENT,
 		anchor: anchor,
 	}
@@ -321,60 +321,60 @@ func yaml_alias_event_initialize(event *yaml_event_t, anchor []byte) bool {
 }
 
 // Create SCALAR.
-func yaml_scalar_event_initialize(event *yaml_event_t, anchor, tag, value []byte, plain_implicit, quoted_implicit bool, style yaml_scalar_style_t) bool {
-	*event = yaml_event_t{
+func yaml_scalar_event_initialize(event *yamlEvent, anchor, tag, value []byte, plain_implicit, quoted_implicit bool, style yamlScalarStyle) bool {
+	*event = yamlEvent{
 		typ:             yaml_SCALAR_EVENT,
 		anchor:          anchor,
 		tag:             tag,
 		value:           value,
 		implicit:        plain_implicit,
 		quoted_implicit: quoted_implicit,
-		style:           yaml_style_t(style),
+		style:           yamlStyle(style),
 	}
 	return true
 }
 
 // Create SEQUENCE-START.
-func yaml_sequence_start_event_initialize(event *yaml_event_t, anchor, tag []byte, implicit bool, style yaml_sequence_style_t) bool {
-	*event = yaml_event_t{
+func yaml_sequence_start_event_initialize(event *yamlEvent, anchor, tag []byte, implicit bool, style yamlSequenceStyle) bool {
+	*event = yamlEvent{
 		typ:      yaml_SEQUENCE_START_EVENT,
 		anchor:   anchor,
 		tag:      tag,
 		implicit: implicit,
-		style:    yaml_style_t(style),
+		style:    yamlStyle(style),
 	}
 	return true
 }
 
 // Create SEQUENCE-END.
-func yaml_sequence_end_event_initialize(event *yaml_event_t) bool {
-	*event = yaml_event_t{
+func yaml_sequence_end_event_initialize(event *yamlEvent) bool {
+	*event = yamlEvent{
 		typ: yaml_SEQUENCE_END_EVENT,
 	}
 	return true
 }
 
 // Create MAPPING-START.
-func yaml_mapping_start_event_initialize(event *yaml_event_t, anchor, tag []byte, implicit bool, style yaml_mapping_style_t) {
-	*event = yaml_event_t{
+func yaml_mapping_start_event_initialize(event *yamlEvent, anchor, tag []byte, implicit bool, style yamlMappingStyle) {
+	*event = yamlEvent{
 		typ:      yaml_MAPPING_START_EVENT,
 		anchor:   anchor,
 		tag:      tag,
 		implicit: implicit,
-		style:    yaml_style_t(style),
+		style:    yamlStyle(style),
 	}
 }
 
 // Create MAPPING-END.
-func yaml_mapping_end_event_initialize(event *yaml_event_t) {
-	*event = yaml_event_t{
+func yaml_mapping_end_event_initialize(event *yamlEvent) {
+	*event = yamlEvent{
 		typ: yaml_MAPPING_END_EVENT,
 	}
 }
 
 // Destroy an event object.
-func yaml_event_delete(event *yaml_event_t) {
-	*event = yaml_event_t{}
+func yaml_event_delete(event *yamlEvent) {
+	*event = yamlEvent{}
 }
 
 ///*

--- a/decode.go
+++ b/decode.go
@@ -29,8 +29,8 @@ import (
 // Parser, produces a node tree out of a libyaml event stream.
 
 type parser struct {
-	parser   yaml_parser_t
-	event    yaml_event_t
+	parser   yamlParser
+	event    yamlEvent
 	doc      *Node
 	anchors  map[string]*Node
 	doneInit bool
@@ -76,7 +76,7 @@ func (p *parser) destroy() {
 
 // expect consumes an event from the event stream and
 // checks that it's of the expected type.
-func (p *parser) expect(e yaml_event_type_t) {
+func (p *parser) expect(e yamlEventType) {
 	if p.event.typ == yaml_NO_EVENT {
 		if !yaml_parser_parse(&p.parser, &p.event) {
 			p.fail()
@@ -95,7 +95,7 @@ func (p *parser) expect(e yaml_event_type_t) {
 
 // peek peeks at the next event in the event stream,
 // puts the results into p.event and returns the event type.
-func (p *parser) peek() yaml_event_type_t {
+func (p *parser) peek() yamlEventType {
 	if p.event.typ != yaml_NO_EVENT {
 		return p.event.typ
 	}

--- a/encode.go
+++ b/encode.go
@@ -29,8 +29,8 @@ import (
 )
 
 type encoder struct {
-	emitter  yaml_emitter_t
-	event    yaml_event_t
+	emitter  yamlEmitter
+	event    yamlEvent
 	out      []byte
 	flow     bool
 	indent   int
@@ -330,7 +330,7 @@ func looksLikeMerge(s string) (result bool) {
 }
 
 func (e *encoder) stringv(tag string, in reflect.Value) {
-	var style yaml_scalar_style_t
+	var style yamlScalarStyle
 	s := in.String()
 	canUsePlain := true
 	switch {
@@ -422,7 +422,7 @@ func (e *encoder) nilv() {
 	e.emitScalar("null", "", "", yaml_PLAIN_SCALAR_STYLE, nil, nil, nil, nil)
 }
 
-func (e *encoder) emitScalar(value, anchor, tag string, style yaml_scalar_style_t, head, line, foot, tail []byte) {
+func (e *encoder) emitScalar(value, anchor, tag string, style yamlScalarStyle, head, line, foot, tail []byte) {
 	// TODO Kill this function. Replace all initialize calls by their underlining Go literals.
 	implicit := tag == ""
 	if !implicit {

--- a/readerc.go
+++ b/readerc.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Set the reader error and return 0.
-func yaml_parser_set_reader_error(parser *yaml_parser_t, problem string, offset int, value int) bool {
+func yaml_parser_set_reader_error(parser *yamlParser, problem string, offset int, value int) bool {
 	parser.error = yaml_READER_ERROR
 	parser.problem = problem
 	parser.problem_offset = offset
@@ -44,7 +44,7 @@ const (
 
 // Determine the input stream encoding by checking the BOM symbol. If no BOM is
 // found, the UTF-8 encoding is assumed. Return 1 on success, 0 on failure.
-func yaml_parser_determine_encoding(parser *yaml_parser_t) bool {
+func yaml_parser_determine_encoding(parser *yamlParser) bool {
 	// Ensure that we had enough bytes in the raw buffer.
 	for !parser.eof && len(parser.raw_buffer)-parser.raw_buffer_pos < 3 {
 		if !yaml_parser_update_raw_buffer(parser) {
@@ -75,7 +75,7 @@ func yaml_parser_determine_encoding(parser *yaml_parser_t) bool {
 }
 
 // Update the raw buffer.
-func yaml_parser_update_raw_buffer(parser *yaml_parser_t) bool {
+func yaml_parser_update_raw_buffer(parser *yamlParser) bool {
 	size_read := 0
 
 	// Return if the raw buffer is full.
@@ -110,7 +110,7 @@ func yaml_parser_update_raw_buffer(parser *yaml_parser_t) bool {
 // Return true on success, false on failure.
 //
 // The length is supposed to be significantly less that the buffer size.
-func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
+func yaml_parser_update_buffer(parser *yamlParser, length int) bool {
 	if parser.read_handler == nil {
 		panic("read handler must be set")
 	}

--- a/writerc.go
+++ b/writerc.go
@@ -23,14 +23,14 @@
 package yaml
 
 // Set the writer error and return false.
-func yaml_emitter_set_writer_error(emitter *yaml_emitter_t, problem string) bool {
+func yaml_emitter_set_writer_error(emitter *yamlEmitter, problem string) bool {
 	emitter.error = yaml_WRITER_ERROR
 	emitter.problem = problem
 	return false
 }
 
 // Flush the output buffer.
-func yaml_emitter_flush(emitter *yaml_emitter_t) bool {
+func yaml_emitter_flush(emitter *yamlEmitter) bool {
 	if emitter.write_handler == nil {
 		panic("write handler not set")
 	}

--- a/yaml.go
+++ b/yaml.go
@@ -791,7 +791,7 @@ func ParserGetEvents(in []byte) (string, error) {
 	p := newParser(in)
 	defer p.destroy()
 	var events strings.Builder
-	var event yaml_event_t
+	var event yamlEvent
 	for {
 		if !yaml_parser_parse(&p.parser, &event) {
 			return "", errors.New(p.parser.problem)
@@ -808,7 +808,7 @@ func ParserGetEvents(in []byte) (string, error) {
 	return events.String(), nil
 }
 
-func formatEvent(e *yaml_event_t) string {
+func formatEvent(e *yamlEvent) string {
 	var b strings.Builder
 	switch e.typ {
 	case yaml_STREAM_START_EVENT:

--- a/yamlh.go
+++ b/yamlh.go
@@ -28,47 +28,47 @@ import (
 )
 
 // The version directive data.
-type yaml_version_directive_t struct {
+type yamlVersionDirective struct {
 	major int8 // The major version number.
 	minor int8 // The minor version number.
 }
 
 // The tag directive data.
-type yaml_tag_directive_t struct {
+type yamlTagDirective struct {
 	handle []byte // The tag handle.
 	prefix []byte // The tag prefix.
 }
 
-type yaml_encoding_t int
+type yamlEncoding int
 
 // The stream encoding.
 const (
 	// Let the parser choose the encoding.
-	yaml_ANY_ENCODING yaml_encoding_t = iota
+	yaml_ANY_ENCODING yamlEncoding = iota
 
 	yaml_UTF8_ENCODING    // The default UTF-8 encoding.
 	yaml_UTF16LE_ENCODING // The UTF-16-LE encoding with BOM.
 	yaml_UTF16BE_ENCODING // The UTF-16-BE encoding with BOM.
 )
 
-type yaml_break_t int
+type yamlBreak int
 
 // Line break types.
 const (
 	// Let the parser choose the break type.
-	yaml_ANY_BREAK yaml_break_t = iota
+	yaml_ANY_BREAK yamlBreak = iota
 
 	yaml_CR_BREAK   // Use CR for line breaks (Mac style).
 	yaml_LN_BREAK   // Use LN for line breaks (Unix style).
 	yaml_CRLN_BREAK // Use CR LN for line breaks (DOS style).
 )
 
-type yaml_error_type_t int
+type yamlErrorType int
 
 // Many bad things could happen with the parser and emitter.
 const (
 	// No error is produced.
-	yaml_NO_ERROR yaml_error_type_t = iota
+	yaml_NO_ERROR yamlErrorType = iota
 
 	yaml_MEMORY_ERROR   // Cannot allocate or reallocate a block of memory.
 	yaml_READER_ERROR   // Cannot read or decode the input stream.
@@ -80,7 +80,7 @@ const (
 )
 
 // The pointer position.
-type yaml_mark_t struct {
+type yamlMark struct {
 	index  int // The position index.
 	line   int // The position line.
 	column int // The position column.
@@ -88,39 +88,39 @@ type yaml_mark_t struct {
 
 // Node Styles
 
-type yaml_style_t int8
+type yamlStyle int8
 
-type yaml_scalar_style_t yaml_style_t
+type yamlScalarStyle yamlStyle
 
 // Scalar styles.
 const (
 	// Let the emitter choose the style.
-	yaml_ANY_SCALAR_STYLE yaml_scalar_style_t = 0
+	yaml_ANY_SCALAR_STYLE yamlScalarStyle = 0
 
-	yaml_PLAIN_SCALAR_STYLE         yaml_scalar_style_t = 1 << iota // The plain scalar style.
-	yaml_SINGLE_QUOTED_SCALAR_STYLE                                 // The single-quoted scalar style.
-	yaml_DOUBLE_QUOTED_SCALAR_STYLE                                 // The double-quoted scalar style.
-	yaml_LITERAL_SCALAR_STYLE                                       // The literal scalar style.
-	yaml_FOLDED_SCALAR_STYLE                                        // The folded scalar style.
+	yaml_PLAIN_SCALAR_STYLE         yamlScalarStyle = 1 << iota // The plain scalar style.
+	yaml_SINGLE_QUOTED_SCALAR_STYLE                             // The single-quoted scalar style.
+	yaml_DOUBLE_QUOTED_SCALAR_STYLE                             // The double-quoted scalar style.
+	yaml_LITERAL_SCALAR_STYLE                                   // The literal scalar style.
+	yaml_FOLDED_SCALAR_STYLE                                    // The folded scalar style.
 )
 
-type yaml_sequence_style_t yaml_style_t
+type yamlSequenceStyle yamlStyle
 
 // Sequence styles.
 const (
 	// Let the emitter choose the style.
-	yaml_ANY_SEQUENCE_STYLE yaml_sequence_style_t = iota
+	yaml_ANY_SEQUENCE_STYLE yamlSequenceStyle = iota
 
 	yaml_BLOCK_SEQUENCE_STYLE // The block sequence style.
 	yaml_FLOW_SEQUENCE_STYLE  // The flow sequence style.
 )
 
-type yaml_mapping_style_t yaml_style_t
+type yamlMappingStyle yamlStyle
 
 // Mapping styles.
 const (
 	// Let the emitter choose the style.
-	yaml_ANY_MAPPING_STYLE yaml_mapping_style_t = iota
+	yaml_ANY_MAPPING_STYLE yamlMappingStyle = iota
 
 	yaml_BLOCK_MAPPING_STYLE // The block mapping style.
 	yaml_FLOW_MAPPING_STYLE  // The flow mapping style.
@@ -128,12 +128,12 @@ const (
 
 // Tokens
 
-type yaml_token_type_t int
+type yamlTokenType int
 
 // Token types.
 const (
 	// An empty token.
-	yaml_NO_TOKEN yaml_token_type_t = iota
+	yaml_NO_TOKEN yamlTokenType = iota
 
 	yaml_STREAM_START_TOKEN // A STREAM-START token.
 	yaml_STREAM_END_TOKEN   // A STREAM-END token.
@@ -163,7 +163,7 @@ const (
 	yaml_SCALAR_TOKEN // A SCALAR token.
 )
 
-func (tt yaml_token_type_t) String() string {
+func (tt yamlTokenType) String() string {
 	switch tt {
 	case yaml_NO_TOKEN:
 		return "yaml_NO_TOKEN"
@@ -214,15 +214,15 @@ func (tt yaml_token_type_t) String() string {
 }
 
 // The token structure.
-type yaml_token_t struct {
+type yamlToken struct {
 	// The token type.
-	typ yaml_token_type_t
+	typ yamlTokenType
 
 	// The start/end of the token.
-	start_mark, end_mark yaml_mark_t
+	start_mark, end_mark yamlMark
 
 	// The stream encoding (for yaml_STREAM_START_TOKEN).
-	encoding yaml_encoding_t
+	encoding yamlEncoding
 
 	// The alias/anchor/scalar value or tag/tag directive handle
 	// (for yaml_ALIAS_TOKEN, yaml_ANCHOR_TOKEN, yaml_SCALAR_TOKEN, yaml_TAG_TOKEN, yaml_TAG_DIRECTIVE_TOKEN).
@@ -235,7 +235,7 @@ type yaml_token_t struct {
 	prefix []byte
 
 	// The scalar style (for yaml_SCALAR_TOKEN).
-	style yaml_scalar_style_t
+	style yamlScalarStyle
 
 	// The version directive major/minor (for yaml_VERSION_DIRECTIVE_TOKEN).
 	major, minor int8
@@ -243,12 +243,12 @@ type yaml_token_t struct {
 
 // Events
 
-type yaml_event_type_t int8
+type yamlEventType int8
 
 // Event types.
 const (
 	// An empty event.
-	yaml_NO_EVENT yaml_event_type_t = iota
+	yaml_NO_EVENT yamlEventType = iota
 
 	yaml_STREAM_START_EVENT   // A STREAM-START event.
 	yaml_STREAM_END_EVENT     // A STREAM-END event.
@@ -278,7 +278,7 @@ var eventStrings = []string{
 	yaml_TAIL_COMMENT_EVENT:   "tail comment",
 }
 
-func (e yaml_event_type_t) String() string {
+func (e yamlEventType) String() string {
 	if e < 0 || int(e) >= len(eventStrings) {
 		return fmt.Sprintf("unknown event %d", e)
 	}
@@ -286,22 +286,22 @@ func (e yaml_event_type_t) String() string {
 }
 
 // The event structure.
-type yaml_event_t struct {
+type yamlEvent struct {
 
 	// The event type.
-	typ yaml_event_type_t
+	typ yamlEventType
 
 	// The start and end of the event.
-	start_mark, end_mark yaml_mark_t
+	start_mark, end_mark yamlMark
 
 	// The document encoding (for yaml_STREAM_START_EVENT).
-	encoding yaml_encoding_t
+	encoding yamlEncoding
 
 	// The version directive (for yaml_DOCUMENT_START_EVENT).
-	version_directive *yaml_version_directive_t
+	version_directive *yamlVersionDirective
 
 	// The list of tag directives (for yaml_DOCUMENT_START_EVENT).
-	tag_directives []yaml_tag_directive_t
+	tag_directives []yamlTagDirective
 
 	// The comments
 	head_comment []byte
@@ -326,12 +326,12 @@ type yaml_event_t struct {
 	quoted_implicit bool
 
 	// The style (for yaml_SCALAR_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT).
-	style yaml_style_t
+	style yamlStyle
 }
 
-func (e *yaml_event_t) scalar_style() yaml_scalar_style_t     { return yaml_scalar_style_t(e.style) }
-func (e *yaml_event_t) sequence_style() yaml_sequence_style_t { return yaml_sequence_style_t(e.style) }
-func (e *yaml_event_t) mapping_style() yaml_mapping_style_t   { return yaml_mapping_style_t(e.style) }
+func (e *yamlEvent) scalar_style() yamlScalarStyle     { return yamlScalarStyle(e.style) }
+func (e *yamlEvent) sequence_style() yamlSequenceStyle { return yamlSequenceStyle(e.style) }
+func (e *yamlEvent) mapping_style() yamlMappingStyle   { return yamlMappingStyle(e.style) }
 
 // Nodes
 
@@ -355,12 +355,12 @@ const (
 	yaml_DEFAULT_MAPPING_TAG  = yaml_MAP_TAG // The default mapping tag is !!map.
 )
 
-type yaml_node_type_t int
+type yamlNodeType int
 
 // Node types.
 const (
 	// An empty node.
-	yaml_NO_NODE yaml_node_type_t = iota
+	yaml_NO_NODE yamlNodeType = iota
 
 	yaml_SCALAR_NODE   // A scalar node.
 	yaml_SEQUENCE_NODE // A sequence node.
@@ -368,59 +368,59 @@ const (
 )
 
 // An element of a sequence node.
-type yaml_node_item_t int
+type yamlNodeItem int
 
 // An element of a mapping node.
-type yaml_node_pair_t struct {
+type yamlNodePair struct {
 	key   int // The key of the element.
 	value int // The value of the element.
 }
 
 // The node structure.
-type yaml_node_t struct {
-	typ yaml_node_type_t // The node type.
-	tag []byte           // The node tag.
+type yamlNode struct {
+	typ yamlNodeType // The node type.
+	tag []byte       // The node tag.
 
 	// The node data.
 
 	// The scalar parameters (for yaml_SCALAR_NODE).
 	scalar struct {
-		value  []byte              // The scalar value.
-		length int                 // The length of the scalar value.
-		style  yaml_scalar_style_t // The scalar style.
+		value  []byte          // The scalar value.
+		length int             // The length of the scalar value.
+		style  yamlScalarStyle // The scalar style.
 	}
 
 	// The sequence parameters (for YAML_SEQUENCE_NODE).
 	sequence struct {
-		items_data []yaml_node_item_t    // The stack of sequence items.
-		style      yaml_sequence_style_t // The sequence style.
+		items_data []yamlNodeItem    // The stack of sequence items.
+		style      yamlSequenceStyle // The sequence style.
 	}
 
 	// The mapping parameters (for yaml_MAPPING_NODE).
 	mapping struct {
-		pairs_data  []yaml_node_pair_t   // The stack of mapping pairs (key, value).
-		pairs_start *yaml_node_pair_t    // The beginning of the stack.
-		pairs_end   *yaml_node_pair_t    // The end of the stack.
-		pairs_top   *yaml_node_pair_t    // The top of the stack.
-		style       yaml_mapping_style_t // The mapping style.
+		pairs_data  []yamlNodePair   // The stack of mapping pairs (key, value).
+		pairs_start *yamlNodePair    // The beginning of the stack.
+		pairs_end   *yamlNodePair    // The end of the stack.
+		pairs_top   *yamlNodePair    // The top of the stack.
+		style       yamlMappingStyle // The mapping style.
 	}
 
-	start_mark yaml_mark_t // The beginning of the node.
-	end_mark   yaml_mark_t // The end of the node.
+	start_mark yamlMark // The beginning of the node.
+	end_mark   yamlMark // The end of the node.
 
 }
 
 // The document structure.
-type yaml_document_t struct {
+type yamlDocument struct {
 
 	// The document nodes.
-	nodes []yaml_node_t
+	nodes []yamlNode
 
 	// The version directive.
-	version_directive *yaml_version_directive_t
+	version_directive *yamlVersionDirective
 
 	// The list of tag directives.
-	tag_directives_data  []yaml_tag_directive_t
+	tag_directives_data  []yamlTagDirective
 	tag_directives_start int // The beginning of the tag directives list.
 	tag_directives_end   int // The end of the tag directives list.
 
@@ -428,7 +428,7 @@ type yaml_document_t struct {
 	end_implicit   int // Is the document end indicator implicit?
 
 	// The start/end of the document.
-	start_mark, end_mark yaml_mark_t
+	start_mark, end_mark yamlMark
 }
 
 // The prototype of a read handler.
@@ -448,21 +448,21 @@ type yaml_document_t struct {
 // On success, the handler should return 1.  If the handler failed,
 // the returned value should be 0. On EOF, the handler should set the
 // size_read to 0 and return 1.
-type yaml_read_handler_t func(parser *yaml_parser_t, buffer []byte) (n int, err error)
+type yamlReadHandler func(parser *yamlParser, buffer []byte) (n int, err error)
 
 // This structure holds information about a potential simple key.
-type yaml_simple_key_t struct {
-	possible     bool        // Is a simple key possible?
-	required     bool        // Is a simple key required?
-	token_number int         // The number of the token.
-	mark         yaml_mark_t // The position mark.
+type yamlSimpleKey struct {
+	possible     bool     // Is a simple key possible?
+	required     bool     // Is a simple key required?
+	token_number int      // The number of the token.
+	mark         yamlMark // The position mark.
 }
 
 // The states of the parser.
-type yaml_parser_state_t int
+type yamlParserState int
 
 const (
-	yaml_PARSE_STREAM_START_STATE yaml_parser_state_t = iota
+	yaml_PARSE_STREAM_START_STATE yamlParserState = iota
 
 	yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE           // Expect the beginning of an implicit document.
 	yaml_PARSE_DOCUMENT_START_STATE                    // Expect DOCUMENT-START.
@@ -489,7 +489,7 @@ const (
 	yaml_PARSE_END_STATE                               // Expect nothing.
 )
 
-func (ps yaml_parser_state_t) String() string {
+func (ps yamlParserState) String() string {
 	switch ps {
 	case yaml_PARSE_STREAM_START_STATE:
 		return "yaml_PARSE_STREAM_START_STATE"
@@ -544,36 +544,36 @@ func (ps yaml_parser_state_t) String() string {
 }
 
 // This structure holds aliases data.
-type yaml_alias_data_t struct {
-	anchor []byte      // The anchor.
-	index  int         // The node id.
-	mark   yaml_mark_t // The anchor mark.
+type yamlAliasData struct {
+	anchor []byte   // The anchor.
+	index  int      // The node id.
+	mark   yamlMark // The anchor mark.
 }
 
 // The parser structure.
 //
 // All members are internal. Manage the structure using the
 // yaml_parser_ family of functions.
-type yaml_parser_t struct {
+type yamlParser struct {
 
 	// Error handling
 
-	error yaml_error_type_t // Error type.
+	error yamlErrorType // Error type.
 
 	problem string // Error description.
 
 	// The byte about which the problem occurred.
 	problem_offset int
 	problem_value  int
-	problem_mark   yaml_mark_t
+	problem_mark   yamlMark
 
 	// The error context.
 	context      string
-	context_mark yaml_mark_t
+	context_mark yamlMark
 
 	// Reader stuff
 
-	read_handler yaml_read_handler_t // Read handler.
+	read_handler yamlReadHandler // Read handler.
 
 	input_reader io.Reader // File input data.
 	input        []byte    // String input data.
@@ -591,10 +591,10 @@ type yaml_parser_t struct {
 	raw_buffer     []byte // The raw buffer.
 	raw_buffer_pos int    // The current position of the buffer.
 
-	encoding yaml_encoding_t // The input encoding.
+	encoding yamlEncoding // The input encoding.
 
-	offset int         // The offset of the current position (in bytes).
-	mark   yaml_mark_t // The mark of the current position.
+	offset int      // The offset of the current position (in bytes).
+	mark   yamlMark // The mark of the current position.
 
 	// Comments
 
@@ -604,7 +604,7 @@ type yaml_parser_t struct {
 	tail_comment []byte // Foot comment that happens at the end of a block.
 	stem_comment []byte // Comment in item preceding a nested structure (list inside list item, etc)
 
-	comments      []yaml_comment_t // The folded comments for all parsed tokens
+	comments      []yamlComment // The folded comments for all parsed tokens
 	comments_head int
 
 	// Scanner stuff
@@ -614,37 +614,37 @@ type yaml_parser_t struct {
 
 	flow_level int // The number of unclosed '[' and '{' indicators.
 
-	tokens          []yaml_token_t // The tokens queue.
-	tokens_head     int            // The head of the tokens queue.
-	tokens_parsed   int            // The number of tokens fetched from the queue.
-	token_available bool           // Does the tokens queue contain a token ready for dequeueing.
+	tokens          []yamlToken // The tokens queue.
+	tokens_head     int         // The head of the tokens queue.
+	tokens_parsed   int         // The number of tokens fetched from the queue.
+	token_available bool        // Does the tokens queue contain a token ready for dequeueing.
 
 	indent  int   // The current indentation level.
 	indents []int // The indentation levels stack.
 
-	simple_key_allowed bool                // May a simple key occur at the current position?
-	simple_keys        []yaml_simple_key_t // The stack of simple keys.
-	simple_keys_by_tok map[int]int         // possible simple_key indexes indexed by token_number
+	simple_key_allowed bool            // May a simple key occur at the current position?
+	simple_keys        []yamlSimpleKey // The stack of simple keys.
+	simple_keys_by_tok map[int]int     // possible simple_key indexes indexed by token_number
 
 	// Parser stuff
 
-	state          yaml_parser_state_t    // The current parser state.
-	states         []yaml_parser_state_t  // The parser states stack.
-	marks          []yaml_mark_t          // The stack of marks.
-	tag_directives []yaml_tag_directive_t // The list of TAG directives.
+	state          yamlParserState    // The current parser state.
+	states         []yamlParserState  // The parser states stack.
+	marks          []yamlMark         // The stack of marks.
+	tag_directives []yamlTagDirective // The list of TAG directives.
 
 	// Dumper stuff
 
-	aliases []yaml_alias_data_t // The alias data.
+	aliases []yamlAliasData // The alias data.
 
-	document *yaml_document_t // The currently parsed document.
+	document *yamlDocument // The currently parsed document.
 }
 
-type yaml_comment_t struct {
-	scan_mark  yaml_mark_t // Position where scanning for comments started
-	token_mark yaml_mark_t // Position after which tokens will be associated with this comment
-	start_mark yaml_mark_t // Position of '#' comment mark
-	end_mark   yaml_mark_t // Position where comment terminated
+type yamlComment struct {
+	scan_mark  yamlMark // Position where scanning for comments started
+	token_mark yamlMark // Position after which tokens will be associated with this comment
+	start_mark yamlMark // Position of '#' comment mark
+	end_mark   yamlMark // Position where comment terminated
 
 	head []byte
 	line []byte
@@ -668,14 +668,14 @@ type yaml_comment_t struct {
 //
 // @returns On success, the handler should return @c 1.  If the handler failed,
 // the returned value should be @c 0.
-type yaml_write_handler_t func(emitter *yaml_emitter_t, buffer []byte) error
+type yamlWriteHandler func(emitter *yamlEmitter, buffer []byte) error
 
-type yaml_emitter_state_t int
+type yamlEmitterState int
 
 // The emitter states.
 const (
 	// Expect STREAM-START.
-	yaml_EMIT_STREAM_START_STATE yaml_emitter_state_t = iota
+	yaml_EMIT_STREAM_START_STATE yamlEmitterState = iota
 
 	yaml_EMIT_FIRST_DOCUMENT_START_STATE       // Expect the first DOCUMENT-START or STREAM-END.
 	yaml_EMIT_DOCUMENT_START_STATE             // Expect DOCUMENT-START or STREAM-END.
@@ -702,16 +702,16 @@ const (
 //
 // All members are internal.  Manage the structure using the @c yaml_emitter_
 // family of functions.
-type yaml_emitter_t struct {
+type yamlEmitter struct {
 
 	// Error handling
 
-	error   yaml_error_type_t // Error type.
-	problem string            // Error description.
+	error   yamlErrorType // Error type.
+	problem string        // Error description.
 
 	// Writer stuff
 
-	write_handler yaml_write_handler_t // Write handler.
+	write_handler yamlWriteHandler // Write handler.
 
 	output_buffer *[]byte   // String output data.
 	output_writer io.Writer // File output data.
@@ -722,25 +722,25 @@ type yaml_emitter_t struct {
 	raw_buffer     []byte // The raw buffer.
 	raw_buffer_pos int    // The current position of the buffer.
 
-	encoding yaml_encoding_t // The stream encoding.
+	encoding yamlEncoding // The stream encoding.
 
 	// Emitter stuff
 
-	canonical   bool         // If the output is in the canonical style?
-	best_indent int          // The number of indentation spaces.
-	best_width  int          // The preferred width of the output lines.
-	unicode     bool         // Allow unescaped non-ASCII characters?
-	line_break  yaml_break_t // The preferred line break.
+	canonical   bool      // If the output is in the canonical style?
+	best_indent int       // The number of indentation spaces.
+	best_width  int       // The preferred width of the output lines.
+	unicode     bool      // Allow unescaped non-ASCII characters?
+	line_break  yamlBreak // The preferred line break.
 
-	state  yaml_emitter_state_t   // The current emitter state.
-	states []yaml_emitter_state_t // The stack of states.
+	state  yamlEmitterState   // The current emitter state.
+	states []yamlEmitterState // The stack of states.
 
-	events      []yaml_event_t // The event queue.
-	events_head int            // The head of the event queue.
+	events      []yamlEvent // The event queue.
+	events_head int         // The head of the event queue.
 
 	indents []int // The stack of indentation levels.
 
-	tag_directives []yaml_tag_directive_t // The list of tag directives.
+	tag_directives []yamlTagDirective // The list of tag directives.
 
 	indent int // The current indentation level.
 
@@ -776,13 +776,13 @@ type yaml_emitter_t struct {
 
 	// Scalar analysis.
 	scalar_data struct {
-		value                 []byte              // The scalar value.
-		multiline             bool                // Does the scalar contain line breaks?
-		flow_plain_allowed    bool                // Can the scalar be expressed in the flow plain style?
-		block_plain_allowed   bool                // Can the scalar be expressed in the block plain style?
-		single_quoted_allowed bool                // Can the scalar be expressed in the single quoted style?
-		block_allowed         bool                // Can the scalar be expressed in the literal or folded styles?
-		style                 yaml_scalar_style_t // The output style.
+		value                 []byte          // The scalar value.
+		multiline             bool            // Does the scalar contain line breaks?
+		flow_plain_allowed    bool            // Can the scalar be expessed in the flow plain style?
+		block_plain_allowed   bool            // Can the scalar be expressed in the block plain style?
+		single_quoted_allowed bool            // Can the scalar be expressed in the single quoted style?
+		block_allowed         bool            // Can the scalar be expressed in the literal or folded styles?
+		style                 yamlScalarStyle // The output style.
 	}
 
 	// Comments
@@ -807,5 +807,5 @@ type yaml_emitter_t struct {
 
 	last_anchor_id int // The last assigned anchor id.
 
-	document *yaml_document_t // The currently emitted document.
+	document *yamlDocument // The currently emitted document.
 }


### PR DESCRIPTION
The types were copied from the c project this implementation was based on.
However, in Go the convention is to use [MixedCaps names](https://go.dev/doc/effective_go#mixed-caps).
I hope that this rename will make the code a bit less scary for Go developers.

I renamed the types using this script:
```bash
gofmt -r 'yaml_emitter_t -> yamlEmitter' -w ./

gofmt -r 'yaml_version_directive_t -> yamlVersionDirective' -w ./
gofmt -r 'yaml_tag_directive_t -> yamlTagDirective' -w ./
gofmt -r 'yaml_mark_t -> yamlMark' -w ./
gofmt -r 'yaml_token_t -> yamlToken' -w ./
gofmt -r 'yaml_event_t -> yamlEvent' -w ./
gofmt -r 'yaml_node_pair_t -> yamlNodePair' -w ./
gofmt -r 'yaml_node_t -> yamlNode' -w ./
gofmt -r 'yaml_document_t -> yamlDocument' -w ./
gofmt -r 'yaml_simple_key_t -> yamlSimpleKey' -w ./
gofmt -r 'yaml_alias_data_t -> yamlAliasData' -w ./
gofmt -r 'yaml_parser_t -> yamlParser' -w ./
gofmt -r 'yaml_comment_t -> yamlComment' -w ./

gofmt -r 'yaml_read_handler_t -> yamlReadHandler' -w ./
gofmt -r 'yaml_write_handler_t -> yamlWriteHandler' -w ./

gofmt -r 'yaml_encoding_t -> yamlEncoding' -w ./
gofmt -r 'yaml_break_t -> yamlBreak' -w ./
gofmt -r 'yaml_error_type_t -> yamlErrorType' -w ./
gofmt -r 'yaml_style_t -> yamlStyle' -w ./
gofmt -r 'yaml_token_type_t -> yamlTokenType' -w ./
gofmt -r 'yaml_event_type_t -> yamlEventType' -w ./
gofmt -r 'yaml_node_type_t -> yamlNodeType' -w ./
gofmt -r 'yaml_node_item_t -> yamlNodeItem' -w ./
gofmt -r 'yaml_parser_state_t -> yamlParserState' -w ./
gofmt -r 'yaml_emitter_state_t -> yamlEmitterState' -w ./

gofmt -r 'yaml_scalar_style_t -> yamlScalarStyle' -w ./
gofmt -r 'yaml_sequence_style_t -> yamlSequenceStyle' -w ./
gofmt -r 'yaml_mapping_style_t -> yamlMappingStyle' -w ./
```