### PR TITLE
Renamed functions to match Go naming conventions

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -26,7 +26,7 @@ import (
 	"io"
 )
 
-func yaml_insert_token(parser *yamlParser, pos int, token *yamlToken) {
+func (parser *yamlParser) insertToken(pos int, token *yamlToken) {
 	//fmt.Println("yaml_insert_token", "pos:", pos, "typ:", token.typ, "head:", parser.tokens_head, "len:", len(parser.tokens))
 
 	// Check if we can move the queue at the beginning of the buffer.
@@ -46,7 +46,7 @@ func yaml_insert_token(parser *yamlParser, pos int, token *yamlToken) {
 }
 
 // Create a new parser object.
-func yaml_parser_initialize(parser *yamlParser) bool {
+func (parser *yamlParser) initialize() bool {
 	*parser = yamlParser{
 		raw_buffer: make([]byte, 0, input_raw_buffer_size),
 		buffer:     make([]byte, 0, input_buffer_size),
@@ -55,12 +55,12 @@ func yaml_parser_initialize(parser *yamlParser) bool {
 }
 
 // Destroy a parser object.
-func yaml_parser_delete(parser *yamlParser) {
+func (parser *yamlParser) delete() {
 	*parser = yamlParser{}
 }
 
 // String read handler.
-func yaml_string_read_handler(parser *yamlParser, buffer []byte) (n int, err error) {
+func yamlStringReadHandler(parser *yamlParser, buffer []byte) (n int, err error) {
 	if parser.input_pos == len(parser.input) {
 		return 0, io.EOF
 	}
@@ -70,31 +70,31 @@ func yaml_string_read_handler(parser *yamlParser, buffer []byte) (n int, err err
 }
 
 // Reader read handler.
-func yaml_reader_read_handler(parser *yamlParser, buffer []byte) (n int, err error) {
+func yamlReaderReadHandler(parser *yamlParser, buffer []byte) (n int, err error) {
 	return parser.input_reader.Read(buffer)
 }
 
 // Set a string input.
-func yaml_parser_set_input_string(parser *yamlParser, input []byte) {
+func (parser *yamlParser) setInputString(input []byte) {
 	if parser.read_handler != nil {
 		panic("must set the input source only once")
 	}
-	parser.read_handler = yaml_string_read_handler
+	parser.read_handler = yamlStringReadHandler
 	parser.input = input
 	parser.input_pos = 0
 }
 
 // Set a file input.
-func yaml_parser_set_input_reader(parser *yamlParser, r io.Reader) {
+func (parser *yamlParser) setInputReader(r io.Reader) {
 	if parser.read_handler != nil {
 		panic("must set the input source only once")
 	}
-	parser.read_handler = yaml_reader_read_handler
+	parser.read_handler = yamlReaderReadHandler
 	parser.input_reader = r
 }
 
 // Set the source encoding.
-func yaml_parser_set_encoding(parser *yamlParser, encoding yamlEncoding) {
+func (parser *yamlParser) setEncoding(encoding yamlEncoding) {
 	if parser.encoding != yaml_ANY_ENCODING {
 		panic("must set the encoding only once")
 	}
@@ -102,7 +102,7 @@ func yaml_parser_set_encoding(parser *yamlParser, encoding yamlEncoding) {
 }
 
 // Create a new emitter object.
-func yaml_emitter_initialize(emitter *yamlEmitter) {
+func (emitter *yamlEmitter) initialize() {
 	*emitter = yamlEmitter{
 		buffer:     make([]byte, output_buffer_size),
 		raw_buffer: make([]byte, 0, output_raw_buffer_size),
@@ -113,43 +113,43 @@ func yaml_emitter_initialize(emitter *yamlEmitter) {
 }
 
 // Destroy an emitter object.
-func yaml_emitter_delete(emitter *yamlEmitter) {
+func (emitter *yamlEmitter) delete() {
 	*emitter = yamlEmitter{}
 }
 
 // String write handler.
-func yaml_string_write_handler(emitter *yamlEmitter, buffer []byte) error {
+func yamlStringWriteHandler(emitter *yamlEmitter, buffer []byte) error {
 	*emitter.output_buffer = append(*emitter.output_buffer, buffer...)
 	return nil
 }
 
 // yaml_writer_write_handler uses emitter.output_writer to write the
 // emitted text.
-func yaml_writer_write_handler(emitter *yamlEmitter, buffer []byte) error {
+func yamlWriterWriteHandler(emitter *yamlEmitter, buffer []byte) error {
 	_, err := emitter.output_writer.Write(buffer)
 	return err
 }
 
 // Set a string output.
-func yaml_emitter_set_output_string(emitter *yamlEmitter, output_buffer *[]byte) {
+func (emitter *yamlEmitter) setOutputString(output_buffer *[]byte) {
 	if emitter.write_handler != nil {
 		panic("must set the output target only once")
 	}
-	emitter.write_handler = yaml_string_write_handler
+	emitter.write_handler = yamlStringWriteHandler
 	emitter.output_buffer = output_buffer
 }
 
 // Set a file output.
-func yaml_emitter_set_output_writer(emitter *yamlEmitter, w io.Writer) {
+func (emitter *yamlEmitter) setOutputWriter(w io.Writer) {
 	if emitter.write_handler != nil {
 		panic("must set the output target only once")
 	}
-	emitter.write_handler = yaml_writer_write_handler
+	emitter.write_handler = yamlWriterWriteHandler
 	emitter.output_writer = w
 }
 
 // Set the output encoding.
-func yaml_emitter_set_encoding(emitter *yamlEmitter, encoding yamlEncoding) {
+func (emitter *yamlEmitter) setEncoding(encoding yamlEncoding) {
 	if emitter.encoding != yaml_ANY_ENCODING {
 		panic("must set the output encoding only once")
 	}
@@ -157,12 +157,12 @@ func yaml_emitter_set_encoding(emitter *yamlEmitter, encoding yamlEncoding) {
 }
 
 // Set the canonical output style.
-func yaml_emitter_set_canonical(emitter *yamlEmitter, canonical bool) {
+func (emitter *yamlEmitter) setCanonical(canonical bool) {
 	emitter.canonical = canonical
 }
 
 // Set the indentation increment.
-func yaml_emitter_set_indent(emitter *yamlEmitter, indent int) {
+func (emitter *yamlEmitter) setIndent(indent int) {
 	if indent < 2 || indent > 9 {
 		indent = 2
 	}
@@ -170,7 +170,7 @@ func yaml_emitter_set_indent(emitter *yamlEmitter, indent int) {
 }
 
 // Set the preferred line width.
-func yaml_emitter_set_width(emitter *yamlEmitter, width int) {
+func (emitter *yamlEmitter) setWidth(width int) {
 	if width < 0 {
 		width = -1
 	}
@@ -178,12 +178,12 @@ func yaml_emitter_set_width(emitter *yamlEmitter, width int) {
 }
 
 // Set if unescaped non-ASCII characters are allowed.
-func yaml_emitter_set_unicode(emitter *yamlEmitter, unicode bool) {
+func (emitter *yamlEmitter) setUnicode(unicode bool) {
 	emitter.unicode = unicode
 }
 
 // Set the preferred line break character.
-func yaml_emitter_set_break(emitter *yamlEmitter, line_break yamlBreak) {
+func (emitter *yamlEmitter) setBreak(line_break yamlBreak) {
 	emitter.line_break = line_break
 }
 
@@ -274,7 +274,7 @@ func yaml_emitter_set_break(emitter *yamlEmitter, line_break yamlBreak) {
 //
 
 // Create STREAM-START.
-func yaml_stream_start_event_initialize(event *yamlEvent, encoding yamlEncoding) {
+func yamlStreamStartEventInitialize(event *yamlEvent, encoding yamlEncoding) {
 	*event = yamlEvent{
 		typ:      yaml_STREAM_START_EVENT,
 		encoding: encoding,
@@ -282,19 +282,16 @@ func yaml_stream_start_event_initialize(event *yamlEvent, encoding yamlEncoding)
 }
 
 // Create STREAM-END.
-func yaml_stream_end_event_initialize(event *yamlEvent) {
+func yamlStreamEndEventInitialize(event *yamlEvent) {
 	*event = yamlEvent{
 		typ: yaml_STREAM_END_EVENT,
 	}
 }
 
 // Create DOCUMENT-START.
-func yaml_document_start_event_initialize(
-	event *yamlEvent,
-	version_directive *yamlVersionDirective,
+func yamlDocumentStartEventInitialize(event *yamlEvent, version_directive *yamlVersionDirective,
 	tag_directives []yamlTagDirective,
-	implicit bool,
-) {
+	implicit bool) {
 	*event = yamlEvent{
 		typ:               yaml_DOCUMENT_START_EVENT,
 		version_directive: version_directive,
@@ -304,7 +301,7 @@ func yaml_document_start_event_initialize(
 }
 
 // Create DOCUMENT-END.
-func yaml_document_end_event_initialize(event *yamlEvent, implicit bool) {
+func yamlDocumentEndEventInitialize(event *yamlEvent, implicit bool) {
 	*event = yamlEvent{
 		typ:      yaml_DOCUMENT_END_EVENT,
 		implicit: implicit,
@@ -312,7 +309,7 @@ func yaml_document_end_event_initialize(event *yamlEvent, implicit bool) {
 }
 
 // Create ALIAS.
-func yaml_alias_event_initialize(event *yamlEvent, anchor []byte) bool {
+func yamlAliasEventInitialize(event *yamlEvent, anchor []byte) bool {
 	*event = yamlEvent{
 		typ:    yaml_ALIAS_EVENT,
 		anchor: anchor,
@@ -321,7 +318,7 @@ func yaml_alias_event_initialize(event *yamlEvent, anchor []byte) bool {
 }
 
 // Create SCALAR.
-func yaml_scalar_event_initialize(event *yamlEvent, anchor, tag, value []byte, plain_implicit, quoted_implicit bool, style yamlScalarStyle) bool {
+func yamlScalarEventInitialize(event *yamlEvent, anchor, tag, value []byte, plain_implicit, quoted_implicit bool, style yamlScalarStyle) bool {
 	*event = yamlEvent{
 		typ:             yaml_SCALAR_EVENT,
 		anchor:          anchor,
@@ -335,7 +332,7 @@ func yaml_scalar_event_initialize(event *yamlEvent, anchor, tag, value []byte, p
 }
 
 // Create SEQUENCE-START.
-func yaml_sequence_start_event_initialize(event *yamlEvent, anchor, tag []byte, implicit bool, style yamlSequenceStyle) bool {
+func yamlSequenceStartEventInitialize(event *yamlEvent, anchor, tag []byte, implicit bool, style yamlSequenceStyle) bool {
 	*event = yamlEvent{
 		typ:      yaml_SEQUENCE_START_EVENT,
 		anchor:   anchor,
@@ -347,7 +344,7 @@ func yaml_sequence_start_event_initialize(event *yamlEvent, anchor, tag []byte, 
 }
 
 // Create SEQUENCE-END.
-func yaml_sequence_end_event_initialize(event *yamlEvent) bool {
+func yamlSequenceEndEventInitialize(event *yamlEvent) bool {
 	*event = yamlEvent{
 		typ: yaml_SEQUENCE_END_EVENT,
 	}
@@ -355,7 +352,7 @@ func yaml_sequence_end_event_initialize(event *yamlEvent) bool {
 }
 
 // Create MAPPING-START.
-func yaml_mapping_start_event_initialize(event *yamlEvent, anchor, tag []byte, implicit bool, style yamlMappingStyle) {
+func yamlMappingStartEventInitialize(event *yamlEvent, anchor, tag []byte, implicit bool, style yamlMappingStyle) {
 	*event = yamlEvent{
 		typ:      yaml_MAPPING_START_EVENT,
 		anchor:   anchor,
@@ -366,14 +363,14 @@ func yaml_mapping_start_event_initialize(event *yamlEvent, anchor, tag []byte, i
 }
 
 // Create MAPPING-END.
-func yaml_mapping_end_event_initialize(event *yamlEvent) {
+func yamlMappingEndEventInitialize(event *yamlEvent) {
 	*event = yamlEvent{
 		typ: yaml_MAPPING_END_EVENT,
 	}
 }
 
 // Destroy an event object.
-func yaml_event_delete(event *yamlEvent) {
+func yamlEventDelete(event *yamlEvent) {
 	*event = yamlEvent{}
 }
 

--- a/decode.go
+++ b/decode.go
@@ -39,22 +39,22 @@ type parser struct {
 
 func newParser(b []byte) *parser {
 	p := parser{}
-	if !yaml_parser_initialize(&p.parser) {
+	if !(&p.parser).initialize() {
 		panic("failed to initialize YAML emitter")
 	}
 	if len(b) == 0 {
 		b = []byte{'\n'}
 	}
-	yaml_parser_set_input_string(&p.parser, b)
+	(&p.parser).setInputString(b)
 	return &p
 }
 
 func newParserFromReader(r io.Reader) *parser {
 	p := parser{}
-	if !yaml_parser_initialize(&p.parser) {
+	if !(&p.parser).initialize() {
 		panic("failed to initialize YAML emitter")
 	}
-	yaml_parser_set_input_reader(&p.parser, r)
+	(&p.parser).setInputReader(r)
 	return &p
 }
 
@@ -69,16 +69,16 @@ func (p *parser) init() {
 
 func (p *parser) destroy() {
 	if p.event.typ != yaml_NO_EVENT {
-		yaml_event_delete(&p.event)
+		yamlEventDelete(&p.event)
 	}
-	yaml_parser_delete(&p.parser)
+	(&p.parser).delete()
 }
 
 // expect consumes an event from the event stream and
 // checks that it's of the expected type.
 func (p *parser) expect(e yamlEventType) {
 	if p.event.typ == yaml_NO_EVENT {
-		if !yaml_parser_parse(&p.parser, &p.event) {
+		if !(&p.parser).parse(&p.event) {
 			p.fail()
 		}
 	}
@@ -89,7 +89,7 @@ func (p *parser) expect(e yamlEventType) {
 		p.parser.problem = fmt.Sprintf("expected %s event but got %s", e, p.event.typ)
 		p.fail()
 	}
-	yaml_event_delete(&p.event)
+	yamlEventDelete(&p.event)
 	p.event.typ = yaml_NO_EVENT
 }
 
@@ -102,7 +102,7 @@ func (p *parser) peek() yamlEventType {
 	// It's curious choice from the underlying API to generally return a
 	// positive result on success, but on this case return true in an error
 	// scenario. This was the source of bugs in the past (issue #666).
-	if !yaml_parser_parse(&p.parser, &p.event) || p.parser.error != yaml_NO_ERROR {
+	if !(&p.parser).parse(&p.event) || p.parser.error != yaml_NO_ERROR {
 		p.fail()
 	}
 	return p.event.typ
@@ -217,7 +217,7 @@ func (p *parser) alias() *Node {
 }
 
 func (p *parser) scalar() *Node {
-	var parsedStyle = p.event.scalar_style()
+	var parsedStyle = p.event.scalarStyle()
 	var nodeStyle Style
 	switch {
 	case parsedStyle&yaml_DOUBLE_QUOTED_SCALAR_STYLE != 0:
@@ -248,7 +248,7 @@ func (p *parser) scalar() *Node {
 
 func (p *parser) sequence() *Node {
 	n := p.node(SequenceNode, seqTag, string(p.event.tag), "")
-	if p.event.sequence_style()&yaml_FLOW_SEQUENCE_STYLE != 0 {
+	if p.event.sequenceStyle()&yaml_FLOW_SEQUENCE_STYLE != 0 {
 		n.Style |= FlowStyle
 	}
 	p.anchor(n, p.event.anchor)
@@ -265,7 +265,7 @@ func (p *parser) sequence() *Node {
 func (p *parser) mapping() *Node {
 	n := p.node(MappingNode, mapTag, string(p.event.tag), "")
 	block := true
-	if p.event.mapping_style()&yaml_FLOW_MAPPING_STYLE != 0 {
+	if p.event.mappingStyle()&yaml_FLOW_MAPPING_STYLE != 0 {
 		block = false
 		n.Style |= FlowStyle
 	}

--- a/parserc.go
+++ b/parserc.go
@@ -65,10 +65,10 @@ import (
 // flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 
 // Peek the next token in the token queue.
-func peek_token(parser *yamlParser) *yamlToken {
-	if parser.token_available || yaml_parser_fetch_more_tokens(parser) {
+func (parser *yamlParser) peekToken() *yamlToken {
+	if parser.token_available || parser.fetchMoreTokens() {
 		token := &parser.tokens[parser.tokens_head]
-		yaml_parser_unfold_comments(parser, token)
+		parser.unfoldComments(token)
 		return token
 	}
 	return nil
@@ -77,7 +77,7 @@ func peek_token(parser *yamlParser) *yamlToken {
 // yaml_parser_unfold_comments walks through the comments queue and joins all
 // comments behind the position of the provided token into the respective
 // top-level comment slices in the parser.
-func yaml_parser_unfold_comments(parser *yamlParser, token *yamlToken) {
+func (parser *yamlParser) unfoldComments(token *yamlToken) {
 	for parser.comments_head < len(parser.comments) && token.start_mark.index >= parser.comments[parser.comments_head].token_mark.index {
 		comment := &parser.comments[parser.comments_head]
 		if len(comment.head) > 0 {
@@ -108,7 +108,7 @@ func yaml_parser_unfold_comments(parser *yamlParser, token *yamlToken) {
 }
 
 // Remove the next token from the queue (must be called after peek_token).
-func skip_token(parser *yamlParser) {
+func (parser *yamlParser) skipToken() {
 	parser.token_available = false
 	parser.tokens_parsed++
 	parser.stream_end_produced = parser.tokens[parser.tokens_head].typ == yaml_STREAM_END_TOKEN
@@ -116,7 +116,7 @@ func skip_token(parser *yamlParser) {
 }
 
 // Get the next event.
-func yaml_parser_parse(parser *yamlParser, event *yamlEvent) bool {
+func (parser *yamlParser) parse(event *yamlEvent) bool {
 	// Erase the event object.
 	*event = yamlEvent{}
 
@@ -126,18 +126,18 @@ func yaml_parser_parse(parser *yamlParser, event *yamlEvent) bool {
 	}
 
 	// Generate the next event.
-	return yaml_parser_state_machine(parser, event)
+	return parser.stateMachine(event)
 }
 
 // Set parser error.
-func yaml_parser_set_parser_error(parser *yamlParser, problem string, problem_mark yamlMark) bool {
+func (parser *yamlParser) setParserError(problem string, problem_mark yamlMark) bool {
 	parser.error = yaml_PARSER_ERROR
 	parser.problem = problem
 	parser.problem_mark = problem_mark
 	return false
 }
 
-func yaml_parser_set_parser_error_context(parser *yamlParser, context string, context_mark yamlMark, problem string, problem_mark yamlMark) bool {
+func (parser *yamlParser) setParserErrorContext(context string, context_mark yamlMark, problem string, problem_mark yamlMark) bool {
 	parser.error = yaml_PARSER_ERROR
 	parser.context = context
 	parser.context_mark = context_mark
@@ -147,78 +147,78 @@ func yaml_parser_set_parser_error_context(parser *yamlParser, context string, co
 }
 
 // State dispatcher.
-func yaml_parser_state_machine(parser *yamlParser, event *yamlEvent) bool {
+func (parser *yamlParser) stateMachine(event *yamlEvent) bool {
 	//trace("yaml_parser_state_machine", "state:", parser.state.String())
 
 	switch parser.state {
 	case yaml_PARSE_STREAM_START_STATE:
-		return yaml_parser_parse_stream_start(parser, event)
+		return parser.parseStreamStart(event)
 
 	case yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE:
-		return yaml_parser_parse_document_start(parser, event, true)
+		return parser.parseDocumentStart(event, true)
 
 	case yaml_PARSE_DOCUMENT_START_STATE:
-		return yaml_parser_parse_document_start(parser, event, false)
+		return parser.parseDocumentStart(event, false)
 
 	case yaml_PARSE_DOCUMENT_CONTENT_STATE:
-		return yaml_parser_parse_document_content(parser, event)
+		return parser.parseDocumentContent(event)
 
 	case yaml_PARSE_DOCUMENT_END_STATE:
-		return yaml_parser_parse_document_end(parser, event)
+		return parser.parseDocumentEnd(event)
 
 	case yaml_PARSE_BLOCK_NODE_STATE:
-		return yaml_parser_parse_node(parser, event, true, false)
+		return parser.parseNode(event, true, false)
 
 	case yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE:
-		return yaml_parser_parse_node(parser, event, true, true)
+		return parser.parseNode(event, true, true)
 
 	case yaml_PARSE_FLOW_NODE_STATE:
-		return yaml_parser_parse_node(parser, event, false, false)
+		return parser.parseNode(event, false, false)
 
 	case yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE:
-		return yaml_parser_parse_block_sequence_entry(parser, event, true)
+		return parser.parseBlockSequenceEntry(event, true)
 
 	case yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE:
-		return yaml_parser_parse_block_sequence_entry(parser, event, false)
+		return parser.parseBlockSequenceEntry(event, false)
 
 	case yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE:
-		return yaml_parser_parse_indentless_sequence_entry(parser, event)
+		return parser.parseIndentlessSequenceEntry(event)
 
 	case yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE:
-		return yaml_parser_parse_block_mapping_key(parser, event, true)
+		return parser.parseBlockMappingKey(event, true)
 
 	case yaml_PARSE_BLOCK_MAPPING_KEY_STATE:
-		return yaml_parser_parse_block_mapping_key(parser, event, false)
+		return parser.parseBlockMappingKey(event, false)
 
 	case yaml_PARSE_BLOCK_MAPPING_VALUE_STATE:
-		return yaml_parser_parse_block_mapping_value(parser, event)
+		return parser.parseBlockMappingValue(event)
 
 	case yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE:
-		return yaml_parser_parse_flow_sequence_entry(parser, event, true)
+		return parser.parseFlowSequenceEntry(event, true)
 
 	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE:
-		return yaml_parser_parse_flow_sequence_entry(parser, event, false)
+		return parser.parseFlowSequenceEntry(event, false)
 
 	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE:
-		return yaml_parser_parse_flow_sequence_entry_mapping_key(parser, event)
+		return parser.parseFlowSequenceEntryMappingKey(event)
 
 	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE:
-		return yaml_parser_parse_flow_sequence_entry_mapping_value(parser, event)
+		return parser.parseFlowSequenceEntryMappingValue(event)
 
 	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE:
-		return yaml_parser_parse_flow_sequence_entry_mapping_end(parser, event)
+		return parser.parseFlowSequenceEntryMappingEnd(event)
 
 	case yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE:
-		return yaml_parser_parse_flow_mapping_key(parser, event, true)
+		return parser.parseFlowMappingKey(event, true)
 
 	case yaml_PARSE_FLOW_MAPPING_KEY_STATE:
-		return yaml_parser_parse_flow_mapping_key(parser, event, false)
+		return parser.parseFlowMappingKey(event, false)
 
 	case yaml_PARSE_FLOW_MAPPING_VALUE_STATE:
-		return yaml_parser_parse_flow_mapping_value(parser, event, false)
+		return parser.parseFlowMappingValue(event, false)
 
 	case yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE:
-		return yaml_parser_parse_flow_mapping_value(parser, event, true)
+		return parser.parseFlowMappingValue(event, true)
 
 	default:
 		panic("invalid parser state")
@@ -229,13 +229,13 @@ func yaml_parser_state_machine(parser *yamlParser, event *yamlEvent) bool {
 // stream   ::= STREAM-START implicit_document? explicit_document* STREAM-END
 //
 //	************
-func yaml_parser_parse_stream_start(parser *yamlParser, event *yamlEvent) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseStreamStart(event *yamlEvent) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
 	if token.typ != yaml_STREAM_START_TOKEN {
-		return yaml_parser_set_parser_error(parser, "did not find expected <stream-start>", token.start_mark)
+		return parser.setParserError("did not find expected <stream-start>", token.start_mark)
 	}
 	parser.state = yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE
 	*event = yamlEvent{
@@ -244,7 +244,7 @@ func yaml_parser_parse_stream_start(parser *yamlParser, event *yamlEvent) bool {
 		end_mark:   token.end_mark,
 		encoding:   token.encoding,
 	}
-	skip_token(parser)
+	parser.skipToken()
 	return true
 }
 
@@ -256,9 +256,9 @@ func yaml_parser_parse_stream_start(parser *yamlParser, event *yamlEvent) bool {
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 //
 //	*************************
-func yaml_parser_parse_document_start(parser *yamlParser, event *yamlEvent, implicit bool) bool {
+func (parser *yamlParser) parseDocumentStart(event *yamlEvent, implicit bool) bool {
 
-	token := peek_token(parser)
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -266,8 +266,8 @@ func yaml_parser_parse_document_start(parser *yamlParser, event *yamlEvent, impl
 	// Parse extra document end indicators.
 	if !implicit {
 		for token.typ == yaml_DOCUMENT_END_TOKEN {
-			skip_token(parser)
-			token = peek_token(parser)
+			parser.skipToken()
+			token = parser.peekToken()
 			if token == nil {
 				return false
 			}
@@ -279,7 +279,7 @@ func yaml_parser_parse_document_start(parser *yamlParser, event *yamlEvent, impl
 		token.typ != yaml_DOCUMENT_START_TOKEN &&
 		token.typ != yaml_STREAM_END_TOKEN {
 		// Parse an implicit document.
-		if !yaml_parser_process_directives(parser, nil, nil) {
+		if !parser.processDirectives(nil, nil) {
 			return false
 		}
 		parser.states = append(parser.states, yaml_PARSE_DOCUMENT_END_STATE)
@@ -318,15 +318,15 @@ func yaml_parser_parse_document_start(parser *yamlParser, event *yamlEvent, impl
 		var version_directive *yamlVersionDirective
 		var tag_directives []yamlTagDirective
 		start_mark := token.start_mark
-		if !yaml_parser_process_directives(parser, &version_directive, &tag_directives) {
+		if !parser.processDirectives(&version_directive, &tag_directives) {
 			return false
 		}
-		token = peek_token(parser)
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
 		if token.typ != yaml_DOCUMENT_START_TOKEN {
-			yaml_parser_set_parser_error(parser,
+			parser.setParserError(
 				"did not find expected <document start>", token.start_mark)
 			return false
 		}
@@ -342,7 +342,7 @@ func yaml_parser_parse_document_start(parser *yamlParser, event *yamlEvent, impl
 			tag_directives:    tag_directives,
 			implicit:          false,
 		}
-		skip_token(parser)
+		parser.skipToken()
 
 	} else {
 		// Parse the stream end.
@@ -352,7 +352,7 @@ func yaml_parser_parse_document_start(parser *yamlParser, event *yamlEvent, impl
 			start_mark: token.start_mark,
 			end_mark:   token.end_mark,
 		}
-		skip_token(parser)
+		parser.skipToken()
 	}
 
 	return true
@@ -362,8 +362,8 @@ func yaml_parser_parse_document_start(parser *yamlParser, event *yamlEvent, impl
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 //
 //	***********
-func yaml_parser_parse_document_content(parser *yamlParser, event *yamlEvent) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseDocumentContent(event *yamlEvent) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -375,10 +375,10 @@ func yaml_parser_parse_document_content(parser *yamlParser, event *yamlEvent) bo
 		token.typ == yaml_STREAM_END_TOKEN {
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
-		return yaml_parser_process_empty_scalar(parser, event,
+		return parser.processEmptyScalar(event,
 			token.start_mark)
 	}
-	return yaml_parser_parse_node(parser, event, true, false)
+	return parser.parseNode(event, true, false)
 }
 
 // Parse the productions:
@@ -387,8 +387,8 @@ func yaml_parser_parse_document_content(parser *yamlParser, event *yamlEvent) bo
 //	*************
 //
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
-func yaml_parser_parse_document_end(parser *yamlParser, event *yamlEvent) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseDocumentEnd(event *yamlEvent) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -399,7 +399,7 @@ func yaml_parser_parse_document_end(parser *yamlParser, event *yamlEvent) bool {
 	implicit := true
 	if token.typ == yaml_DOCUMENT_END_TOKEN {
 		end_mark = token.end_mark
-		skip_token(parser)
+		parser.skipToken()
 		implicit = false
 	}
 
@@ -412,7 +412,7 @@ func yaml_parser_parse_document_end(parser *yamlParser, event *yamlEvent) bool {
 		end_mark:   end_mark,
 		implicit:   implicit,
 	}
-	yaml_parser_set_event_comments(parser, event)
+	parser.setEventComments(event)
 	if len(event.head_comment) > 0 && len(event.foot_comment) == 0 {
 		event.foot_comment = event.head_comment
 		event.head_comment = nil
@@ -420,7 +420,7 @@ func yaml_parser_parse_document_end(parser *yamlParser, event *yamlEvent) bool {
 	return true
 }
 
-func yaml_parser_set_event_comments(parser *yamlParser, event *yamlEvent) {
+func (parser *yamlParser) setEventComments(event *yamlEvent) {
 	event.head_comment = parser.head_comment
 	event.line_comment = parser.line_comment
 	event.foot_comment = parser.foot_comment
@@ -468,10 +468,10 @@ func yaml_parser_set_event_comments(parser *yamlParser, event *yamlEvent) {
 // flow_content         ::= flow_collection | SCALAR
 //
 //	******
-func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentless_sequence bool) bool {
+func (parser *yamlParser) parseNode(event *yamlEvent, block, indentless_sequence bool) bool {
 	//defer trace("yaml_parser_parse_node", "block:", block, "indentless_sequence:", indentless_sequence)()
 
-	token := peek_token(parser)
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -485,8 +485,8 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 			end_mark:   token.end_mark,
 			anchor:     token.value,
 		}
-		yaml_parser_set_event_comments(parser, event)
-		skip_token(parser)
+		parser.setEventComments(event)
+		parser.skipToken()
 		return true
 	}
 
@@ -500,8 +500,8 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 		anchor = token.value
 		start_mark = token.start_mark
 		end_mark = token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+		parser.skipToken()
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
@@ -511,8 +511,8 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 			tag_suffix = token.suffix
 			tag_mark = token.start_mark
 			end_mark = token.end_mark
-			skip_token(parser)
-			token = peek_token(parser)
+			parser.skipToken()
+			token = parser.peekToken()
 			if token == nil {
 				return false
 			}
@@ -524,16 +524,16 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 		start_mark = token.start_mark
 		tag_mark = token.start_mark
 		end_mark = token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+		parser.skipToken()
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
 		if token.typ == yaml_ANCHOR_TOKEN {
 			anchor = token.value
 			end_mark = token.end_mark
-			skip_token(parser)
-			token = peek_token(parser)
+			parser.skipToken()
+			token = parser.peekToken()
 			if token == nil {
 				return false
 			}
@@ -554,7 +554,7 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 				}
 			}
 			if len(tag) == 0 {
-				yaml_parser_set_parser_error_context(parser,
+				parser.setParserErrorContext(
 					"while parsing a node", start_mark,
 					"found undefined tag handle", tag_mark)
 				return false
@@ -599,8 +599,8 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 			quoted_implicit: quoted_implicit,
 			style:           yamlStyle(token.style),
 		}
-		yaml_parser_set_event_comments(parser, event)
-		skip_token(parser)
+		parser.setEventComments(event)
+		parser.skipToken()
 		return true
 	}
 	if token.typ == yaml_FLOW_SEQUENCE_START_TOKEN {
@@ -616,7 +616,7 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 			implicit:   implicit,
 			style:      yamlStyle(yaml_FLOW_SEQUENCE_STYLE),
 		}
-		yaml_parser_set_event_comments(parser, event)
+		parser.setEventComments(event)
 		return true
 	}
 	if token.typ == yaml_FLOW_MAPPING_START_TOKEN {
@@ -631,7 +631,7 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 			implicit:   implicit,
 			style:      yamlStyle(yaml_FLOW_MAPPING_STYLE),
 		}
-		yaml_parser_set_event_comments(parser, event)
+		parser.setEventComments(event)
 		return true
 	}
 	if block && token.typ == yaml_BLOCK_SEQUENCE_START_TOKEN {
@@ -691,7 +691,7 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 	if block {
 		context = "while parsing a block node"
 	}
-	yaml_parser_set_parser_error_context(parser, context, start_mark,
+	parser.setParserErrorContext(context, start_mark,
 		"did not find expected node content", token.start_mark)
 	return false
 }
@@ -700,17 +700,17 @@ func yaml_parser_parse_node(parser *yamlParser, event *yamlEvent, block, indentl
 // block_sequence ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
 //
 //	********************  *********** *             *********
-func yaml_parser_parse_block_sequence_entry(parser *yamlParser, event *yamlEvent, first bool) bool {
+func (parser *yamlParser) parseBlockSequenceEntry(event *yamlEvent, first bool) bool {
 	if first {
-		token := peek_token(parser)
+		token := parser.peekToken()
 		if token == nil {
 			return false
 		}
 		parser.marks = append(parser.marks, token.start_mark)
-		skip_token(parser)
+		parser.skipToken()
 	}
 
-	token := peek_token(parser)
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -718,18 +718,18 @@ func yaml_parser_parse_block_sequence_entry(parser *yamlParser, event *yamlEvent
 	if token.typ == yaml_BLOCK_ENTRY_TOKEN {
 		mark := token.end_mark
 		prior_head_len := len(parser.head_comment)
-		skip_token(parser)
-		yaml_parser_split_stem_comment(parser, prior_head_len)
-		token = peek_token(parser)
+		parser.skipToken()
+		parser.splitStemComment(prior_head_len)
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
 		if token.typ != yaml_BLOCK_ENTRY_TOKEN && token.typ != yaml_BLOCK_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE)
-			return yaml_parser_parse_node(parser, event, true, false)
+			return parser.parseNode(event, true, false)
 		} else {
 			parser.state = yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE
-			return yaml_parser_process_empty_scalar(parser, event, mark)
+			return parser.processEmptyScalar(event, mark)
 		}
 	}
 	if token.typ == yaml_BLOCK_END_TOKEN {
@@ -743,13 +743,13 @@ func yaml_parser_parse_block_sequence_entry(parser *yamlParser, event *yamlEvent
 			end_mark:   token.end_mark,
 		}
 
-		skip_token(parser)
+		parser.skipToken()
 		return true
 	}
 
 	context_mark := parser.marks[len(parser.marks)-1]
 	parser.marks = parser.marks[:len(parser.marks)-1]
-	return yaml_parser_set_parser_error_context(parser,
+	return parser.setParserErrorContext(
 		"while parsing a block collection", context_mark,
 		"did not find expected '-' indicator", token.start_mark)
 }
@@ -758,8 +758,8 @@ func yaml_parser_parse_block_sequence_entry(parser *yamlParser, event *yamlEvent
 // indentless_sequence  ::= (BLOCK-ENTRY block_node?)+
 //
 //	*********** *
-func yaml_parser_parse_indentless_sequence_entry(parser *yamlParser, event *yamlEvent) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseIndentlessSequenceEntry(event *yamlEvent) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -767,9 +767,9 @@ func yaml_parser_parse_indentless_sequence_entry(parser *yamlParser, event *yaml
 	if token.typ == yaml_BLOCK_ENTRY_TOKEN {
 		mark := token.end_mark
 		prior_head_len := len(parser.head_comment)
-		skip_token(parser)
-		yaml_parser_split_stem_comment(parser, prior_head_len)
-		token = peek_token(parser)
+		parser.skipToken()
+		parser.splitStemComment(prior_head_len)
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
@@ -778,10 +778,10 @@ func yaml_parser_parse_indentless_sequence_entry(parser *yamlParser, event *yaml
 			token.typ != yaml_VALUE_TOKEN &&
 			token.typ != yaml_BLOCK_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE)
-			return yaml_parser_parse_node(parser, event, true, false)
+			return parser.parseNode(event, true, false)
 		}
 		parser.state = yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE
-		return yaml_parser_process_empty_scalar(parser, event, mark)
+		return parser.processEmptyScalar(event, mark)
 	}
 	parser.state = parser.states[len(parser.states)-1]
 	parser.states = parser.states[:len(parser.states)-1]
@@ -800,12 +800,12 @@ func yaml_parser_parse_indentless_sequence_entry(parser *yamlParser, event *yaml
 // is assigned to the underlying sequence or map as a whole, not the individual
 // sequence or map entry as would be expected otherwise. To handle this case the
 // previous head comment is moved aside as the stem comment.
-func yaml_parser_split_stem_comment(parser *yamlParser, stem_len int) {
+func (parser *yamlParser) splitStemComment(stem_len int) {
 	if stem_len == 0 {
 		return
 	}
 
-	token := peek_token(parser)
+	token := parser.peekToken()
 	if token == nil || token.typ != yaml_BLOCK_SEQUENCE_START_TOKEN && token.typ != yaml_BLOCK_MAPPING_START_TOKEN {
 		return
 	}
@@ -830,17 +830,17 @@ func yaml_parser_split_stem_comment(parser *yamlParser, stem_len int) {
 //
 //	BLOCK-END
 //	*********
-func yaml_parser_parse_block_mapping_key(parser *yamlParser, event *yamlEvent, first bool) bool {
+func (parser *yamlParser) parseBlockMappingKey(event *yamlEvent, first bool) bool {
 	if first {
-		token := peek_token(parser)
+		token := parser.peekToken()
 		if token == nil {
 			return false
 		}
 		parser.marks = append(parser.marks, token.start_mark)
-		skip_token(parser)
+		parser.skipToken()
 	}
 
-	token := peek_token(parser)
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -860,8 +860,8 @@ func yaml_parser_parse_block_mapping_key(parser *yamlParser, event *yamlEvent, f
 
 	if token.typ == yaml_KEY_TOKEN {
 		mark := token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+		parser.skipToken()
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
@@ -869,10 +869,10 @@ func yaml_parser_parse_block_mapping_key(parser *yamlParser, event *yamlEvent, f
 			token.typ != yaml_VALUE_TOKEN &&
 			token.typ != yaml_BLOCK_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_BLOCK_MAPPING_VALUE_STATE)
-			return yaml_parser_parse_node(parser, event, true, true)
+			return parser.parseNode(event, true, true)
 		} else {
 			parser.state = yaml_PARSE_BLOCK_MAPPING_VALUE_STATE
-			return yaml_parser_process_empty_scalar(parser, event, mark)
+			return parser.processEmptyScalar(event, mark)
 		}
 	} else if token.typ == yaml_BLOCK_END_TOKEN {
 		parser.state = parser.states[len(parser.states)-1]
@@ -883,14 +883,14 @@ func yaml_parser_parse_block_mapping_key(parser *yamlParser, event *yamlEvent, f
 			start_mark: token.start_mark,
 			end_mark:   token.end_mark,
 		}
-		yaml_parser_set_event_comments(parser, event)
-		skip_token(parser)
+		parser.setEventComments(event)
+		parser.skipToken()
 		return true
 	}
 
 	context_mark := parser.marks[len(parser.marks)-1]
 	parser.marks = parser.marks[:len(parser.marks)-1]
-	return yaml_parser_set_parser_error_context(parser,
+	return parser.setParserErrorContext(
 		"while parsing a block mapping", context_mark,
 		"did not find expected key", token.start_mark)
 }
@@ -903,15 +903,15 @@ func yaml_parser_parse_block_mapping_key(parser *yamlParser, event *yamlEvent, f
 //	(VALUE block_node_or_indentless_sequence?)?)*
 //	 ***** *
 //	BLOCK-END
-func yaml_parser_parse_block_mapping_value(parser *yamlParser, event *yamlEvent) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseBlockMappingValue(event *yamlEvent) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
 	if token.typ == yaml_VALUE_TOKEN {
 		mark := token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+		parser.skipToken()
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
@@ -919,13 +919,13 @@ func yaml_parser_parse_block_mapping_value(parser *yamlParser, event *yamlEvent)
 			token.typ != yaml_VALUE_TOKEN &&
 			token.typ != yaml_BLOCK_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_BLOCK_MAPPING_KEY_STATE)
-			return yaml_parser_parse_node(parser, event, true, true)
+			return parser.parseNode(event, true, true)
 		}
 		parser.state = yaml_PARSE_BLOCK_MAPPING_KEY_STATE
-		return yaml_parser_process_empty_scalar(parser, event, mark)
+		return parser.processEmptyScalar(event, mark)
 	}
 	parser.state = yaml_PARSE_BLOCK_MAPPING_KEY_STATE
-	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+	return parser.processEmptyScalar(event, token.start_mark)
 }
 
 // Parse the productions:
@@ -942,31 +942,31 @@ func yaml_parser_parse_block_mapping_value(parser *yamlParser, event *yamlEvent)
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //
 //	*
-func yaml_parser_parse_flow_sequence_entry(parser *yamlParser, event *yamlEvent, first bool) bool {
+func (parser *yamlParser) parseFlowSequenceEntry(event *yamlEvent, first bool) bool {
 	if first {
-		token := peek_token(parser)
+		token := parser.peekToken()
 		if token == nil {
 			return false
 		}
 		parser.marks = append(parser.marks, token.start_mark)
-		skip_token(parser)
+		parser.skipToken()
 	}
-	token := peek_token(parser)
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
 	if token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
 		if !first {
 			if token.typ == yaml_FLOW_ENTRY_TOKEN {
-				skip_token(parser)
-				token = peek_token(parser)
+				parser.skipToken()
+				token = parser.peekToken()
 				if token == nil {
 					return false
 				}
 			} else {
 				context_mark := parser.marks[len(parser.marks)-1]
 				parser.marks = parser.marks[:len(parser.marks)-1]
-				return yaml_parser_set_parser_error_context(parser,
+				return parser.setParserErrorContext(
 					"while parsing a flow sequence", context_mark,
 					"did not find expected ',' or ']'", token.start_mark)
 			}
@@ -981,11 +981,11 @@ func yaml_parser_parse_flow_sequence_entry(parser *yamlParser, event *yamlEvent,
 				implicit:   true,
 				style:      yamlStyle(yaml_FLOW_MAPPING_STYLE),
 			}
-			skip_token(parser)
+			parser.skipToken()
 			return true
 		} else if token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE)
-			return yaml_parser_parse_node(parser, event, false, false)
+			return parser.parseNode(event, false, false)
 		}
 	}
 
@@ -998,9 +998,9 @@ func yaml_parser_parse_flow_sequence_entry(parser *yamlParser, event *yamlEvent,
 		start_mark: token.start_mark,
 		end_mark:   token.end_mark,
 	}
-	yaml_parser_set_event_comments(parser, event)
+	parser.setEventComments(event)
 
-	skip_token(parser)
+	parser.skipToken()
 	return true
 }
 
@@ -1008,8 +1008,8 @@ func yaml_parser_parse_flow_sequence_entry(parser *yamlParser, event *yamlEvent,
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //
 //	*** *
-func yaml_parser_parse_flow_sequence_entry_mapping_key(parser *yamlParser, event *yamlEvent) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseFlowSequenceEntryMappingKey(event *yamlEvent) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -1017,44 +1017,44 @@ func yaml_parser_parse_flow_sequence_entry_mapping_key(parser *yamlParser, event
 		token.typ != yaml_FLOW_ENTRY_TOKEN &&
 		token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
 		parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE)
-		return yaml_parser_parse_node(parser, event, false, false)
+		return parser.parseNode(event, false, false)
 	}
 	mark := token.end_mark
-	skip_token(parser)
+	parser.skipToken()
 	parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE
-	return yaml_parser_process_empty_scalar(parser, event, mark)
+	return parser.processEmptyScalar(event, mark)
 }
 
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //
 //	***** *
-func yaml_parser_parse_flow_sequence_entry_mapping_value(parser *yamlParser, event *yamlEvent) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseFlowSequenceEntryMappingValue(event *yamlEvent) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
 	if token.typ == yaml_VALUE_TOKEN {
-		skip_token(parser)
-		token := peek_token(parser)
+		parser.skipToken()
+		token := parser.peekToken()
 		if token == nil {
 			return false
 		}
 		if token.typ != yaml_FLOW_ENTRY_TOKEN && token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE)
-			return yaml_parser_parse_node(parser, event, false, false)
+			return parser.parseNode(event, false, false)
 		}
 	}
 	parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE
-	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+	return parser.processEmptyScalar(event, token.start_mark)
 }
 
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //
 //	*
-func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yamlParser, event *yamlEvent) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseFlowSequenceEntryMappingEnd(event *yamlEvent) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -1080,14 +1080,14 @@ func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yamlParser, event
 //
 // flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //   - *** *
-func yaml_parser_parse_flow_mapping_key(parser *yamlParser, event *yamlEvent, first bool) bool {
+func (parser *yamlParser) parseFlowMappingKey(event *yamlEvent, first bool) bool {
 	if first {
-		token := peek_token(parser)
+		token := parser.peekToken()
 		parser.marks = append(parser.marks, token.start_mark)
-		skip_token(parser)
+		parser.skipToken()
 	}
 
-	token := peek_token(parser)
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -1095,23 +1095,23 @@ func yaml_parser_parse_flow_mapping_key(parser *yamlParser, event *yamlEvent, fi
 	if token.typ != yaml_FLOW_MAPPING_END_TOKEN {
 		if !first {
 			if token.typ == yaml_FLOW_ENTRY_TOKEN {
-				skip_token(parser)
-				token = peek_token(parser)
+				parser.skipToken()
+				token = parser.peekToken()
 				if token == nil {
 					return false
 				}
 			} else {
 				context_mark := parser.marks[len(parser.marks)-1]
 				parser.marks = parser.marks[:len(parser.marks)-1]
-				return yaml_parser_set_parser_error_context(parser,
+				return parser.setParserErrorContext(
 					"while parsing a flow mapping", context_mark,
 					"did not find expected ',' or '}'", token.start_mark)
 			}
 		}
 
 		if token.typ == yaml_KEY_TOKEN {
-			skip_token(parser)
-			token = peek_token(parser)
+			parser.skipToken()
+			token = parser.peekToken()
 			if token == nil {
 				return false
 			}
@@ -1119,14 +1119,14 @@ func yaml_parser_parse_flow_mapping_key(parser *yamlParser, event *yamlEvent, fi
 				token.typ != yaml_FLOW_ENTRY_TOKEN &&
 				token.typ != yaml_FLOW_MAPPING_END_TOKEN {
 				parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_VALUE_STATE)
-				return yaml_parser_parse_node(parser, event, false, false)
+				return parser.parseNode(event, false, false)
 			} else {
 				parser.state = yaml_PARSE_FLOW_MAPPING_VALUE_STATE
-				return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+				return parser.processEmptyScalar(event, token.start_mark)
 			}
 		} else if token.typ != yaml_FLOW_MAPPING_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE)
-			return yaml_parser_parse_node(parser, event, false, false)
+			return parser.parseNode(event, false, false)
 		}
 	}
 
@@ -1138,40 +1138,40 @@ func yaml_parser_parse_flow_mapping_key(parser *yamlParser, event *yamlEvent, fi
 		start_mark: token.start_mark,
 		end_mark:   token.end_mark,
 	}
-	yaml_parser_set_event_comments(parser, event)
-	skip_token(parser)
+	parser.setEventComments(event)
+	parser.skipToken()
 	return true
 }
 
 // Parse the productions:
 // flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //   - ***** *
-func yaml_parser_parse_flow_mapping_value(parser *yamlParser, event *yamlEvent, empty bool) bool {
-	token := peek_token(parser)
+func (parser *yamlParser) parseFlowMappingValue(event *yamlEvent, empty bool) bool {
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
 	if empty {
 		parser.state = yaml_PARSE_FLOW_MAPPING_KEY_STATE
-		return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+		return parser.processEmptyScalar(event, token.start_mark)
 	}
 	if token.typ == yaml_VALUE_TOKEN {
-		skip_token(parser)
-		token = peek_token(parser)
+		parser.skipToken()
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
 		if token.typ != yaml_FLOW_ENTRY_TOKEN && token.typ != yaml_FLOW_MAPPING_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_KEY_STATE)
-			return yaml_parser_parse_node(parser, event, false, false)
+			return parser.parseNode(event, false, false)
 		}
 	}
 	parser.state = yaml_PARSE_FLOW_MAPPING_KEY_STATE
-	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+	return parser.processEmptyScalar(event, token.start_mark)
 }
 
 // Generate an empty scalar event.
-func yaml_parser_process_empty_scalar(parser *yamlParser, event *yamlEvent, mark yamlMark) bool {
+func (parser *yamlParser) processEmptyScalar(event *yamlEvent, mark yamlMark) bool {
 	*event = yamlEvent{
 		typ:        yaml_SCALAR_EVENT,
 		start_mark: mark,
@@ -1189,14 +1189,11 @@ var default_tag_directives = []yamlTagDirective{
 }
 
 // Parse directives.
-func yaml_parser_process_directives(parser *yamlParser,
-	version_directive_ref **yamlVersionDirective,
-	tag_directives_ref *[]yamlTagDirective) bool {
-
+func (parser *yamlParser) processDirectives(version_directive_ref **yamlVersionDirective, tag_directives_ref *[]yamlTagDirective) bool {
 	var version_directive *yamlVersionDirective
 	var tag_directives []yamlTagDirective
 
-	token := peek_token(parser)
+	token := parser.peekToken()
 	if token == nil {
 		return false
 	}
@@ -1204,12 +1201,12 @@ func yaml_parser_process_directives(parser *yamlParser,
 	for token.typ == yaml_VERSION_DIRECTIVE_TOKEN || token.typ == yaml_TAG_DIRECTIVE_TOKEN {
 		if token.typ == yaml_VERSION_DIRECTIVE_TOKEN {
 			if version_directive != nil {
-				yaml_parser_set_parser_error(parser,
+				parser.setParserError(
 					"found duplicate %YAML directive", token.start_mark)
 				return false
 			}
 			if token.major != 1 || token.minor != 1 {
-				yaml_parser_set_parser_error(parser,
+				parser.setParserError(
 					"found incompatible YAML document", token.start_mark)
 				return false
 			}
@@ -1222,21 +1219,21 @@ func yaml_parser_process_directives(parser *yamlParser,
 				handle: token.value,
 				prefix: token.prefix,
 			}
-			if !yaml_parser_append_tag_directive(parser, value, false, token.start_mark) {
+			if !parser.appendTagDirective(value, false, token.start_mark) {
 				return false
 			}
 			tag_directives = append(tag_directives, value)
 		}
 
-		skip_token(parser)
-		token = peek_token(parser)
+		parser.skipToken()
+		token = parser.peekToken()
 		if token == nil {
 			return false
 		}
 	}
 
 	for i := range default_tag_directives {
-		if !yaml_parser_append_tag_directive(parser, default_tag_directives[i], true, token.start_mark) {
+		if !parser.appendTagDirective(default_tag_directives[i], true, token.start_mark) {
 			return false
 		}
 	}
@@ -1251,13 +1248,13 @@ func yaml_parser_process_directives(parser *yamlParser,
 }
 
 // Append a tag directive to the directives stack.
-func yaml_parser_append_tag_directive(parser *yamlParser, value yamlTagDirective, allow_duplicates bool, mark yamlMark) bool {
+func (parser *yamlParser) appendTagDirective(value yamlTagDirective, allow_duplicates bool, mark yamlMark) bool {
 	for i := range parser.tag_directives {
 		if bytes.Equal(value.handle, parser.tag_directives[i].handle) {
 			if allow_duplicates {
 				return true
 			}
-			return yaml_parser_set_parser_error(parser, "found duplicate %TAG directive", mark)
+			return parser.setParserError("found duplicate %TAG directive", mark)
 		}
 	}
 

--- a/scannerc.go
+++ b/scannerc.go
@@ -504,14 +504,14 @@ import (
 
 // Ensure that the buffer contains the required number of characters.
 // Return true on success, false on failure (reader error or memory error).
-func cache(parser *yamlParser, length int) bool {
-	// [Go] This was inlined: !cache(A, B) -> unread < B && !update(A, B)
-	return parser.unread >= length || yaml_parser_update_buffer(parser, length)
+func (parser *yamlParser) cache(length int) bool {
+	// [Go] This was inlined: !A.cache(B) -> unread < B && !A.update(B)
+	return parser.unread >= length || parser.updateBuffer(length)
 }
 
 // Advance the buffer pointer.
-func skip(parser *yamlParser) {
-	if !is_blank(parser.buffer, parser.buffer_pos) {
+func (parser *yamlParser) skip() {
+	if !isBlank(parser.buffer, parser.buffer_pos) {
 		parser.newlines = 0
 	}
 	parser.mark.index++
@@ -520,15 +520,15 @@ func skip(parser *yamlParser) {
 	parser.buffer_pos += width(parser.buffer[parser.buffer_pos])
 }
 
-func skip_line(parser *yamlParser) {
-	if is_crlf(parser.buffer, parser.buffer_pos) {
+func (parser *yamlParser) skipLine() {
+	if isCRLF(parser.buffer, parser.buffer_pos) {
 		parser.mark.index += 2
 		parser.mark.column = 0
 		parser.mark.line++
 		parser.unread -= 2
 		parser.buffer_pos += 2
 		parser.newlines++
-	} else if is_break(parser.buffer, parser.buffer_pos) {
+	} else if isBreak(parser.buffer, parser.buffer_pos) {
 		parser.mark.index++
 		parser.mark.column = 0
 		parser.mark.line++
@@ -539,8 +539,8 @@ func skip_line(parser *yamlParser) {
 }
 
 // Copy a character to a string buffer and advance pointers.
-func read(parser *yamlParser, s []byte) []byte {
-	if !is_blank(parser.buffer, parser.buffer_pos) {
+func (parser *yamlParser) read(s []byte) []byte {
+	if !isBlank(parser.buffer, parser.buffer_pos) {
 		parser.newlines = 0
 	}
 	w := width(parser.buffer[parser.buffer_pos])
@@ -565,7 +565,7 @@ func read(parser *yamlParser, s []byte) []byte {
 }
 
 // Copy a line break character to a string buffer and advance pointers.
-func read_line(parser *yamlParser, s []byte) []byte {
+func (parser *yamlParser) readLine(s []byte) []byte {
 	buf := parser.buffer
 	pos := parser.buffer_pos
 	switch {
@@ -599,7 +599,7 @@ func read_line(parser *yamlParser, s []byte) []byte {
 }
 
 // Get the next token.
-func yaml_parser_scan(parser *yamlParser, token *yamlToken) bool {
+func (parser *yamlParser) scan(token *yamlToken) bool {
 	// Erase the token object.
 	*token = yamlToken{} // [Go] Is this necessary?
 
@@ -610,7 +610,7 @@ func yaml_parser_scan(parser *yamlParser, token *yamlToken) bool {
 
 	// Ensure that the tokens queue contains enough tokens.
 	if !parser.token_available {
-		if !yaml_parser_fetch_more_tokens(parser) {
+		if !parser.fetchMoreTokens() {
 			return false
 		}
 	}
@@ -628,7 +628,7 @@ func yaml_parser_scan(parser *yamlParser, token *yamlToken) bool {
 }
 
 // Set the scanner error and return false.
-func yaml_parser_set_scanner_error(parser *yamlParser, context string, context_mark yamlMark, problem string) bool {
+func (parser *yamlParser) setScannerError(context string, context_mark yamlMark, problem string) bool {
 	parser.error = yaml_SCANNER_ERROR
 	parser.context = context
 	parser.context_mark = context_mark
@@ -637,12 +637,12 @@ func yaml_parser_set_scanner_error(parser *yamlParser, context string, context_m
 	return false
 }
 
-func yaml_parser_set_scanner_tag_error(parser *yamlParser, directive bool, context_mark yamlMark, problem string) bool {
+func (parser *yamlParser) setScannerTagError(directive bool, context_mark yamlMark, problem string) bool {
 	context := "while parsing a tag"
 	if directive {
 		context = "while parsing a %TAG directive"
 	}
-	return yaml_parser_set_scanner_error(parser, context, context_mark, problem)
+	return parser.setScannerError(context, context_mark, problem)
 }
 
 func trace(args ...any) func() {
@@ -654,7 +654,7 @@ func trace(args ...any) func() {
 
 // Ensure that the tokens queue contains at least one token which can be
 // returned to the Parser.
-func yaml_parser_fetch_more_tokens(parser *yamlParser) bool {
+func (parser *yamlParser) fetchMoreTokens() bool {
 	// While we need more tokens to fetch, do it.
 	for {
 		// [Go] The comment parsing logic requires a lookahead of two tokens
@@ -667,14 +667,14 @@ func yaml_parser_fetch_more_tokens(parser *yamlParser) bool {
 			head_tok_idx, ok := parser.simple_keys_by_tok[parser.tokens_parsed]
 			if !ok {
 				break
-			} else if valid, ok := yaml_simple_key_is_valid(parser, &parser.simple_keys[head_tok_idx]); !ok {
+			} else if valid, ok := parser.simpleKeyIsValid(&parser.simple_keys[head_tok_idx]); !ok {
 				return false
 			} else if !valid {
 				break
 			}
 		}
 		// Fetch the next token.
-		if !yaml_parser_fetch_next_token(parser) {
+		if !parser.fetchNextToken() {
 			return false
 		}
 	}
@@ -684,21 +684,21 @@ func yaml_parser_fetch_more_tokens(parser *yamlParser) bool {
 }
 
 // The dispatcher for token fetchers.
-func yaml_parser_fetch_next_token(parser *yamlParser) (ok bool) {
+func (parser *yamlParser) fetchNextToken() (ok bool) {
 	// Ensure that the buffer is initialized.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 
 	// Check if we just started scanning.  Fetch STREAM-START then.
 	if !parser.stream_start_produced {
-		return yaml_parser_fetch_stream_start(parser)
+		return parser.fetchStreamStart()
 	}
 
 	scan_mark := parser.mark
 
 	// Eat whitespaces and comments until we reach the next token.
-	if !yaml_parser_scan_to_next_token(parser) {
+	if !parser.scanToNextToken() {
 		return false
 	}
 
@@ -707,37 +707,37 @@ func yaml_parser_fetch_next_token(parser *yamlParser) (ok bool) {
 	// the respective indexes.
 
 	// Check the indentation level against the current column.
-	if !yaml_parser_unroll_indent(parser, parser.mark.column, scan_mark) {
+	if !parser.unrollIndent(parser.mark.column, scan_mark) {
 		return false
 	}
 
 	// Ensure that the buffer contains at least 4 characters.  4 is the length
 	// of the longest indicators ('--- ' and '... ').
-	if parser.unread < 4 && !yaml_parser_update_buffer(parser, 4) {
+	if parser.unread < 4 && !parser.updateBuffer(4) {
 		return false
 	}
 
 	// Is it the end of the stream?
-	if is_z(parser.buffer, parser.buffer_pos) {
-		return yaml_parser_fetch_stream_end(parser)
+	if isZ(parser.buffer, parser.buffer_pos) {
+		return parser.fetchStreamEnd()
 	}
 
 	// Is it a directive?
 	if parser.mark.column == 0 && parser.buffer[parser.buffer_pos] == '%' {
-		return yaml_parser_fetch_directive(parser)
+		return parser.fetchDirective()
 	}
 
 	buf := parser.buffer
 	pos := parser.buffer_pos
 
 	// Is it the document start indicator?
-	if parser.mark.column == 0 && buf[pos] == '-' && buf[pos+1] == '-' && buf[pos+2] == '-' && is_blankz(buf, pos+3) {
-		return yaml_parser_fetch_document_indicator(parser, yaml_DOCUMENT_START_TOKEN)
+	if parser.mark.column == 0 && buf[pos] == '-' && buf[pos+1] == '-' && buf[pos+2] == '-' && isBlankz(buf, pos+3) {
+		return parser.fetchDocumentIndicator(yaml_DOCUMENT_START_TOKEN)
 	}
 
 	// Is it the document end indicator?
-	if parser.mark.column == 0 && buf[pos] == '.' && buf[pos+1] == '.' && buf[pos+2] == '.' && is_blankz(buf, pos+3) {
-		return yaml_parser_fetch_document_indicator(parser, yaml_DOCUMENT_END_TOKEN)
+	if parser.mark.column == 0 && buf[pos] == '.' && buf[pos+1] == '.' && buf[pos+2] == '.' && isBlankz(buf, pos+3) {
+		return parser.fetchDocumentIndicator(yaml_DOCUMENT_END_TOKEN)
 	}
 
 	comment_mark := parser.mark
@@ -754,7 +754,7 @@ func yaml_parser_fetch_next_token(parser *yamlParser) (ok bool) {
 			// a head comment for whatever follows.
 			return
 		}
-		if !yaml_parser_scan_line_comment(parser, comment_mark) {
+		if !parser.scanLineComment(comment_mark) {
 			ok = false
 			return
 		}
@@ -762,79 +762,79 @@ func yaml_parser_fetch_next_token(parser *yamlParser) (ok bool) {
 
 	// Is it the flow sequence start indicator?
 	if buf[pos] == '[' {
-		return yaml_parser_fetch_flow_collection_start(parser, yaml_FLOW_SEQUENCE_START_TOKEN)
+		return parser.fetchFlowCollectionStart(yaml_FLOW_SEQUENCE_START_TOKEN)
 	}
 
 	// Is it the flow mapping start indicator?
 	if parser.buffer[parser.buffer_pos] == '{' {
-		return yaml_parser_fetch_flow_collection_start(parser, yaml_FLOW_MAPPING_START_TOKEN)
+		return parser.fetchFlowCollectionStart(yaml_FLOW_MAPPING_START_TOKEN)
 	}
 
 	// Is it the flow sequence end indicator?
 	if parser.buffer[parser.buffer_pos] == ']' {
-		return yaml_parser_fetch_flow_collection_end(parser,
+		return parser.fetchFlowCollectionEnd(
 			yaml_FLOW_SEQUENCE_END_TOKEN)
 	}
 
 	// Is it the flow mapping end indicator?
 	if parser.buffer[parser.buffer_pos] == '}' {
-		return yaml_parser_fetch_flow_collection_end(parser,
+		return parser.fetchFlowCollectionEnd(
 			yaml_FLOW_MAPPING_END_TOKEN)
 	}
 
 	// Is it the flow entry indicator?
 	if parser.buffer[parser.buffer_pos] == ',' {
-		return yaml_parser_fetch_flow_entry(parser)
+		return parser.fetchFlowEntry()
 	}
 
 	// Is it the block entry indicator?
-	if parser.buffer[parser.buffer_pos] == '-' && is_blankz(parser.buffer, parser.buffer_pos+1) {
-		return yaml_parser_fetch_block_entry(parser)
+	if parser.buffer[parser.buffer_pos] == '-' && isBlankz(parser.buffer, parser.buffer_pos+1) {
+		return parser.fetchBlockEntry()
 	}
 
 	// Is it the key indicator?
-	if parser.buffer[parser.buffer_pos] == '?' && is_blankz(parser.buffer, parser.buffer_pos+1) {
-		return yaml_parser_fetch_key(parser)
+	if parser.buffer[parser.buffer_pos] == '?' && isBlankz(parser.buffer, parser.buffer_pos+1) {
+		return parser.fetchKey()
 	}
 
 	// Is it the value indicator?
-	if parser.buffer[parser.buffer_pos] == ':' && (parser.flow_level > 0 || is_blankz(parser.buffer, parser.buffer_pos+1)) {
-		return yaml_parser_fetch_value(parser)
+	if parser.buffer[parser.buffer_pos] == ':' && (parser.flow_level > 0 || isBlankz(parser.buffer, parser.buffer_pos+1)) {
+		return parser.fetchValue()
 	}
 
 	// Is it an alias?
 	if parser.buffer[parser.buffer_pos] == '*' {
-		return yaml_parser_fetch_anchor(parser, yaml_ALIAS_TOKEN)
+		return parser.fetchAnchor(yaml_ALIAS_TOKEN)
 	}
 
 	// Is it an anchor?
 	if parser.buffer[parser.buffer_pos] == '&' {
-		return yaml_parser_fetch_anchor(parser, yaml_ANCHOR_TOKEN)
+		return parser.fetchAnchor(yaml_ANCHOR_TOKEN)
 	}
 
 	// Is it a tag?
 	if parser.buffer[parser.buffer_pos] == '!' {
-		return yaml_parser_fetch_tag(parser)
+		return parser.fetchTag()
 	}
 
 	// Is it a literal scalar?
 	if parser.buffer[parser.buffer_pos] == '|' && parser.flow_level == 0 {
-		return yaml_parser_fetch_block_scalar(parser, true)
+		return parser.fetchBlockScalar(true)
 	}
 
 	// Is it a folded scalar?
 	if parser.buffer[parser.buffer_pos] == '>' && parser.flow_level == 0 {
-		return yaml_parser_fetch_block_scalar(parser, false)
+		return parser.fetchBlockScalar(false)
 	}
 
 	// Is it a single-quoted scalar?
 	if parser.buffer[parser.buffer_pos] == '\'' {
-		return yaml_parser_fetch_flow_scalar(parser, true)
+		return parser.fetchFlowScalar(true)
 	}
 
 	// Is it a double-quoted scalar?
 	if parser.buffer[parser.buffer_pos] == '"' {
-		return yaml_parser_fetch_flow_scalar(parser, false)
+		return parser.fetchFlowScalar(false)
 	}
 
 	// Is it a plain scalar?
@@ -857,7 +857,7 @@ func yaml_parser_fetch_next_token(parser *yamlParser) (ok bool) {
 	//switch parser.buffer[parser.buffer_pos] {
 	//case '-', '?', ':', ',', '?', '-', ',', ':', ']', '[', '}', '{', '&', '#', '!', '*', '>', '|', '"', '\'', '@', '%', '-', '`':
 	//}
-	if !(is_blankz(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == '-' ||
+	if !(isBlankz(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == '-' ||
 		parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == ':' ||
 		parser.buffer[parser.buffer_pos] == ',' || parser.buffer[parser.buffer_pos] == '[' ||
 		parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '{' ||
@@ -867,19 +867,19 @@ func yaml_parser_fetch_next_token(parser *yamlParser) (ok bool) {
 		parser.buffer[parser.buffer_pos] == '>' || parser.buffer[parser.buffer_pos] == '\'' ||
 		parser.buffer[parser.buffer_pos] == '"' || parser.buffer[parser.buffer_pos] == '%' ||
 		parser.buffer[parser.buffer_pos] == '@' || parser.buffer[parser.buffer_pos] == '`') ||
-		(parser.buffer[parser.buffer_pos] == '-' && !is_blank(parser.buffer, parser.buffer_pos+1)) ||
+		(parser.buffer[parser.buffer_pos] == '-' && !isBlank(parser.buffer, parser.buffer_pos+1)) ||
 		((parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == ':') &&
-			!is_blankz(parser.buffer, parser.buffer_pos+1)) {
-		return yaml_parser_fetch_plain_scalar(parser)
+			!isBlankz(parser.buffer, parser.buffer_pos+1)) {
+		return parser.fetchPlainScalar()
 	}
 
 	// If we don't determine the token type so far, it is an error.
-	return yaml_parser_set_scanner_error(parser,
+	return parser.setScannerError(
 		"while scanning for the next token", parser.mark,
 		"found character that cannot start any token")
 }
 
-func yaml_simple_key_is_valid(parser *yamlParser, simple_key *yamlSimpleKey) (valid, ok bool) {
+func (parser *yamlParser) simpleKeyIsValid(simple_key *yamlSimpleKey) (valid, ok bool) {
 	if !simple_key.possible {
 		return false, true
 	}
@@ -895,7 +895,7 @@ func yaml_simple_key_is_valid(parser *yamlParser, simple_key *yamlSimpleKey) (va
 	if simple_key.mark.line < parser.mark.line || simple_key.mark.index+1024 < parser.mark.index {
 		// Check if the potential simple key to be removed is required.
 		if simple_key.required {
-			return false, yaml_parser_set_scanner_error(parser,
+			return false, parser.setScannerError(
 				"while scanning a simple key", simple_key.mark,
 				"could not find expected ':'")
 		}
@@ -907,7 +907,7 @@ func yaml_simple_key_is_valid(parser *yamlParser, simple_key *yamlSimpleKey) (va
 
 // Check if a simple key may start at the current position and add it if
 // needed.
-func yaml_parser_save_simple_key(parser *yamlParser) bool {
+func (parser *yamlParser) saveSimpleKey() bool {
 	// A simple key is required at the current position if the scanner is in
 	// the block context and the current column coincides with the indentation
 	// level.
@@ -925,7 +925,7 @@ func yaml_parser_save_simple_key(parser *yamlParser) bool {
 			mark:         parser.mark,
 		}
 
-		if !yaml_parser_remove_simple_key(parser) {
+		if !parser.removeSimpleKey() {
 			return false
 		}
 		parser.simple_keys[len(parser.simple_keys)-1] = simple_key
@@ -935,12 +935,12 @@ func yaml_parser_save_simple_key(parser *yamlParser) bool {
 }
 
 // Remove a potential simple key at the current flow level.
-func yaml_parser_remove_simple_key(parser *yamlParser) bool {
+func (parser *yamlParser) removeSimpleKey() bool {
 	i := len(parser.simple_keys) - 1
 	if parser.simple_keys[i].possible {
 		// If the key is required, it is an error.
 		if parser.simple_keys[i].required {
-			return yaml_parser_set_scanner_error(parser,
+			return parser.setScannerError(
 				"while scanning a simple key", parser.simple_keys[i].mark,
 				"could not find expected ':'")
 		}
@@ -955,7 +955,7 @@ func yaml_parser_remove_simple_key(parser *yamlParser) bool {
 const max_flow_level = 10000
 
 // Increase the flow level and resize the simple key list if needed.
-func yaml_parser_increase_flow_level(parser *yamlParser) bool {
+func (parser *yamlParser) increaseFlowLevel() bool {
 	// Reset the simple key on the next level.
 	parser.simple_keys = append(parser.simple_keys, yamlSimpleKey{
 		possible:     false,
@@ -967,7 +967,7 @@ func yaml_parser_increase_flow_level(parser *yamlParser) bool {
 	// Increase the flow level.
 	parser.flow_level++
 	if parser.flow_level > max_flow_level {
-		return yaml_parser_set_scanner_error(parser,
+		return parser.setScannerError(
 			"while increasing flow level", parser.simple_keys[len(parser.simple_keys)-1].mark,
 			fmt.Sprintf("exceeded max depth of %d", max_flow_level))
 	}
@@ -975,7 +975,7 @@ func yaml_parser_increase_flow_level(parser *yamlParser) bool {
 }
 
 // Decrease the flow level.
-func yaml_parser_decrease_flow_level(parser *yamlParser) bool {
+func (parser *yamlParser) decreaseFlowLevel() bool {
 	if parser.flow_level > 0 {
 		parser.flow_level--
 		last := len(parser.simple_keys) - 1
@@ -991,7 +991,7 @@ const max_indents = 10000
 // Push the current indentation level to the stack and set the new level
 // the current column is greater than the indentation level.  In this case,
 // append or insert the specified token into the token queue.
-func yaml_parser_roll_indent(parser *yamlParser, column, number int, typ yamlTokenType, mark yamlMark) bool {
+func (parser *yamlParser) rollIndent(column, number int, typ yamlTokenType, mark yamlMark) bool {
 	// In the flow context, do nothing.
 	if parser.flow_level > 0 {
 		return true
@@ -1003,7 +1003,7 @@ func yaml_parser_roll_indent(parser *yamlParser, column, number int, typ yamlTok
 		parser.indents = append(parser.indents, parser.indent)
 		parser.indent = column
 		if len(parser.indents) > max_indents {
-			return yaml_parser_set_scanner_error(parser,
+			return parser.setScannerError(
 				"while increasing indent level", parser.simple_keys[len(parser.simple_keys)-1].mark,
 				fmt.Sprintf("exceeded max depth of %d", max_indents))
 		}
@@ -1017,7 +1017,7 @@ func yaml_parser_roll_indent(parser *yamlParser, column, number int, typ yamlTok
 		if number > -1 {
 			number -= parser.tokens_parsed
 		}
-		yaml_insert_token(parser, number, &token)
+		parser.insertToken(number, &token)
 	}
 	return true
 }
@@ -1025,7 +1025,7 @@ func yaml_parser_roll_indent(parser *yamlParser, column, number int, typ yamlTok
 // Pop indentation levels from the indents stack until the current level
 // becomes less or equal to the column.  For each indentation level, append
 // the BLOCK-END token.
-func yaml_parser_unroll_indent(parser *yamlParser, column int, scan_mark yamlMark) bool {
+func (parser *yamlParser) unrollIndent(column int, scan_mark yamlMark) bool {
 	// In the flow context, do nothing.
 	if parser.flow_level > 0 {
 		return true
@@ -1069,7 +1069,7 @@ func yaml_parser_unroll_indent(parser *yamlParser, column int, scan_mark yamlMar
 			start_mark: block_mark,
 			end_mark:   block_mark,
 		}
-		yaml_insert_token(parser, -1, &token)
+		parser.insertToken(-1, &token)
 
 		// Pop the indentation level.
 		parser.indent = parser.indents[len(parser.indents)-1]
@@ -1079,7 +1079,7 @@ func yaml_parser_unroll_indent(parser *yamlParser, column int, scan_mark yamlMar
 }
 
 // Initialize the scanner and produce the STREAM-START token.
-func yaml_parser_fetch_stream_start(parser *yamlParser) bool {
+func (parser *yamlParser) fetchStreamStart() bool {
 
 	// Set the initial indentation.
 	parser.indent = -1
@@ -1102,12 +1102,12 @@ func yaml_parser_fetch_stream_start(parser *yamlParser) bool {
 		end_mark:   parser.mark,
 		encoding:   parser.encoding,
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the STREAM-END token and shut down the scanner.
-func yaml_parser_fetch_stream_end(parser *yamlParser) bool {
+func (parser *yamlParser) fetchStreamEnd() bool {
 
 	// Force new line.
 	if parser.mark.column != 0 {
@@ -1116,12 +1116,12 @@ func yaml_parser_fetch_stream_end(parser *yamlParser) bool {
 	}
 
 	// Reset the indentation level.
-	if !yaml_parser_unroll_indent(parser, -1, parser.mark) {
+	if !parser.unrollIndent(-1, parser.mark) {
 		return false
 	}
 
 	// Reset simple keys.
-	if !yaml_parser_remove_simple_key(parser) {
+	if !parser.removeSimpleKey() {
 		return false
 	}
 
@@ -1133,19 +1133,19 @@ func yaml_parser_fetch_stream_end(parser *yamlParser) bool {
 		start_mark: parser.mark,
 		end_mark:   parser.mark,
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce a VERSION-DIRECTIVE or TAG-DIRECTIVE token.
-func yaml_parser_fetch_directive(parser *yamlParser) bool {
+func (parser *yamlParser) fetchDirective() bool {
 	// Reset the indentation level.
-	if !yaml_parser_unroll_indent(parser, -1, parser.mark) {
+	if !parser.unrollIndent(-1, parser.mark) {
 		return false
 	}
 
 	// Reset simple keys.
-	if !yaml_parser_remove_simple_key(parser) {
+	if !parser.removeSimpleKey() {
 		return false
 	}
 
@@ -1153,23 +1153,23 @@ func yaml_parser_fetch_directive(parser *yamlParser) bool {
 
 	// Create the YAML-DIRECTIVE or TAG-DIRECTIVE token.
 	token := yamlToken{}
-	if !yaml_parser_scan_directive(parser, &token) {
+	if !parser.scanDirective(&token) {
 		return false
 	}
 	// Append the token to the queue.
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the DOCUMENT-START or DOCUMENT-END token.
-func yaml_parser_fetch_document_indicator(parser *yamlParser, typ yamlTokenType) bool {
+func (parser *yamlParser) fetchDocumentIndicator(typ yamlTokenType) bool {
 	// Reset the indentation level.
-	if !yaml_parser_unroll_indent(parser, -1, parser.mark) {
+	if !parser.unrollIndent(-1, parser.mark) {
 		return false
 	}
 
 	// Reset simple keys.
-	if !yaml_parser_remove_simple_key(parser) {
+	if !parser.removeSimpleKey() {
 		return false
 	}
 
@@ -1178,9 +1178,9 @@ func yaml_parser_fetch_document_indicator(parser *yamlParser, typ yamlTokenType)
 	// Consume the token.
 	start_mark := parser.mark
 
-	skip(parser)
-	skip(parser)
-	skip(parser)
+	parser.skip()
+	parser.skip()
+	parser.skip()
 
 	end_mark := parser.mark
 
@@ -1191,20 +1191,20 @@ func yaml_parser_fetch_document_indicator(parser *yamlParser, typ yamlTokenType)
 		end_mark:   end_mark,
 	}
 	// Append the token to the queue.
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the FLOW-SEQUENCE-START or FLOW-MAPPING-START token.
-func yaml_parser_fetch_flow_collection_start(parser *yamlParser, typ yamlTokenType) bool {
+func (parser *yamlParser) fetchFlowCollectionStart(typ yamlTokenType) bool {
 
 	// The indicators '[' and '{' may start a simple key.
-	if !yaml_parser_save_simple_key(parser) {
+	if !parser.saveSimpleKey() {
 		return false
 	}
 
 	// Increase the flow level.
-	if !yaml_parser_increase_flow_level(parser) {
+	if !parser.increaseFlowLevel() {
 		return false
 	}
 
@@ -1213,7 +1213,7 @@ func yaml_parser_fetch_flow_collection_start(parser *yamlParser, typ yamlTokenTy
 
 	// Consume the token.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 	end_mark := parser.mark
 
 	// Create the FLOW-SEQUENCE-START of FLOW-MAPPING-START token.
@@ -1223,19 +1223,19 @@ func yaml_parser_fetch_flow_collection_start(parser *yamlParser, typ yamlTokenTy
 		end_mark:   end_mark,
 	}
 	// Append the token to the queue.
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the FLOW-SEQUENCE-END or FLOW-MAPPING-END token.
-func yaml_parser_fetch_flow_collection_end(parser *yamlParser, typ yamlTokenType) bool {
+func (parser *yamlParser) fetchFlowCollectionEnd(typ yamlTokenType) bool {
 	// Reset any potential simple key on the current flow level.
-	if !yaml_parser_remove_simple_key(parser) {
+	if !parser.removeSimpleKey() {
 		return false
 	}
 
 	// Decrease the flow level.
-	if !yaml_parser_decrease_flow_level(parser) {
+	if !parser.decreaseFlowLevel() {
 		return false
 	}
 
@@ -1245,7 +1245,7 @@ func yaml_parser_fetch_flow_collection_end(parser *yamlParser, typ yamlTokenType
 	// Consume the token.
 
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 	end_mark := parser.mark
 
 	// Create the FLOW-SEQUENCE-END of FLOW-MAPPING-END token.
@@ -1255,14 +1255,14 @@ func yaml_parser_fetch_flow_collection_end(parser *yamlParser, typ yamlTokenType
 		end_mark:   end_mark,
 	}
 	// Append the token to the queue.
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the FLOW-ENTRY token.
-func yaml_parser_fetch_flow_entry(parser *yamlParser) bool {
+func (parser *yamlParser) fetchFlowEntry() bool {
 	// Reset any potential simple keys on the current flow level.
-	if !yaml_parser_remove_simple_key(parser) {
+	if !parser.removeSimpleKey() {
 		return false
 	}
 
@@ -1271,7 +1271,7 @@ func yaml_parser_fetch_flow_entry(parser *yamlParser) bool {
 
 	// Consume the token.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 	end_mark := parser.mark
 
 	// Create the FLOW-ENTRY token and append it to the queue.
@@ -1280,21 +1280,21 @@ func yaml_parser_fetch_flow_entry(parser *yamlParser) bool {
 		start_mark: start_mark,
 		end_mark:   end_mark,
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the BLOCK-ENTRY token.
-func yaml_parser_fetch_block_entry(parser *yamlParser) bool {
+func (parser *yamlParser) fetchBlockEntry() bool {
 	// Check if the scanner is in the block context.
 	if parser.flow_level == 0 {
 		// Check if we are allowed to start a new entry.
 		if !parser.simple_key_allowed {
-			return yaml_parser_set_scanner_error(parser, "", parser.mark,
+			return parser.setScannerError("", parser.mark,
 				"block sequence entries are not allowed in this context")
 		}
 		// Add the BLOCK-SEQUENCE-START token if needed.
-		if !yaml_parser_roll_indent(parser, parser.mark.column, -1, yaml_BLOCK_SEQUENCE_START_TOKEN, parser.mark) {
+		if !parser.rollIndent(parser.mark.column, -1, yaml_BLOCK_SEQUENCE_START_TOKEN, parser.mark) {
 			return false
 		}
 	} else {
@@ -1304,7 +1304,7 @@ func yaml_parser_fetch_block_entry(parser *yamlParser) bool {
 	}
 
 	// Reset any potential simple keys on the current flow level.
-	if !yaml_parser_remove_simple_key(parser) {
+	if !parser.removeSimpleKey() {
 		return false
 	}
 
@@ -1313,7 +1313,7 @@ func yaml_parser_fetch_block_entry(parser *yamlParser) bool {
 
 	// Consume the token.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 	end_mark := parser.mark
 
 	// Create the BLOCK-ENTRY token and append it to the queue.
@@ -1322,28 +1322,28 @@ func yaml_parser_fetch_block_entry(parser *yamlParser) bool {
 		start_mark: start_mark,
 		end_mark:   end_mark,
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the KEY token.
-func yaml_parser_fetch_key(parser *yamlParser) bool {
+func (parser *yamlParser) fetchKey() bool {
 
 	// In the block context, additional checks are required.
 	if parser.flow_level == 0 {
 		// Check if we are allowed to start a new key (not necessary simple).
 		if !parser.simple_key_allowed {
-			return yaml_parser_set_scanner_error(parser, "", parser.mark,
+			return parser.setScannerError("", parser.mark,
 				"mapping keys are not allowed in this context")
 		}
 		// Add the BLOCK-MAPPING-START token if needed.
-		if !yaml_parser_roll_indent(parser, parser.mark.column, -1, yaml_BLOCK_MAPPING_START_TOKEN, parser.mark) {
+		if !parser.rollIndent(parser.mark.column, -1, yaml_BLOCK_MAPPING_START_TOKEN, parser.mark) {
 			return false
 		}
 	}
 
 	// Reset any potential simple keys on the current flow level.
-	if !yaml_parser_remove_simple_key(parser) {
+	if !parser.removeSimpleKey() {
 		return false
 	}
 
@@ -1352,7 +1352,7 @@ func yaml_parser_fetch_key(parser *yamlParser) bool {
 
 	// Consume the token.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 	end_mark := parser.mark
 
 	// Create the KEY token and append it to the queue.
@@ -1361,17 +1361,17 @@ func yaml_parser_fetch_key(parser *yamlParser) bool {
 		start_mark: start_mark,
 		end_mark:   end_mark,
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the VALUE token.
-func yaml_parser_fetch_value(parser *yamlParser) bool {
+func (parser *yamlParser) fetchValue() bool {
 
 	simple_key := &parser.simple_keys[len(parser.simple_keys)-1]
 
 	// Have we found a simple key?
-	if valid, ok := yaml_simple_key_is_valid(parser, simple_key); !ok {
+	if valid, ok := parser.simpleKeyIsValid(simple_key); !ok {
 		return false
 
 	} else if valid {
@@ -1382,10 +1382,10 @@ func yaml_parser_fetch_value(parser *yamlParser) bool {
 			start_mark: simple_key.mark,
 			end_mark:   simple_key.mark,
 		}
-		yaml_insert_token(parser, simple_key.token_number-parser.tokens_parsed, &token)
+		parser.insertToken(simple_key.token_number-parser.tokens_parsed, &token)
 
 		// In the block context, we may need to add the BLOCK-MAPPING-START token.
-		if !yaml_parser_roll_indent(parser, simple_key.mark.column,
+		if !parser.rollIndent(simple_key.mark.column,
 			simple_key.token_number,
 			yaml_BLOCK_MAPPING_START_TOKEN, simple_key.mark) {
 			return false
@@ -1406,12 +1406,12 @@ func yaml_parser_fetch_value(parser *yamlParser) bool {
 
 			// Check if we are allowed to start a complex value.
 			if !parser.simple_key_allowed {
-				return yaml_parser_set_scanner_error(parser, "", parser.mark,
+				return parser.setScannerError("", parser.mark,
 					"mapping values are not allowed in this context")
 			}
 
 			// Add the BLOCK-MAPPING-START token if needed.
-			if !yaml_parser_roll_indent(parser, parser.mark.column, -1, yaml_BLOCK_MAPPING_START_TOKEN, parser.mark) {
+			if !parser.rollIndent(parser.mark.column, -1, yaml_BLOCK_MAPPING_START_TOKEN, parser.mark) {
 				return false
 			}
 		}
@@ -1422,7 +1422,7 @@ func yaml_parser_fetch_value(parser *yamlParser) bool {
 
 	// Consume the token.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 	end_mark := parser.mark
 
 	// Create the VALUE token and append it to the queue.
@@ -1431,14 +1431,14 @@ func yaml_parser_fetch_value(parser *yamlParser) bool {
 		start_mark: start_mark,
 		end_mark:   end_mark,
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the ALIAS or ANCHOR token.
-func yaml_parser_fetch_anchor(parser *yamlParser, typ yamlTokenType) bool {
+func (parser *yamlParser) fetchAnchor(typ yamlTokenType) bool {
 	// An anchor or an alias could be a simple key.
-	if !yaml_parser_save_simple_key(parser) {
+	if !parser.saveSimpleKey() {
 		return false
 	}
 
@@ -1447,17 +1447,17 @@ func yaml_parser_fetch_anchor(parser *yamlParser, typ yamlTokenType) bool {
 
 	// Create the ALIAS or ANCHOR token and append it to the queue.
 	var token yamlToken
-	if !yaml_parser_scan_anchor(parser, &token, typ) {
+	if !parser.scanAnchor(&token, typ) {
 		return false
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the TAG token.
-func yaml_parser_fetch_tag(parser *yamlParser) bool {
+func (parser *yamlParser) fetchTag() bool {
 	// A tag could be a simple key.
-	if !yaml_parser_save_simple_key(parser) {
+	if !parser.saveSimpleKey() {
 		return false
 	}
 
@@ -1466,17 +1466,17 @@ func yaml_parser_fetch_tag(parser *yamlParser) bool {
 
 	// Create the TAG token and append it to the queue.
 	var token yamlToken
-	if !yaml_parser_scan_tag(parser, &token) {
+	if !parser.scanTag(&token) {
 		return false
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the SCALAR(...,literal) or SCALAR(...,folded) tokens.
-func yaml_parser_fetch_block_scalar(parser *yamlParser, literal bool) bool {
+func (parser *yamlParser) fetchBlockScalar(literal bool) bool {
 	// Remove any potential simple keys.
-	if !yaml_parser_remove_simple_key(parser) {
+	if !parser.removeSimpleKey() {
 		return false
 	}
 
@@ -1485,17 +1485,17 @@ func yaml_parser_fetch_block_scalar(parser *yamlParser, literal bool) bool {
 
 	// Create the SCALAR token and append it to the queue.
 	var token yamlToken
-	if !yaml_parser_scan_block_scalar(parser, &token, literal) {
+	if !parser.scanBlockScalar(&token, literal) {
 		return false
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the SCALAR(...,single-quoted) or SCALAR(...,double-quoted) tokens.
-func yaml_parser_fetch_flow_scalar(parser *yamlParser, single bool) bool {
+func (parser *yamlParser) fetchFlowScalar(single bool) bool {
 	// A plain scalar could be a simple key.
-	if !yaml_parser_save_simple_key(parser) {
+	if !parser.saveSimpleKey() {
 		return false
 	}
 
@@ -1504,17 +1504,17 @@ func yaml_parser_fetch_flow_scalar(parser *yamlParser, single bool) bool {
 
 	// Create the SCALAR token and append it to the queue.
 	var token yamlToken
-	if !yaml_parser_scan_flow_scalar(parser, &token, single) {
+	if !parser.scanFlowScalar(&token, single) {
 		return false
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Produce the SCALAR(...,plain) token.
-func yaml_parser_fetch_plain_scalar(parser *yamlParser) bool {
+func (parser *yamlParser) fetchPlainScalar() bool {
 	// A plain scalar could be a simple key.
-	if !yaml_parser_save_simple_key(parser) {
+	if !parser.saveSimpleKey() {
 		return false
 	}
 
@@ -1523,26 +1523,26 @@ func yaml_parser_fetch_plain_scalar(parser *yamlParser) bool {
 
 	// Create the SCALAR token and append it to the queue.
 	var token yamlToken
-	if !yaml_parser_scan_plain_scalar(parser, &token) {
+	if !parser.scanPlainScalar(&token) {
 		return false
 	}
-	yaml_insert_token(parser, -1, &token)
+	parser.insertToken(-1, &token)
 	return true
 }
 
 // Eat whitespaces and comments until the next token is found.
-func yaml_parser_scan_to_next_token(parser *yamlParser) bool {
+func (parser *yamlParser) scanToNextToken() bool {
 
 	scan_mark := parser.mark
 
 	// Until the next token is not found.
 	for {
 		// Allow the BOM mark to start a line.
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
-		if parser.mark.column == 0 && is_bom(parser.buffer, parser.buffer_pos) {
-			skip(parser)
+		if parser.mark.column == 0 && isBOM(parser.buffer, parser.buffer_pos) {
+			parser.skip()
 		}
 
 		// Eat whitespaces.
@@ -1550,13 +1550,13 @@ func yaml_parser_scan_to_next_token(parser *yamlParser) bool {
 		//  - in the flow context
 		//  - in the block context, but not at the beginning of the line or
 		//  after '-', '?', or ':' (complex value).
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 
 		for parser.buffer[parser.buffer_pos] == ' ' || ((parser.flow_level > 0 || !parser.simple_key_allowed) && parser.buffer[parser.buffer_pos] == '\t') {
-			skip(parser)
-			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			parser.skip()
+			if parser.unread < 1 && !parser.updateBuffer(1) {
 				return false
 			}
 		}
@@ -1572,7 +1572,7 @@ func yaml_parser_scan_to_next_token(parser *yamlParser) bool {
 			tokenA := parser.tokens[len(parser.tokens)-2]
 			tokenB := parser.tokens[len(parser.tokens)-1]
 			comment := &parser.comments[len(parser.comments)-1]
-			if tokenA.typ == yaml_BLOCK_SEQUENCE_START_TOKEN && tokenB.typ == yaml_BLOCK_ENTRY_TOKEN && len(comment.line) > 0 && !is_break(parser.buffer, parser.buffer_pos) {
+			if tokenA.typ == yaml_BLOCK_SEQUENCE_START_TOKEN && tokenB.typ == yaml_BLOCK_ENTRY_TOKEN && len(comment.line) > 0 && !isBreak(parser.buffer, parser.buffer_pos) {
 				// If it was in the prior line, reposition so it becomes a
 				// header of the follow up token. Otherwise, keep it in place
 				// so it becomes a header of the former.
@@ -1586,17 +1586,17 @@ func yaml_parser_scan_to_next_token(parser *yamlParser) bool {
 
 		// Eat a comment until a line break.
 		if parser.buffer[parser.buffer_pos] == '#' {
-			if !yaml_parser_scan_comments(parser, scan_mark) {
+			if !parser.scanComments(scan_mark) {
 				return false
 			}
 		}
 
 		// If it is a line break, eat it.
-		if is_break(parser.buffer, parser.buffer_pos) {
-			if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+		if isBreak(parser.buffer, parser.buffer_pos) {
+			if parser.unread < 2 && !parser.updateBuffer(2) {
 				return false
 			}
-			skip_line(parser)
+			parser.skipLine()
 
 			// In the block context, a new line may start a simple key.
 			if parser.flow_level == 0 {
@@ -1618,14 +1618,14 @@ func yaml_parser_scan_to_next_token(parser *yamlParser) bool {
 //	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //	%TAG    !yaml!  tag:yaml.org,2002:  \n
 //	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-func yaml_parser_scan_directive(parser *yamlParser, token *yamlToken) bool {
+func (parser *yamlParser) scanDirective(token *yamlToken) bool {
 	// Eat '%'.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 
 	// Scan the directive name.
 	var name []byte
-	if !yaml_parser_scan_directive_name(parser, start_mark, &name) {
+	if !parser.scanDirectiveName(start_mark, &name) {
 		return false
 	}
 
@@ -1633,7 +1633,7 @@ func yaml_parser_scan_directive(parser *yamlParser, token *yamlToken) bool {
 	if bytes.Equal(name, []byte("YAML")) {
 		// Scan the VERSION directive value.
 		var major, minor int8
-		if !yaml_parser_scan_version_directive_value(parser, start_mark, &major, &minor) {
+		if !parser.scanVersionDirectiveValue(start_mark, &major, &minor) {
 			return false
 		}
 		end_mark := parser.mark
@@ -1651,7 +1651,7 @@ func yaml_parser_scan_directive(parser *yamlParser, token *yamlToken) bool {
 	} else if bytes.Equal(name, []byte("TAG")) {
 		// Scan the TAG directive value.
 		var handle, prefix []byte
-		if !yaml_parser_scan_tag_directive_value(parser, start_mark, &handle, &prefix) {
+		if !parser.scanTagDirectiveValue(start_mark, &handle, &prefix) {
 			return false
 		}
 		end_mark := parser.mark
@@ -1667,49 +1667,49 @@ func yaml_parser_scan_directive(parser *yamlParser, token *yamlToken) bool {
 
 		// Unknown directive.
 	} else {
-		yaml_parser_set_scanner_error(parser, "while scanning a directive",
+		parser.setScannerError("while scanning a directive",
 			start_mark, "found unknown directive name")
 		return false
 	}
 
 	// Eat the rest of the line including any comments.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 
-	for is_blank(parser.buffer, parser.buffer_pos) {
-		skip(parser)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	for isBlank(parser.buffer, parser.buffer_pos) {
+		parser.skip()
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
 
 	if parser.buffer[parser.buffer_pos] == '#' {
 		// [Go] Discard this inline comment for the time being.
-		//if !yaml_parser_scan_line_comment(parser, start_mark) {
+		//if !parser.ScanLineComment(start_mark) {
 		//	return false
 		//}
-		for !is_breakz(parser.buffer, parser.buffer_pos) {
-			skip(parser)
-			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		for !isBreakz(parser.buffer, parser.buffer_pos) {
+			parser.skip()
+			if parser.unread < 1 && !parser.updateBuffer(1) {
 				return false
 			}
 		}
 	}
 
 	// Check if we are at the end of the line.
-	if !is_breakz(parser.buffer, parser.buffer_pos) {
-		yaml_parser_set_scanner_error(parser, "while scanning a directive",
+	if !isBreakz(parser.buffer, parser.buffer_pos) {
+		parser.setScannerError("while scanning a directive",
 			start_mark, "did not find expected comment or line break")
 		return false
 	}
 
 	// Eat a line break.
-	if is_break(parser.buffer, parser.buffer_pos) {
-		if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+	if isBreak(parser.buffer, parser.buffer_pos) {
+		if parser.unread < 2 && !parser.updateBuffer(2) {
 			return false
 		}
-		skip_line(parser)
+		parser.skipLine()
 	}
 
 	return true
@@ -1723,30 +1723,30 @@ func yaml_parser_scan_directive(parser *yamlParser, token *yamlToken) bool {
 //	 ^^^^
 //	%TAG    !yaml!  tag:yaml.org,2002:  \n
 //	 ^^^
-func yaml_parser_scan_directive_name(parser *yamlParser, start_mark yamlMark, name *[]byte) bool {
+func (parser *yamlParser) scanDirectiveName(start_mark yamlMark, name *[]byte) bool {
 	// Consume the directive name.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 
 	var s []byte
-	for is_alpha(parser.buffer, parser.buffer_pos) {
-		s = read(parser, s)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	for isAlpha(parser.buffer, parser.buffer_pos) {
+		s = parser.read(s)
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
 
 	// Check if the name is empty.
 	if len(s) == 0 {
-		yaml_parser_set_scanner_error(parser, "while scanning a directive",
+		parser.setScannerError("while scanning a directive",
 			start_mark, "could not find expected directive name")
 		return false
 	}
 
 	// Check for an blank character after the name.
-	if !is_blankz(parser.buffer, parser.buffer_pos) {
-		yaml_parser_set_scanner_error(parser, "while scanning a directive",
+	if !isBlankz(parser.buffer, parser.buffer_pos) {
+		parser.setScannerError("while scanning a directive",
 			start_mark, "found unexpected non-alphabetical character")
 		return false
 	}
@@ -1760,33 +1760,33 @@ func yaml_parser_scan_directive_name(parser *yamlParser, start_mark yamlMark, na
 //
 //	%YAML   1.1     # a comment \n
 //	     ^^^^^^
-func yaml_parser_scan_version_directive_value(parser *yamlParser, start_mark yamlMark, major, minor *int8) bool {
+func (parser *yamlParser) scanVersionDirectiveValue(start_mark yamlMark, major, minor *int8) bool {
 	// Eat whitespaces.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
-	for is_blank(parser.buffer, parser.buffer_pos) {
-		skip(parser)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	for isBlank(parser.buffer, parser.buffer_pos) {
+		parser.skip()
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
 
 	// Consume the major version number.
-	if !yaml_parser_scan_version_directive_number(parser, start_mark, major) {
+	if !parser.scanVersionDirectiveNumber(start_mark, major) {
 		return false
 	}
 
 	// Eat '.'.
 	if parser.buffer[parser.buffer_pos] != '.' {
-		return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
+		return parser.setScannerError("while scanning a %YAML directive",
 			start_mark, "did not find expected digit or '.' character")
 	}
 
-	skip(parser)
+	parser.skip()
 
 	// Consume the minor version number.
-	if !yaml_parser_scan_version_directive_number(parser, start_mark, minor) {
+	if !parser.scanVersionDirectiveNumber(start_mark, minor) {
 		return false
 	}
 	return true
@@ -1802,30 +1802,30 @@ const max_number_length = 2
 //	        ^
 //	%YAML   1.1     # a comment \n
 //	          ^
-func yaml_parser_scan_version_directive_number(parser *yamlParser, start_mark yamlMark, number *int8) bool {
+func (parser *yamlParser) scanVersionDirectiveNumber(start_mark yamlMark, number *int8) bool {
 
 	// Repeat while the next character is digit.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 	var value, length int8
-	for is_digit(parser.buffer, parser.buffer_pos) {
+	for isDigit(parser.buffer, parser.buffer_pos) {
 		// Check if the number is too long.
 		length++
 		if length > max_number_length {
-			return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
+			return parser.setScannerError("while scanning a %YAML directive",
 				start_mark, "found extremely long version number")
 		}
-		value = value*10 + int8(as_digit(parser.buffer, parser.buffer_pos))
-		skip(parser)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		value = value*10 + int8(asDigit(parser.buffer, parser.buffer_pos))
+		parser.skip()
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
 
 	// Check if the number was present.
 	if length == 0 {
-		return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
+		return parser.setScannerError("while scanning a %YAML directive",
 			start_mark, "did not find expected version number")
 	}
 	*number = value
@@ -1838,55 +1838,55 @@ func yaml_parser_scan_version_directive_number(parser *yamlParser, start_mark ya
 //
 //	%TAG    !yaml!  tag:yaml.org,2002:  \n
 //	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-func yaml_parser_scan_tag_directive_value(parser *yamlParser, start_mark yamlMark, handle, prefix *[]byte) bool {
+func (parser *yamlParser) scanTagDirectiveValue(start_mark yamlMark, handle, prefix *[]byte) bool {
 	var handle_value, prefix_value []byte
 
 	// Eat whitespaces.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 
-	for is_blank(parser.buffer, parser.buffer_pos) {
-		skip(parser)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	for isBlank(parser.buffer, parser.buffer_pos) {
+		parser.skip()
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
 
 	// Scan a handle.
-	if !yaml_parser_scan_tag_handle(parser, true, start_mark, &handle_value) {
+	if !parser.scanTagHandle(true, start_mark, &handle_value) {
 		return false
 	}
 
 	// Expect a whitespace.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
-	if !is_blank(parser.buffer, parser.buffer_pos) {
-		yaml_parser_set_scanner_error(parser, "while scanning a %TAG directive",
+	if !isBlank(parser.buffer, parser.buffer_pos) {
+		parser.setScannerError("while scanning a %TAG directive",
 			start_mark, "did not find expected whitespace")
 		return false
 	}
 
 	// Eat whitespaces.
-	for is_blank(parser.buffer, parser.buffer_pos) {
-		skip(parser)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	for isBlank(parser.buffer, parser.buffer_pos) {
+		parser.skip()
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
 
 	// Scan a prefix.
-	if !yaml_parser_scan_tag_uri(parser, true, nil, start_mark, &prefix_value) {
+	if !parser.scanTagUri(true, nil, start_mark, &prefix_value) {
 		return false
 	}
 
 	// Expect a whitespace or line break.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
-	if !is_blankz(parser.buffer, parser.buffer_pos) {
-		yaml_parser_set_scanner_error(parser, "while scanning a %TAG directive",
+	if !isBlankz(parser.buffer, parser.buffer_pos) {
+		parser.setScannerError("while scanning a %TAG directive",
 			start_mark, "did not find expected whitespace or line break")
 		return false
 	}
@@ -1896,21 +1896,21 @@ func yaml_parser_scan_tag_directive_value(parser *yamlParser, start_mark yamlMar
 	return true
 }
 
-func yaml_parser_scan_anchor(parser *yamlParser, token *yamlToken, typ yamlTokenType) bool {
+func (parser *yamlParser) scanAnchor(token *yamlToken, typ yamlTokenType) bool {
 	var s []byte
 
 	// Eat the indicator character.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 
 	// Consume the value.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 
-	for is_anchor_char(parser.buffer, parser.buffer_pos) {
-		s = read(parser, s)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	for isAnchorChar(parser.buffer, parser.buffer_pos) {
+		s = parser.read(s)
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
@@ -1925,7 +1925,7 @@ func yaml_parser_scan_anchor(parser *yamlParser, token *yamlToken, typ yamlToken
 	 */
 
 	if len(s) == 0 ||
-		!(is_blankz(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == '?' ||
+		!(isBlankz(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == '?' ||
 			parser.buffer[parser.buffer_pos] == ':' || parser.buffer[parser.buffer_pos] == ',' ||
 			parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '}' ||
 			parser.buffer[parser.buffer_pos] == '%' || parser.buffer[parser.buffer_pos] == '@' ||
@@ -1934,7 +1934,7 @@ func yaml_parser_scan_anchor(parser *yamlParser, token *yamlToken, typ yamlToken
 		if typ == yaml_ANCHOR_TOKEN {
 			context = "while scanning an anchor"
 		}
-		yaml_parser_set_scanner_error(parser, context, start_mark,
+		parser.setScannerError(context, start_mark,
 			"did not find expected alphabetic or numeric character")
 		return false
 	}
@@ -1954,13 +1954,13 @@ func yaml_parser_scan_anchor(parser *yamlParser, token *yamlToken, typ yamlToken
  * Scan a TAG token.
  */
 
-func yaml_parser_scan_tag(parser *yamlParser, token *yamlToken) bool {
+func (parser *yamlParser) scanTag(token *yamlToken) bool {
 	var handle, suffix []byte
 
 	start_mark := parser.mark
 
 	// Check if the tag is in the canonical form.
-	if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+	if parser.unread < 2 && !parser.updateBuffer(2) {
 		return false
 	}
 
@@ -1968,39 +1968,39 @@ func yaml_parser_scan_tag(parser *yamlParser, token *yamlToken) bool {
 		// Keep the handle as ''
 
 		// Eat '!<'
-		skip(parser)
-		skip(parser)
+		parser.skip()
+		parser.skip()
 
 		// Consume the tag value.
-		if !yaml_parser_scan_tag_uri(parser, false, nil, start_mark, &suffix) {
+		if !parser.scanTagUri(false, nil, start_mark, &suffix) {
 			return false
 		}
 
 		// Check for '>' and eat it.
 		if parser.buffer[parser.buffer_pos] != '>' {
-			yaml_parser_set_scanner_error(parser, "while scanning a tag",
+			parser.setScannerError("while scanning a tag",
 				start_mark, "did not find the expected '>'")
 			return false
 		}
 
-		skip(parser)
+		parser.skip()
 	} else {
 		// The tag has either the '!suffix' or the '!handle!suffix' form.
 
 		// First, try to scan a handle.
-		if !yaml_parser_scan_tag_handle(parser, false, start_mark, &handle) {
+		if !parser.scanTagHandle(false, start_mark, &handle) {
 			return false
 		}
 
 		// Check if it is, indeed, handle.
 		if handle[0] == '!' && len(handle) > 1 && handle[len(handle)-1] == '!' {
 			// Scan the suffix now.
-			if !yaml_parser_scan_tag_uri(parser, false, nil, start_mark, &suffix) {
+			if !parser.scanTagUri(false, nil, start_mark, &suffix) {
 				return false
 			}
 		} else {
 			// It wasn't a handle after all.  Scan the rest of the tag.
-			if !yaml_parser_scan_tag_uri(parser, false, handle, start_mark, &suffix) {
+			if !parser.scanTagUri(false, handle, start_mark, &suffix) {
 				return false
 			}
 
@@ -2016,11 +2016,11 @@ func yaml_parser_scan_tag(parser *yamlParser, token *yamlToken) bool {
 	}
 
 	// Check the character which ends the tag.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
-	if !is_blankz(parser.buffer, parser.buffer_pos) {
-		yaml_parser_set_scanner_error(parser, "while scanning a tag",
+	if !isBlankz(parser.buffer, parser.buffer_pos) {
+		parser.setScannerError("while scanning a tag",
 			start_mark, "did not find expected whitespace or line break")
 		return false
 	}
@@ -2039,13 +2039,13 @@ func yaml_parser_scan_tag(parser *yamlParser, token *yamlToken) bool {
 }
 
 // Scan a tag handle.
-func yaml_parser_scan_tag_handle(parser *yamlParser, directive bool, start_mark yamlMark, handle *[]byte) bool {
+func (parser *yamlParser) scanTagHandle(directive bool, start_mark yamlMark, handle *[]byte) bool {
 	// Check the initial '!' character.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 	if parser.buffer[parser.buffer_pos] != '!' {
-		yaml_parser_set_scanner_tag_error(parser, directive,
+		parser.setScannerTagError(directive,
 			start_mark, "did not find expected '!'")
 		return false
 	}
@@ -2053,27 +2053,27 @@ func yaml_parser_scan_tag_handle(parser *yamlParser, directive bool, start_mark 
 	var s []byte
 
 	// Copy the '!' character.
-	s = read(parser, s)
+	s = parser.read(s)
 
 	// Copy all subsequent alphabetical and numerical characters.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
-	for is_alpha(parser.buffer, parser.buffer_pos) {
-		s = read(parser, s)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	for isAlpha(parser.buffer, parser.buffer_pos) {
+		s = parser.read(s)
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
 
 	// Check if the trailing character is '!' and copy it.
 	if parser.buffer[parser.buffer_pos] == '!' {
-		s = read(parser, s)
+		s = parser.read(s)
 	} else {
 		// It's either the '!' tag or not really a tag handle.  If it's a %TAG
 		// directive, it's an error.  If it's a tag token, it must be a part of URI.
 		if directive && string(s) != "!" {
-			yaml_parser_set_scanner_tag_error(parser, directive,
+			parser.setScannerTagError(directive,
 				start_mark, "did not find expected '!'")
 			return false
 		}
@@ -2084,7 +2084,7 @@ func yaml_parser_scan_tag_handle(parser *yamlParser, directive bool, start_mark 
 }
 
 // Scan a tag.
-func yaml_parser_scan_tag_uri(parser *yamlParser, directive bool, head []byte, start_mark yamlMark, uri *[]byte) bool {
+func (parser *yamlParser) scanTagUri(directive bool, head []byte, start_mark yamlMark, uri *[]byte) bool {
 	//size_t length = head ? strlen((char *)head) : 0
 	var s []byte
 	hasTag := len(head) > 0
@@ -2097,7 +2097,7 @@ func yaml_parser_scan_tag_uri(parser *yamlParser, directive bool, head []byte, s
 	}
 
 	// Scan the tag.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 
@@ -2107,7 +2107,7 @@ func yaml_parser_scan_tag_uri(parser *yamlParser, directive bool, head []byte, s
 	//      '=', '+', '$', ',', '.', '!', '~', '*', '\'', '(', ')', '[', ']',
 	//      '%'.
 	// [Go] TODO Convert this into more reasonable logic.
-	for is_alpha(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == ';' ||
+	for isAlpha(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == ';' ||
 		parser.buffer[parser.buffer_pos] == '/' || parser.buffer[parser.buffer_pos] == '?' ||
 		parser.buffer[parser.buffer_pos] == ':' || parser.buffer[parser.buffer_pos] == '@' ||
 		parser.buffer[parser.buffer_pos] == '&' || parser.buffer[parser.buffer_pos] == '=' ||
@@ -2120,20 +2120,20 @@ func yaml_parser_scan_tag_uri(parser *yamlParser, directive bool, head []byte, s
 		parser.buffer[parser.buffer_pos] == '%' {
 		// Check if it is a URI-escape sequence.
 		if parser.buffer[parser.buffer_pos] == '%' {
-			if !yaml_parser_scan_uri_escapes(parser, directive, start_mark, &s) {
+			if !parser.scanUriEscapes(directive, start_mark, &s) {
 				return false
 			}
 		} else {
-			s = read(parser, s)
+			s = parser.read(s)
 		}
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 		hasTag = true
 	}
 
 	if !hasTag {
-		yaml_parser_set_scanner_tag_error(parser, directive,
+		parser.setScannerTagError(directive,
 			start_mark, "did not find expected tag URI")
 		return false
 	}
@@ -2142,59 +2142,59 @@ func yaml_parser_scan_tag_uri(parser *yamlParser, directive bool, head []byte, s
 }
 
 // Decode an URI-escape sequence corresponding to a single UTF-8 character.
-func yaml_parser_scan_uri_escapes(parser *yamlParser, directive bool, start_mark yamlMark, s *[]byte) bool {
+func (parser *yamlParser) scanUriEscapes(directive bool, start_mark yamlMark, s *[]byte) bool {
 
 	// Decode the required number of characters.
 	w := 1024
 	for w > 0 {
 		// Check for a URI-escaped octet.
-		if parser.unread < 3 && !yaml_parser_update_buffer(parser, 3) {
+		if parser.unread < 3 && !parser.updateBuffer(3) {
 			return false
 		}
 
 		if !(parser.buffer[parser.buffer_pos] == '%' &&
-			is_hex(parser.buffer, parser.buffer_pos+1) &&
-			is_hex(parser.buffer, parser.buffer_pos+2)) {
-			return yaml_parser_set_scanner_tag_error(parser, directive,
+			isHex(parser.buffer, parser.buffer_pos+1) &&
+			isHex(parser.buffer, parser.buffer_pos+2)) {
+			return parser.setScannerTagError(directive,
 				start_mark, "did not find URI escaped octet")
 		}
 
 		// Get the octet.
-		octet := byte((as_hex(parser.buffer, parser.buffer_pos+1) << 4) + as_hex(parser.buffer, parser.buffer_pos+2))
+		octet := byte((asHex(parser.buffer, parser.buffer_pos+1) << 4) + asHex(parser.buffer, parser.buffer_pos+2))
 
 		// If it is the leading octet, determine the length of the UTF-8 sequence.
 		if w == 1024 {
 			w = width(octet)
 			if w == 0 {
-				return yaml_parser_set_scanner_tag_error(parser, directive,
+				return parser.setScannerTagError(directive,
 					start_mark, "found an incorrect leading UTF-8 octet")
 			}
 		} else {
 			// Check if the trailing octet is correct.
 			if octet&0xC0 != 0x80 {
-				return yaml_parser_set_scanner_tag_error(parser, directive,
+				return parser.setScannerTagError(directive,
 					start_mark, "found an incorrect trailing UTF-8 octet")
 			}
 		}
 
 		// Copy the octet and move the pointers.
 		*s = append(*s, octet)
-		skip(parser)
-		skip(parser)
-		skip(parser)
+		parser.skip()
+		parser.skip()
+		parser.skip()
 		w--
 	}
 	return true
 }
 
 // Scan a block scalar.
-func yaml_parser_scan_block_scalar(parser *yamlParser, token *yamlToken, literal bool) bool {
+func (parser *yamlParser) scanBlockScalar(token *yamlToken, literal bool) bool {
 	// Eat the indicator '|' or '>'.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 
 	// Scan the additional block scalar indicators.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 
@@ -2207,37 +2207,37 @@ func yaml_parser_scan_block_scalar(parser *yamlParser, token *yamlToken, literal
 		} else {
 			chomping = -1
 		}
-		skip(parser)
+		parser.skip()
 
 		// Check for an indentation indicator.
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
-		if is_digit(parser.buffer, parser.buffer_pos) {
+		if isDigit(parser.buffer, parser.buffer_pos) {
 			// Check that the indentation is greater than 0.
 			if parser.buffer[parser.buffer_pos] == '0' {
-				yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
+				parser.setScannerError("while scanning a block scalar",
 					start_mark, "found an indentation indicator equal to 0")
 				return false
 			}
 
 			// Get the indentation level and eat the indicator.
-			increment = as_digit(parser.buffer, parser.buffer_pos)
-			skip(parser)
+			increment = asDigit(parser.buffer, parser.buffer_pos)
+			parser.skip()
 		}
 
-	} else if is_digit(parser.buffer, parser.buffer_pos) {
+	} else if isDigit(parser.buffer, parser.buffer_pos) {
 		// Do the same as above, but in the opposite order.
 
 		if parser.buffer[parser.buffer_pos] == '0' {
-			yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
+			parser.setScannerError("while scanning a block scalar",
 				start_mark, "found an indentation indicator equal to 0")
 			return false
 		}
-		increment = as_digit(parser.buffer, parser.buffer_pos)
-		skip(parser)
+		increment = asDigit(parser.buffer, parser.buffer_pos)
+		parser.skip()
 
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 		if parser.buffer[parser.buffer_pos] == '+' || parser.buffer[parser.buffer_pos] == '-' {
@@ -2246,45 +2246,45 @@ func yaml_parser_scan_block_scalar(parser *yamlParser, token *yamlToken, literal
 			} else {
 				chomping = -1
 			}
-			skip(parser)
+			parser.skip()
 		}
 	}
 
 	// Eat whitespaces and comments to the end of the line.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
-	for is_blank(parser.buffer, parser.buffer_pos) {
-		skip(parser)
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	for isBlank(parser.buffer, parser.buffer_pos) {
+		parser.skip()
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 	}
 	if parser.buffer[parser.buffer_pos] == '#' {
-		if !yaml_parser_scan_line_comment(parser, start_mark) {
+		if !parser.scanLineComment(start_mark) {
 			return false
 		}
-		for !is_breakz(parser.buffer, parser.buffer_pos) {
-			skip(parser)
-			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		for !isBreakz(parser.buffer, parser.buffer_pos) {
+			parser.skip()
+			if parser.unread < 1 && !parser.updateBuffer(1) {
 				return false
 			}
 		}
 	}
 
 	// Check if we are at the end of the line.
-	if !is_breakz(parser.buffer, parser.buffer_pos) {
-		yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
+	if !isBreakz(parser.buffer, parser.buffer_pos) {
+		parser.setScannerError("while scanning a block scalar",
 			start_mark, "did not find expected comment or line break")
 		return false
 	}
 
 	// Eat a line break.
-	if is_break(parser.buffer, parser.buffer_pos) {
-		if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+	if isBreak(parser.buffer, parser.buffer_pos) {
+		if parser.unread < 2 && !parser.updateBuffer(2) {
 			return false
 		}
-		skip_line(parser)
+		parser.skipLine()
 	}
 
 	end_mark := parser.mark
@@ -2301,20 +2301,20 @@ func yaml_parser_scan_block_scalar(parser *yamlParser, token *yamlToken, literal
 
 	// Scan the leading line breaks and determine the indentation level if needed.
 	var s, leading_break, trailing_breaks []byte
-	if !yaml_parser_scan_block_scalar_breaks(parser, &indent, &trailing_breaks, start_mark, &end_mark) {
+	if !parser.scanBlockScalarBreaks(&indent, &trailing_breaks, start_mark, &end_mark) {
 		return false
 	}
 
 	// Scan the block scalar content.
-	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+	if parser.unread < 1 && !parser.updateBuffer(1) {
 		return false
 	}
 	var leading_blank, trailing_blank bool
-	for parser.mark.column == indent && !is_z(parser.buffer, parser.buffer_pos) {
+	for parser.mark.column == indent && !isZ(parser.buffer, parser.buffer_pos) {
 		// We are at the beginning of a non-empty line.
 
 		// Is it a trailing whitespace?
-		trailing_blank = is_blank(parser.buffer, parser.buffer_pos)
+		trailing_blank = isBlank(parser.buffer, parser.buffer_pos)
 
 		// Check if we need to fold the leading line break.
 		if !literal && !leading_blank && !trailing_blank && len(leading_break) > 0 && leading_break[0] == '\n' {
@@ -2332,25 +2332,25 @@ func yaml_parser_scan_block_scalar(parser *yamlParser, token *yamlToken, literal
 		trailing_breaks = trailing_breaks[:0]
 
 		// Is it a leading whitespace?
-		leading_blank = is_blank(parser.buffer, parser.buffer_pos)
+		leading_blank = isBlank(parser.buffer, parser.buffer_pos)
 
 		// Consume the current line.
-		for !is_breakz(parser.buffer, parser.buffer_pos) {
-			s = read(parser, s)
-			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		for !isBreakz(parser.buffer, parser.buffer_pos) {
+			s = parser.read(s)
+			if parser.unread < 1 && !parser.updateBuffer(1) {
 				return false
 			}
 		}
 
 		// Consume the line break.
-		if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+		if parser.unread < 2 && !parser.updateBuffer(2) {
 			return false
 		}
 
-		leading_break = read_line(parser, leading_break)
+		leading_break = parser.readLine(leading_break)
 
 		// Eat the following indentation spaces and line breaks.
-		if !yaml_parser_scan_block_scalar_breaks(parser, &indent, &trailing_breaks, start_mark, &end_mark) {
+		if !parser.scanBlockScalarBreaks(&indent, &trailing_breaks, start_mark, &end_mark) {
 			return false
 		}
 	}
@@ -2379,19 +2379,19 @@ func yaml_parser_scan_block_scalar(parser *yamlParser, token *yamlToken, literal
 
 // Scan indentation spaces and line breaks for a block scalar.  Determine the
 // indentation level if needed.
-func yaml_parser_scan_block_scalar_breaks(parser *yamlParser, indent *int, breaks *[]byte, start_mark yamlMark, end_mark *yamlMark) bool {
+func (parser *yamlParser) scanBlockScalarBreaks(indent *int, breaks *[]byte, start_mark yamlMark, end_mark *yamlMark) bool {
 	*end_mark = parser.mark
 
 	// Eat the indentation spaces and line breaks.
 	max_indent := 0
 	for {
 		// Eat the indentation spaces.
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
-		for (*indent == 0 || parser.mark.column < *indent) && is_space(parser.buffer, parser.buffer_pos) {
-			skip(parser)
-			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		for (*indent == 0 || parser.mark.column < *indent) && isSpace(parser.buffer, parser.buffer_pos) {
+			parser.skip()
+			if parser.unread < 1 && !parser.updateBuffer(1) {
 				return false
 			}
 		}
@@ -2400,22 +2400,22 @@ func yaml_parser_scan_block_scalar_breaks(parser *yamlParser, indent *int, break
 		}
 
 		// Check for a tab character messing the indentation.
-		if (*indent == 0 || parser.mark.column < *indent) && is_tab(parser.buffer, parser.buffer_pos) {
-			return yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
+		if (*indent == 0 || parser.mark.column < *indent) && isTab(parser.buffer, parser.buffer_pos) {
+			return parser.setScannerError("while scanning a block scalar",
 				start_mark, "found a tab character where an indentation space is expected")
 		}
 
 		// Have we found a non-empty line?
-		if !is_break(parser.buffer, parser.buffer_pos) {
+		if !isBreak(parser.buffer, parser.buffer_pos) {
 			break
 		}
 
 		// Consume the line break.
-		if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+		if parser.unread < 2 && !parser.updateBuffer(2) {
 			return false
 		}
 		// [Go] Should really be returning breaks instead.
-		*breaks = read_line(parser, *breaks)
+		*breaks = parser.readLine(*breaks)
 		*end_mark = parser.mark
 	}
 
@@ -2433,16 +2433,16 @@ func yaml_parser_scan_block_scalar_breaks(parser *yamlParser, indent *int, break
 }
 
 // Scan a quoted scalar.
-func yaml_parser_scan_flow_scalar(parser *yamlParser, token *yamlToken, single bool) bool {
+func (parser *yamlParser) scanFlowScalar(token *yamlToken, single bool) bool {
 	// Eat the left quote.
 	start_mark := parser.mark
-	skip(parser)
+	parser.skip()
 
 	// Consume the content of the quoted scalar.
 	var s, leading_break, trailing_breaks, whitespaces []byte
 	for {
 		// Check that there are no document indicators at the beginning of the line.
-		if parser.unread < 4 && !yaml_parser_update_buffer(parser, 4) {
+		if parser.unread < 4 && !parser.updateBuffer(4) {
 			return false
 		}
 
@@ -2453,27 +2453,27 @@ func yaml_parser_scan_flow_scalar(parser *yamlParser, token *yamlToken, single b
 				(parser.buffer[parser.buffer_pos+0] == '.' &&
 					parser.buffer[parser.buffer_pos+1] == '.' &&
 					parser.buffer[parser.buffer_pos+2] == '.')) &&
-			is_blankz(parser.buffer, parser.buffer_pos+3) {
-			yaml_parser_set_scanner_error(parser, "while scanning a quoted scalar",
+			isBlankz(parser.buffer, parser.buffer_pos+3) {
+			parser.setScannerError("while scanning a quoted scalar",
 				start_mark, "found unexpected document indicator")
 			return false
 		}
 
 		// Check for EOF.
-		if is_z(parser.buffer, parser.buffer_pos) {
-			yaml_parser_set_scanner_error(parser, "while scanning a quoted scalar",
+		if isZ(parser.buffer, parser.buffer_pos) {
+			parser.setScannerError("while scanning a quoted scalar",
 				start_mark, "found unexpected end of stream")
 			return false
 		}
 
 		// Consume non-blank characters.
 		leading_blanks := false
-		for !is_blankz(parser.buffer, parser.buffer_pos) {
+		for !isBlankz(parser.buffer, parser.buffer_pos) {
 			if single && parser.buffer[parser.buffer_pos] == '\'' && parser.buffer[parser.buffer_pos+1] == '\'' {
 				// Is is an escaped single quote.
 				s = append(s, '\'')
-				skip(parser)
-				skip(parser)
+				parser.skip()
+				parser.skip()
 
 			} else if single && parser.buffer[parser.buffer_pos] == '\'' {
 				// It is a right single quote.
@@ -2482,13 +2482,13 @@ func yaml_parser_scan_flow_scalar(parser *yamlParser, token *yamlToken, single b
 				// It is a right double quote.
 				break
 
-			} else if !single && parser.buffer[parser.buffer_pos] == '\\' && is_break(parser.buffer, parser.buffer_pos+1) {
+			} else if !single && parser.buffer[parser.buffer_pos] == '\\' && isBreak(parser.buffer, parser.buffer_pos+1) {
 				// It is an escaped line break.
-				if parser.unread < 3 && !yaml_parser_update_buffer(parser, 3) {
+				if parser.unread < 3 && !parser.updateBuffer(3) {
 					return false
 				}
-				skip(parser)
-				skip_line(parser)
+				parser.skip()
+				parser.skipLine()
 				leading_blanks = true
 				break
 
@@ -2545,34 +2545,34 @@ func yaml_parser_scan_flow_scalar(parser *yamlParser, token *yamlToken, single b
 				case 'U':
 					code_length = 8
 				default:
-					yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
+					parser.setScannerError("while parsing a quoted scalar",
 						start_mark, "found unknown escape character")
 					return false
 				}
 
-				skip(parser)
-				skip(parser)
+				parser.skip()
+				parser.skip()
 
 				// Consume an arbitrary escape code.
 				if code_length > 0 {
 					var value int
 
 					// Scan the character value.
-					if parser.unread < code_length && !yaml_parser_update_buffer(parser, code_length) {
+					if parser.unread < code_length && !parser.updateBuffer(code_length) {
 						return false
 					}
 					for k := 0; k < code_length; k++ {
-						if !is_hex(parser.buffer, parser.buffer_pos+k) {
-							yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
+						if !isHex(parser.buffer, parser.buffer_pos+k) {
+							parser.setScannerError("while parsing a quoted scalar",
 								start_mark, "did not find expected hexadecimal number")
 							return false
 						}
-						value = (value << 4) + as_hex(parser.buffer, parser.buffer_pos+k)
+						value = (value << 4) + asHex(parser.buffer, parser.buffer_pos+k)
 					}
 
 					// Check the value and write the character.
 					if (value >= 0xD800 && value <= 0xDFFF) || value > 0x10FFFF {
-						yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
+						parser.setScannerError("while parsing a quoted scalar",
 							start_mark, "found invalid Unicode character escape code")
 						return false
 					}
@@ -2594,19 +2594,19 @@ func yaml_parser_scan_flow_scalar(parser *yamlParser, token *yamlToken, single b
 
 					// Advance the pointer.
 					for k := 0; k < code_length; k++ {
-						skip(parser)
+						parser.skip()
 					}
 				}
 			} else {
 				// It is a non-escaped non-blank character.
-				s = read(parser, s)
+				s = parser.read(s)
 			}
-			if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+			if parser.unread < 2 && !parser.updateBuffer(2) {
 				return false
 			}
 		}
 
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 
@@ -2622,29 +2622,29 @@ func yaml_parser_scan_flow_scalar(parser *yamlParser, token *yamlToken, single b
 		}
 
 		// Consume blank characters.
-		for is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos) {
-			if is_blank(parser.buffer, parser.buffer_pos) {
+		for isBlank(parser.buffer, parser.buffer_pos) || isBreak(parser.buffer, parser.buffer_pos) {
+			if isBlank(parser.buffer, parser.buffer_pos) {
 				// Consume a space or a tab character.
 				if !leading_blanks {
-					whitespaces = read(parser, whitespaces)
+					whitespaces = parser.read(whitespaces)
 				} else {
-					skip(parser)
+					parser.skip()
 				}
 			} else {
-				if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+				if parser.unread < 2 && !parser.updateBuffer(2) {
 					return false
 				}
 
 				// Check if it is a first line break.
 				if !leading_blanks {
 					whitespaces = whitespaces[:0]
-					leading_break = read_line(parser, leading_break)
+					leading_break = parser.readLine(leading_break)
 					leading_blanks = true
 				} else {
-					trailing_breaks = read_line(parser, trailing_breaks)
+					trailing_breaks = parser.readLine(trailing_breaks)
 				}
 			}
-			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			if parser.unread < 1 && !parser.updateBuffer(1) {
 				return false
 			}
 		}
@@ -2671,7 +2671,7 @@ func yaml_parser_scan_flow_scalar(parser *yamlParser, token *yamlToken, single b
 	}
 
 	// Eat the right quote.
-	skip(parser)
+	parser.skip()
 	end_mark := parser.mark
 
 	// Create a token.
@@ -2689,7 +2689,7 @@ func yaml_parser_scan_flow_scalar(parser *yamlParser, token *yamlToken, single b
 }
 
 // Scan a plain scalar.
-func yaml_parser_scan_plain_scalar(parser *yamlParser, token *yamlToken) bool {
+func (parser *yamlParser) scanPlainScalar(token *yamlToken) bool {
 
 	var s, leading_break, trailing_breaks, whitespaces []byte
 	var leading_blanks bool
@@ -2701,7 +2701,7 @@ func yaml_parser_scan_plain_scalar(parser *yamlParser, token *yamlToken) bool {
 	// Consume the content of the plain scalar.
 	for {
 		// Check for a document indicator.
-		if parser.unread < 4 && !yaml_parser_update_buffer(parser, 4) {
+		if parser.unread < 4 && !parser.updateBuffer(4) {
 			return false
 		}
 		if parser.mark.column == 0 &&
@@ -2711,7 +2711,7 @@ func yaml_parser_scan_plain_scalar(parser *yamlParser, token *yamlToken) bool {
 				(parser.buffer[parser.buffer_pos+0] == '.' &&
 					parser.buffer[parser.buffer_pos+1] == '.' &&
 					parser.buffer[parser.buffer_pos+2] == '.')) &&
-			is_blankz(parser.buffer, parser.buffer_pos+3) {
+			isBlankz(parser.buffer, parser.buffer_pos+3) {
 			break
 		}
 
@@ -2721,13 +2721,13 @@ func yaml_parser_scan_plain_scalar(parser *yamlParser, token *yamlToken) bool {
 		}
 
 		// Consume non-blank characters.
-		for !is_blankz(parser.buffer, parser.buffer_pos) {
+		for !isBlankz(parser.buffer, parser.buffer_pos) {
 
 			// Check for indicators that may end a plain scalar.
-			if (parser.buffer[parser.buffer_pos] == ':' && is_blankz(parser.buffer, parser.buffer_pos+1)) ||
+			if (parser.buffer[parser.buffer_pos] == ':' && isBlankz(parser.buffer, parser.buffer_pos+1)) ||
 				(parser.flow_level > 0 &&
 					(parser.buffer[parser.buffer_pos] == ',' ||
-						(parser.buffer[parser.buffer_pos] == '?' && is_blankz(parser.buffer, parser.buffer_pos+1)) ||
+						(parser.buffer[parser.buffer_pos] == '?' && isBlankz(parser.buffer, parser.buffer_pos+1)) ||
 						parser.buffer[parser.buffer_pos] == '[' ||
 						parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '{' ||
 						parser.buffer[parser.buffer_pos] == '}')) {
@@ -2758,55 +2758,55 @@ func yaml_parser_scan_plain_scalar(parser *yamlParser, token *yamlToken) bool {
 			}
 
 			// Copy the character.
-			s = read(parser, s)
+			s = parser.read(s)
 
 			end_mark = parser.mark
-			if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+			if parser.unread < 2 && !parser.updateBuffer(2) {
 				return false
 			}
 		}
 
 		// Is it the end?
-		if !(is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos)) {
+		if !(isBlank(parser.buffer, parser.buffer_pos) || isBreak(parser.buffer, parser.buffer_pos)) {
 			break
 		}
 
 		// Consume blank characters.
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		if parser.unread < 1 && !parser.updateBuffer(1) {
 			return false
 		}
 
-		for is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos) {
-			if is_blank(parser.buffer, parser.buffer_pos) {
+		for isBlank(parser.buffer, parser.buffer_pos) || isBreak(parser.buffer, parser.buffer_pos) {
+			if isBlank(parser.buffer, parser.buffer_pos) {
 
 				// Check for tab characters that abuse indentation.
-				if leading_blanks && parser.mark.column < indent && is_tab(parser.buffer, parser.buffer_pos) {
-					yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
+				if leading_blanks && parser.mark.column < indent && isTab(parser.buffer, parser.buffer_pos) {
+					parser.setScannerError("while scanning a plain scalar",
 						start_mark, "found a tab character that violates indentation")
 					return false
 				}
 
 				// Consume a space or a tab character.
 				if !leading_blanks {
-					whitespaces = read(parser, whitespaces)
+					whitespaces = parser.read(whitespaces)
 				} else {
-					skip(parser)
+					parser.skip()
 				}
 			} else {
-				if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+				if parser.unread < 2 && !parser.updateBuffer(2) {
 					return false
 				}
 
 				// Check if it is a first line break.
 				if !leading_blanks {
 					whitespaces = whitespaces[:0]
-					leading_break = read_line(parser, leading_break)
+					leading_break = parser.readLine(leading_break)
 					leading_blanks = true
 				} else {
-					trailing_breaks = read_line(parser, trailing_breaks)
+					trailing_breaks = parser.readLine(trailing_breaks)
 				}
 			}
-			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			if parser.unread < 1 && !parser.updateBuffer(1) {
 				return false
 			}
 		}
@@ -2833,7 +2833,7 @@ func yaml_parser_scan_plain_scalar(parser *yamlParser, token *yamlToken) bool {
 	return true
 }
 
-func yaml_parser_scan_line_comment(parser *yamlParser, token_mark yamlMark) bool {
+func (parser *yamlParser) scanLineComment(token_mark yamlMark) bool {
 	if parser.newlines > 0 {
 		return true
 	}
@@ -2842,33 +2842,33 @@ func yaml_parser_scan_line_comment(parser *yamlParser, token_mark yamlMark) bool
 	var text []byte
 
 	for peek := 0; peek < 512; peek++ {
-		if parser.unread < peek+1 && !yaml_parser_update_buffer(parser, peek+1) {
+		if parser.unread < peek+1 && !parser.updateBuffer(peek+1) {
 			break
 		}
-		if is_blank(parser.buffer, parser.buffer_pos+peek) {
+		if isBlank(parser.buffer, parser.buffer_pos+peek) {
 			continue
 		}
 		if parser.buffer[parser.buffer_pos+peek] == '#' {
 			seen := parser.mark.index + peek
 			for {
-				if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+				if parser.unread < 1 && !parser.updateBuffer(1) {
 					return false
 				}
-				if is_breakz(parser.buffer, parser.buffer_pos) {
+				if isBreakz(parser.buffer, parser.buffer_pos) {
 					if parser.mark.index >= seen {
 						break
 					}
-					if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+					if parser.unread < 2 && !parser.updateBuffer(2) {
 						return false
 					}
-					skip_line(parser)
+					parser.skipLine()
 				} else if parser.mark.index >= seen {
 					if len(text) == 0 {
 						start_mark = parser.mark
 					}
-					text = read(parser, text)
+					text = parser.read(text)
 				} else {
-					skip(parser)
+					parser.skip()
 				}
 			}
 		}
@@ -2884,7 +2884,7 @@ func yaml_parser_scan_line_comment(parser *yamlParser, token_mark yamlMark) bool
 	return true
 }
 
-func yaml_parser_scan_comments(parser *yamlParser, scan_mark yamlMark) bool {
+func (parser *yamlParser) scanComments(scan_mark yamlMark) bool {
 	token := parser.tokens[len(parser.tokens)-1]
 
 	if token.typ == yaml_FLOW_ENTRY_TOKEN && len(parser.tokens) > 1 {
@@ -2920,16 +2920,16 @@ func yaml_parser_scan_comments(parser *yamlParser, scan_mark yamlMark) bool {
 
 	var peek = 0
 	for ; peek < 512; peek++ {
-		if parser.unread < peek+1 && !yaml_parser_update_buffer(parser, peek+1) {
+		if parser.unread < peek+1 && !parser.updateBuffer(peek+1) {
 			break
 		}
 		column++
-		if is_blank(parser.buffer, parser.buffer_pos+peek) {
+		if isBlank(parser.buffer, parser.buffer_pos+peek) {
 			continue
 		}
 		c := parser.buffer[parser.buffer_pos+peek]
 		var close_flow = parser.flow_level > 0 && (c == ']' || c == '}')
-		if close_flow || is_breakz(parser.buffer, parser.buffer_pos+peek) {
+		if close_flow || isBreakz(parser.buffer, parser.buffer_pos+peek) {
 			// Got line break or terminator.
 			if close_flow || !recent_empty {
 				if close_flow || first_empty && (start_mark.line == foot_line && token.typ != yaml_VALUE_TOKEN || start_mark.column-1 < next_indent) {
@@ -2960,7 +2960,7 @@ func yaml_parser_scan_comments(parser *yamlParser, scan_mark yamlMark) bool {
 					}
 				}
 			}
-			if !is_break(parser.buffer, parser.buffer_pos+peek) {
+			if !isBreak(parser.buffer, parser.buffer_pos+peek) {
 				break
 			}
 			first_empty = false
@@ -3000,21 +3000,21 @@ func yaml_parser_scan_comments(parser *yamlParser, scan_mark yamlMark) bool {
 		// Consume until after the consumed comment line.
 		seen := parser.mark.index + peek
 		for {
-			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			if parser.unread < 1 && !parser.updateBuffer(1) {
 				return false
 			}
-			if is_breakz(parser.buffer, parser.buffer_pos) {
+			if isBreakz(parser.buffer, parser.buffer_pos) {
 				if parser.mark.index >= seen {
 					break
 				}
-				if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+				if parser.unread < 2 && !parser.updateBuffer(2) {
 					return false
 				}
-				skip_line(parser)
+				parser.skipLine()
 			} else if parser.mark.index >= seen {
-				text = read(parser, text)
+				text = parser.read(text)
 			} else {
-				skip(parser)
+				parser.skip()
 			}
 		}
 

--- a/writerc.go
+++ b/writerc.go
@@ -23,14 +23,14 @@
 package yaml
 
 // Set the writer error and return false.
-func yaml_emitter_set_writer_error(emitter *yamlEmitter, problem string) bool {
+func (emitter *yamlEmitter) setWriterError(problem string) bool {
 	emitter.error = yaml_WRITER_ERROR
 	emitter.problem = problem
 	return false
 }
 
 // Flush the output buffer.
-func yaml_emitter_flush(emitter *yamlEmitter) bool {
+func (emitter *yamlEmitter) flush() bool {
 	if emitter.write_handler == nil {
 		panic("write handler not set")
 	}
@@ -41,7 +41,7 @@ func yaml_emitter_flush(emitter *yamlEmitter) bool {
 	}
 
 	if err := emitter.write_handler(emitter, emitter.buffer[:emitter.buffer_pos]); err != nil {
-		return yaml_emitter_set_writer_error(emitter, "write error: "+err.Error())
+		return emitter.setWriterError("write error: " + err.Error())
 	}
 	emitter.buffer_pos = 0
 	return true

--- a/yaml.go
+++ b/yaml.go
@@ -793,16 +793,16 @@ func ParserGetEvents(in []byte) (string, error) {
 	var events strings.Builder
 	var event yamlEvent
 	for {
-		if !yaml_parser_parse(&p.parser, &event) {
+		if !(&p.parser).parse(&event) {
 			return "", errors.New(p.parser.problem)
 		}
 		formatted := formatEvent(&event)
 		events.WriteString(formatted)
 		if event.typ == yaml_STREAM_END_EVENT {
-			yaml_event_delete(&event)
+			yamlEventDelete(&event)
 			break
 		}
-		yaml_event_delete(&event)
+		yamlEventDelete(&event)
 		events.WriteByte('\n')
 	}
 	return events.String(), nil
@@ -839,7 +839,7 @@ func formatEvent(e *yamlEvent) string {
 			b.Write(e.tag)
 			b.WriteString(">")
 		}
-		switch e.scalar_style() {
+		switch e.scalarStyle() {
 		case yaml_PLAIN_SCALAR_STYLE:
 			b.WriteString(" :")
 		case yaml_LITERAL_SCALAR_STYLE:
@@ -870,7 +870,7 @@ func formatEvent(e *yamlEvent) string {
 			b.Write(e.tag)
 			b.WriteString(">")
 		}
-		if e.sequence_style() == yaml_FLOW_SEQUENCE_STYLE {
+		if e.sequenceStyle() == yaml_FLOW_SEQUENCE_STYLE {
 			b.WriteString(" []")
 		}
 	case yaml_SEQUENCE_END_EVENT:
@@ -886,7 +886,7 @@ func formatEvent(e *yamlEvent) string {
 			b.Write(e.tag)
 			b.WriteString(">")
 		}
-		if e.mapping_style() == yaml_FLOW_MAPPING_STYLE {
+		if e.mappingStyle() == yaml_FLOW_MAPPING_STYLE {
 			b.WriteString(" {}")
 		}
 	case yaml_MAPPING_END_EVENT:

--- a/yamlh.go
+++ b/yamlh.go
@@ -329,9 +329,9 @@ type yamlEvent struct {
 	style yamlStyle
 }
 
-func (e *yamlEvent) scalar_style() yamlScalarStyle     { return yamlScalarStyle(e.style) }
-func (e *yamlEvent) sequence_style() yamlSequenceStyle { return yamlSequenceStyle(e.style) }
-func (e *yamlEvent) mapping_style() yamlMappingStyle   { return yamlMappingStyle(e.style) }
+func (e *yamlEvent) scalarStyle() yamlScalarStyle     { return yamlScalarStyle(e.style) }
+func (e *yamlEvent) sequenceStyle() yamlSequenceStyle { return yamlSequenceStyle(e.style) }
+func (e *yamlEvent) mappingStyle() yamlMappingStyle   { return yamlMappingStyle(e.style) }
 
 // Nodes
 

--- a/yamlprivateh.go
+++ b/yamlprivateh.go
@@ -45,7 +45,7 @@ const (
 
 // Check if the character at the specified position is an alphabetical
 // character, a digit, '_', or '-'.
-func is_alpha(b []byte, i int) bool {
+func isAlpha(b []byte, i int) bool {
 	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'Z' ||
 		b[i] >= 'a' && b[i] <= 'z' || b[i] == '_' || b[i] == '-'
 }
@@ -54,7 +54,7 @@ func is_alpha(b []byte, i int) bool {
 // defined by spec production [23] c-flow-indicator ::=
 // c-collect-entry | c-sequence-start | c-sequence-end |
 // c-mapping-start | c-mapping-end
-func is_flow_indicator(b []byte, i int) bool {
+func isFlowIndicator(b []byte, i int) bool {
 	return b[i] == '[' || b[i] == ']' ||
 		b[i] == '{' || b[i] == '}' || b[i] == ','
 }
@@ -66,33 +66,33 @@ func is_flow_indicator(b []byte, i int) bool {
 // ']', '{', '}', ','.
 // We further limit it to ascii chars only, which is a subset of the spec
 // production but is usually what most people expect.
-func is_anchor_char(b []byte, i int) bool {
-	return is_printable(b, i) &&
-		!is_break(b, i) &&
-		!is_blank(b, i) &&
-		!is_bom(b, i) &&
-		!is_flow_indicator(b, i) &&
-		is_ascii(b, i)
+func isAnchorChar(b []byte, i int) bool {
+	return isPrintable(b, i) &&
+		!isBreak(b, i) &&
+		!isBlank(b, i) &&
+		!isBOM(b, i) &&
+		!isFlowIndicator(b, i) &&
+		isAscii(b, i)
 }
 
 // Check if the character at the specified position is a digit.
-func is_digit(b []byte, i int) bool {
+func isDigit(b []byte, i int) bool {
 	return b[i] >= '0' && b[i] <= '9'
 }
 
 // Get the value of a digit.
-func as_digit(b []byte, i int) int {
+func asDigit(b []byte, i int) int {
 	return int(b[i]) - '0'
 }
 
 // Check if the character at the specified position is a hex-digit.
-func is_hex(b []byte, i int) bool {
+func isHex(b []byte, i int) bool {
 	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'F' ||
 		b[i] >= 'a' && b[i] <= 'f'
 }
 
 // Get the value of a hex-digit.
-func as_hex(b []byte, i int) int {
+func asHex(b []byte, i int) int {
 	bi := b[i]
 	if bi >= 'A' && bi <= 'F' {
 		return int(bi) - 'A' + 10
@@ -104,12 +104,12 @@ func as_hex(b []byte, i int) int {
 }
 
 // Check if the character is ASCII.
-func is_ascii(b []byte, i int) bool {
+func isAscii(b []byte, i int) bool {
 	return b[i] <= 0x7F
 }
 
 // Check if the character at the start of the buffer can be printed unescaped.
-func is_printable(b []byte, i int) bool {
+func isPrintable(b []byte, i int) bool {
 	return ((b[i] == 0x0A) || // . == #x0A
 		(b[i] >= 0x20 && b[i] <= 0x7E) || // #x20 <= . <= #x7E
 		(b[i] == 0xC2 && b[i+1] >= 0xA0) || // #0xA0 <= . <= #xD7FF
@@ -122,33 +122,33 @@ func is_printable(b []byte, i int) bool {
 }
 
 // Check if the character at the specified position is NUL.
-func is_z(b []byte, i int) bool {
+func isZ(b []byte, i int) bool {
 	return b[i] == 0x00
 }
 
 // Check if the beginning of the buffer is a BOM.
-func is_bom(b []byte, i int) bool {
+func isBOM(b []byte, i int) bool {
 	return b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF
 }
 
 // Check if the character at the specified position is space.
-func is_space(b []byte, i int) bool {
+func isSpace(b []byte, i int) bool {
 	return b[i] == ' '
 }
 
 // Check if the character at the specified position is tab.
-func is_tab(b []byte, i int) bool {
+func isTab(b []byte, i int) bool {
 	return b[i] == '\t'
 }
 
 // Check if the character at the specified position is blank (space or tab).
-func is_blank(b []byte, i int) bool {
+func isBlank(b []byte, i int) bool {
 	//return is_space(b, i) || is_tab(b, i)
 	return b[i] == ' ' || b[i] == '\t'
 }
 
 // Check if the character at the specified position is a line break.
-func is_break(b []byte, i int) bool {
+func isBreak(b []byte, i int) bool {
 	return (b[i] == '\r' || // CR (#xD)
 		b[i] == '\n' || // LF (#xA)
 		b[i] == 0xC2 && b[i+1] == 0x85 || // NEL (#x85)
@@ -156,12 +156,12 @@ func is_break(b []byte, i int) bool {
 		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA9) // PS (#x2029)
 }
 
-func is_crlf(b []byte, i int) bool {
+func isCRLF(b []byte, i int) bool {
 	return b[i] == '\r' && b[i+1] == '\n'
 }
 
 // Check if the character is a line break or NUL.
-func is_breakz(b []byte, i int) bool {
+func isBreakz(b []byte, i int) bool {
 	//return is_break(b, i) || is_z(b, i)
 	return (
 	// is_break:
@@ -175,7 +175,7 @@ func is_breakz(b []byte, i int) bool {
 }
 
 // Check if the character is a line break, space, or NUL.
-func is_spacez(b []byte, i int) bool {
+func isSpacez(b []byte, i int) bool {
 	//return is_space(b, i) || is_breakz(b, i)
 	return (
 	// is_space:
@@ -190,7 +190,7 @@ func is_spacez(b []byte, i int) bool {
 }
 
 // Check if the character is a line break, space, tab, or NUL.
-func is_blankz(b []byte, i int) bool {
+func isBlankz(b []byte, i int) bool {
 	//return is_blank(b, i) || is_breakz(b, i)
 	return (
 	// is_blank:


### PR DESCRIPTION
Similar to https://github.com/yaml/go-yaml/pull/80, trying to make the code a bit less scary for Go developers.

The PR includes the following type of diffs:
```diff
-func yaml_insert_token(parser *yamlParser, pos int, token *yamlToken) {
+func (parser *yamlParser) insertToken(pos int, token *yamlToken) {
```
^^ also dropped the `yaml_` prefix in the name

```diff
-func yaml_parser_initialize(parser *yamlParser) bool {
+func (parser *yamlParser) initialize() bool {
```
^^ also dropped the `yaml_parser_` prefix in the name

```diff
-func yaml_string_read_handler(parser *yamlParser, buffer []byte) (n int, err error) {
+func yamlStringReadHandler(parser *yamlParser, buffer []byte) (n int, err error) {
```

```diff
-func flush(emitter *yamlEmitter) bool {
+func (emitter *yamlEmitter) flushIfNeeded() bool {
```
^^ renamed the function due to a naming conflict
