### PR TITLE
Enable almost all govet rules in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,11 @@ linters:
       allow-unused: false
       require-specific: true
       require-explanation: true
+    govet:
+      enable-all: true
+      disable:
+      - fieldalignment
+      - shadow
 
 formatters:
   enable:


### PR DESCRIPTION
govet is a powerful linter, unfortunately most rules are not enabled
by default.

The code quality in our project is good enough that we can enable almost
all govet rules without changes.
