### PR TITLE
Add file names linting to the CI

### DIFF
--- a/.github/workflows/files.yaml
+++ b/.github/workflows/files.yaml
@@ -27,6 +27,17 @@ jobs:
     - name: yamllint
       uses: ibiqlik/action-yamllint@v3
 
+  ls-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout-action
+      uses: actions/checkout@v5
+
+    - name: ls-lint
+      uses: ls-lint/action@v2
+      with:
+        config: .ls-lint.yaml
+
   typos:
     runs-on: ubuntu-latest
     steps:

--- a/.ls-lint.yaml
+++ b/.ls-lint.yaml
@@ -1,0 +1,16 @@
+# ls-lint configuration file.
+# More information on the file format can be found on https://ls-lint.org/
+ls:
+  # root directory
+  .yml: exists:0      # .yml files
+  .*.yml: exists:0    # .yml dotfiles
+
+  # any subdirectory, even dotfile directory
+  '**':
+    .yml: exists:0    # .yml files
+    .*.yml: exists:0  # .yml dotfiles
+
+ignore:
+- .git          # git folder
+- .cache        # cache folder
+- yts/testdata  # third-party folder


### PR DESCRIPTION
ls-lint is a powerful tool for linting file names.

It helps ensure that filenames follow a consistent naming convention.

Right now, we are only enforcing to disallow .yml files.
Only .yaml files are allowed.

Fixes #90 