### PR TITLE
Enable misspell, dupword, and nolintlint linter rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
   - dupword
   - govet
   - misspell
+  - nolintlint
   disable:
   - errcheck
   - ineffassign
@@ -25,6 +26,10 @@ linters:
       - BLOCK-END
     misspell:
       locale: US
+    nolintlint:
+      allow-unused: false
+      require-specific: true
+      require-explanation: true
 
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,8 @@ linters:
       - 'NULL'
       - DOCUMENT-START
       - BLOCK-END
+    misspell:
+      locale: US
 
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,7 @@ linters:
   enable:
   - dupword
   - govet
+  - misspell
   disable:
   - errcheck
   - ineffassign

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@ version: '2'
 
 linters:
   enable:
+  - dupword
   - govet
   disable:
   - errcheck
@@ -15,6 +16,12 @@ linters:
     - common-false-positives
     - legacy
     - std-error-handling
+  settings:
+    dupword:
+      ignore:
+      - 'NULL'
+      - DOCUMENT-START
+      - BLOCK-END
 
 formatters:
   enable:

--- a/decode_test.go
+++ b/decode_test.go
@@ -913,7 +913,7 @@ func TestDecoderSingleDocument(t *testing.T) {
 	for i, item := range unmarshalTests {
 		t.Run(fmt.Sprintf("test %d: %q", i, item.data), func(t *testing.T) {
 			if item.data == "" {
-				// Behaviour differs when there's no YAML.
+				// Behavior differs when there's no YAML.
 				return
 			}
 			typ := reflect.ValueOf(item.value).Type()

--- a/emitterc.go
+++ b/emitterc.go
@@ -744,7 +744,7 @@ func (emitter *yamlEmitter) emitFlowMappingValue(event *yamlEvent, simple bool) 
 func (emitter *yamlEmitter) emitBlockSequenceItem(event *yamlEvent, first bool) bool {
 	if first {
 		// emitter.mapping context tells us if we are currently in a mapping context.
-		// emiiter.column tells us which column we are in the yaml output. 0 is the first char of the column.
+		// emitter.column tells us which column we are in the yaml output. 0 is the first char of the column.
 		// emitter.indentation tells us if the last character was an indentation character.
 		// emitter.compact_sequence_indent tells us if '- ' is considered part of the indentation for sequence elements.
 		// So, `seq` means that we are in a mapping context, and we are either at the first char of the column or

--- a/emitterc.go
+++ b/emitterc.go
@@ -744,7 +744,7 @@ func (emitter *yamlEmitter) emitFlowMappingValue(event *yamlEvent, simple bool) 
 func (emitter *yamlEmitter) emitBlockSequenceItem(event *yamlEvent, first bool) bool {
 	if first {
 		// emitter.mapping context tells us if we are currently in a mapping context.
-		// emiiter.column tells us which column we are in in the yaml output. 0 is the first char of the column.
+		// emiiter.column tells us which column we are in the yaml output. 0 is the first char of the column.
 		// emitter.indentation tells us if the last character was an indentation character.
 		// emitter.compact_sequence_indent tells us if '- ' is considered part of the indentation for sequence elements.
 		// So, `seq` means that we are in a mapping context, and we are either at the first char of the column or

--- a/encode.go
+++ b/encode.go
@@ -289,7 +289,7 @@ func (e *encoder) slicev(tag string, in reflect.Value) {
 // isBase60 returns whether s is in base 60 notation as defined in YAML 1.1.
 //
 // The base 60 float notation in YAML 1.1 is a terrible idea and is unsupported
-// in YAML 1.2 and by this package, but these should be marshalled quoted for
+// in YAML 1.2 and by this package, but these should be marshaled quoted for
 // the time being for compatibility with other parsers.
 func isBase60Float(s string) (result bool) {
 	// Fast path.
@@ -311,7 +311,7 @@ var base60float = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+(?:\.[0
 // isOldBool returns whether s is bool notation as defined in YAML 1.1.
 //
 // We continue to force strings that YAML 1.1 would interpret as booleans to be
-// rendered as quotes strings so that the marshalled output valid for YAML 1.1
+// rendered as quotes strings so that the marshaled output valid for YAML 1.1
 // parsing.
 func isOldBool(s string) (result bool) {
 	switch s {

--- a/encode_test.go
+++ b/encode_test.go
@@ -581,6 +581,7 @@ var marshalErrorTests = []struct {
 		B       int
 		inlineB `yaml:",inline"`
 	}{1, inlineB{2, inlineC{3}}},
+	//nolint:dupword // struct is duplicated here as the first one is the struct and the second is the name of the inline struct
 	panic: `duplicated key 'b' in struct struct \{ B int; .*`,
 }, {
 	value: &struct {

--- a/yaml.go
+++ b/yaml.go
@@ -71,7 +71,7 @@ type Marshaler interface {
 // lowercased as the default key. Custom keys may be defined via the
 // "yaml" name in the field tag: the content preceding the first comma
 // is used as the key, and the following comma-separated options are
-// used to tweak the marshalling process (see Marshal).
+// used to tweak the marshaling process (see Marshal).
 // Conflicting names result in a runtime error.
 //
 // For example:
@@ -176,11 +176,11 @@ func unmarshal(in []byte, out any, strict bool) (err error) {
 // of the generated document will reflect the structure of the value itself.
 // Maps and pointers (to struct, string, int, etc) are accepted as the in value.
 //
-// Struct fields are only marshalled if they are exported (have an upper case
-// first letter), and are marshalled using the field name lowercased as the
+// Struct fields are only marshaled if they are exported (have an upper case
+// first letter), and are marshaled using the field name lowercased as the
 // default key. Custom keys may be defined via the "yaml" name in the field
 // tag: the content preceding the first comma is used as the key, and the
-// following comma-separated options are used to tweak the marshalling process.
+// following comma-separated options are used to tweak the marshaling process.
 // Conflicting names result in a runtime error.
 //
 // The field tag format accepted is:


### PR DESCRIPTION
- **Enable dupwords in golangci-lint**
- **Enable misspell linter in golangci-lint configuration**
- **Configure misspell linter to use American English**
- **Enable nolintlint linter in golangci**
