### PR TITLE
Replace `reflect.Ptr` with `reflect.Pointer`

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -417,7 +417,7 @@ func (d *decoder) prepare(n *Node, out reflect.Value) (newout reflect.Value, unm
 	again := true
 	for again {
 		again = false
-		if out.Kind() == reflect.Ptr {
+		if out.Kind() == reflect.Pointer {
 			if out.IsNil() {
 				out.Set(reflect.New(out.Type().Elem()))
 			}
@@ -445,7 +445,7 @@ func (d *decoder) fieldByIndex(n *Node, v reflect.Value, index []int) (field ref
 	}
 	for _, num := range index {
 		for {
-			if v.Kind() == reflect.Ptr {
+			if v.Kind() == reflect.Pointer {
 				if v.IsNil() {
 					v.Set(reflect.New(v.Type().Elem()))
 				}
@@ -553,7 +553,7 @@ func (d *decoder) alias(n *Node, out reflect.Value) (good bool) {
 func (d *decoder) null(out reflect.Value) bool {
 	if out.CanAddr() {
 		switch out.Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+		case reflect.Interface, reflect.Pointer, reflect.Map, reflect.Slice:
 			out.Set(reflect.Zero(out.Type()))
 			return true
 		}
@@ -716,7 +716,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 			out.Set(resolvedv)
 			return true
 		}
-	case reflect.Ptr:
+	case reflect.Pointer:
 		panic("yaml internal error: please report the issue")
 	}
 	d.terror(n, tag, out)

--- a/encode.go
+++ b/encode.go
@@ -112,7 +112,7 @@ func (e *encoder) marshalDoc(tag string, in reflect.Value) {
 
 func (e *encoder) marshal(tag string, in reflect.Value) {
 	tag = shortTag(tag)
-	if !in.IsValid() || in.Kind() == reflect.Ptr && in.IsNil() {
+	if !in.IsValid() || in.Kind() == reflect.Pointer && in.IsNil() {
 		e.nilv()
 		return
 	}
@@ -164,7 +164,7 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 		e.marshal(tag, in.Elem())
 	case reflect.Map:
 		e.mapv(tag, in)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		e.marshal(tag, in.Elem())
 	case reflect.Struct:
 		e.structv(tag, in)
@@ -199,7 +199,7 @@ func (e *encoder) mapv(tag string, in reflect.Value) {
 func (e *encoder) fieldByIndex(v reflect.Value, index []int) (field reflect.Value) {
 	for _, num := range index {
 		for {
-			if v.Kind() == reflect.Ptr {
+			if v.Kind() == reflect.Pointer {
 				if v.IsNil() {
 					return reflect.Value{}
 				}

--- a/internal/testutil/assert/assert.go
+++ b/internal/testutil/assert/assert.go
@@ -106,7 +106,7 @@ func ErrorAs(tb miniTB, err error, target interface{}) {
 	}
 
 	reflectedType := reflect.TypeOf(target)
-	if reflectedType.Kind() != reflect.Ptr {
+	if reflectedType.Kind() != reflect.Pointer {
 		// this is not supposed to happen with the current implementation of [errors.As]
 		tb.Fatalf("a pointer was expected: got: %s; want: ptr", reflectedType.Kind())
 		return
@@ -224,7 +224,7 @@ func isNil(v any) bool {
 	}
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice, reflect.Interface, reflect.UnsafePointer:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.Interface, reflect.UnsafePointer:
 		return rv.IsNil()
 	default:
 		return false

--- a/sorter.go
+++ b/sorter.go
@@ -29,11 +29,11 @@ func (l keyList) Less(i, j int) bool {
 	b := l[j]
 	ak := a.Kind()
 	bk := b.Kind()
-	for (ak == reflect.Interface || ak == reflect.Ptr) && !a.IsNil() {
+	for (ak == reflect.Interface || ak == reflect.Pointer) && !a.IsNil() {
 		a = a.Elem()
 		ak = a.Kind()
 	}
-	for (bk == reflect.Interface || bk == reflect.Ptr) && !b.IsNil() {
+	for (bk == reflect.Interface || bk == reflect.Pointer) && !b.IsNil() {
 		b = b.Elem()
 		bk = b.Kind()
 	}

--- a/yaml.go
+++ b/yaml.go
@@ -125,7 +125,7 @@ func (dec *Decoder) Decode(v any) (err error) {
 		return io.EOF
 	}
 	out := reflect.ValueOf(v)
-	if out.Kind() == reflect.Ptr && !out.IsNil() {
+	if out.Kind() == reflect.Pointer && !out.IsNil() {
 		out = out.Elem()
 	}
 	d.unmarshal(node, out)
@@ -143,7 +143,7 @@ func (n *Node) Decode(v any) (err error) {
 	d := newDecoder()
 	defer handleErr(&err)
 	out := reflect.ValueOf(v)
-	if out.Kind() == reflect.Ptr && !out.IsNil() {
+	if out.Kind() == reflect.Pointer && !out.IsNil() {
 		out = out.Elem()
 	}
 	d.unmarshal(n, out)
@@ -161,7 +161,7 @@ func unmarshal(in []byte, out any, strict bool) (err error) {
 	node := p.parse()
 	if node != nil {
 		v := reflect.ValueOf(out)
-		if v.Kind() == reflect.Ptr && !v.IsNil() {
+		if v.Kind() == reflect.Pointer && !v.IsNil() {
 			v = v.Elem()
 		}
 		d.unmarshal(node, v)
@@ -675,15 +675,15 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					return nil, errors.New("option ,inline needs a map with string keys in struct " + st.String())
 				}
 				inlineMap = info.Num
-			case reflect.Struct, reflect.Ptr:
+			case reflect.Struct, reflect.Pointer:
 				ftype := field.Type
-				for ftype.Kind() == reflect.Ptr {
+				for ftype.Kind() == reflect.Pointer {
 					ftype = ftype.Elem()
 				}
 				if ftype.Kind() != reflect.Struct {
 					return nil, errors.New("option ,inline may only be used on a struct or map field")
 				}
-				if reflect.PtrTo(ftype).Implements(unmarshalerType) {
+				if reflect.PointerTo(ftype).Implements(unmarshalerType) {
 					inlineUnmarshalers = append(inlineUnmarshalers, []int{i})
 				} else {
 					sinfo, err := getStructInfo(ftype)
@@ -754,7 +754,7 @@ type IsZeroer interface {
 func isZero(v reflect.Value) bool {
 	kind := v.Kind()
 	if z, ok := v.Interface().(IsZeroer); ok {
-		if (kind == reflect.Ptr || kind == reflect.Interface) && v.IsNil() {
+		if (kind == reflect.Pointer || kind == reflect.Interface) && v.IsNil() {
 			return true
 		}
 		return z.IsZero()
@@ -762,7 +762,7 @@ func isZero(v reflect.Value) bool {
 	switch kind {
 	case reflect.String:
 		return len(v.String()) == 0
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		return v.IsNil()
 	case reflect.Slice:
 		return v.Len() == 0


### PR DESCRIPTION
`Ptr` has been deprecated and has a [gofix](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/gofix#hdr-Constants) directive to inline it to `Pointer`.

See [`Ptr`](https://cs.opensource.google/go/go/+/refs/tags/go1.18:src/reflect/type.go;l=272).

Also replace `reflect.PtrTo` with `reflect.PointerTo` for the same [reason](https://pkg.go.dev/reflect#PtrTo):

> PtrTo is the old spelling of PointerTo. The two functions behave identically.