### PR TITLE
Enable staticcheck in golangci and fix everything reported

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,18 +6,11 @@ linters:
   - govet
   - misspell
   - nolintlint
+  - staticcheck
   disable:
   - errcheck
   - ineffassign
-  - staticcheck
   - unused
-  exclusions:
-    generated: lax
-    presets:
-    - comments
-    - common-false-positives
-    - legacy
-    - std-error-handling
   settings:
     dupword:
       ignore:
@@ -35,12 +28,17 @@ linters:
       disable:
       - fieldalignment
       - shadow
+    staticcheck:
+      checks:
+      # enable all rules
+      - all
+      # disable some of them
+      - -QF1001  # De Morgan's laws is too opinionated.
+      - -ST1003  # The codebase has too many underscores in identifiers for now.
 
 formatters:
   enable:
   - gofumpt
-  exclusions:
-    generated: lax
 
 issues:
   max-issues-per-linter: 0

--- a/apic.go
+++ b/apic.go
@@ -363,8 +363,8 @@ func newMappingEndEvent() yamlEvent {
 }
 
 // Destroy an event object.
-func (event *yamlEvent) delete() {
-	*event = yamlEvent{}
+func (e *yamlEvent) delete() {
+	*e = yamlEvent{}
 }
 
 ///*

--- a/decode_test.go
+++ b/decode_test.go
@@ -1515,12 +1515,12 @@ func TestObsoleteUnmarshalerTypeErrorProxying(t *testing.T) {
 	assert.ErrorMatches(t, expectedError, err)
 }
 
-var failingErr = errors.New("failingErr")
+var errFailing = errors.New("failingErr")
 
 type failingUnmarshaler struct{}
 
 func (ft *failingUnmarshaler) UnmarshalYAML(node *yaml.Node) error {
-	return failingErr
+	return errFailing
 }
 
 func TestUnmarshalerError(t *testing.T) {
@@ -1533,7 +1533,7 @@ func TestUnmarshalerError(t *testing.T) {
 	err := yaml.Unmarshal([]byte(data), &dst)
 	expectedErr := &yaml.TypeError{
 		Errors: []*yaml.UnmarshalError{
-			{Line: 1, Column: 17, Err: failingErr},
+			{Line: 1, Column: 17, Err: errFailing},
 		},
 	}
 	assert.DeepEqual(t, expectedErr, err)
@@ -1546,7 +1546,7 @@ func TestUnmarshalerError(t *testing.T) {
 type obsoleteFailingUnmarshaler struct{}
 
 func (ft *obsoleteFailingUnmarshaler) UnmarshalYAML(unmarshal func(any) error) error {
-	return failingErr
+	return errFailing
 }
 
 func TestObsoleteUnmarshalerError(t *testing.T) {
@@ -1559,7 +1559,7 @@ func TestObsoleteUnmarshalerError(t *testing.T) {
 	err := yaml.Unmarshal([]byte(data), &dst)
 	expectedErr := &yaml.TypeError{
 		Errors: []*yaml.UnmarshalError{
-			{Line: 1, Column: 17, Err: failingErr},
+			{Line: 1, Column: 17, Err: errFailing},
 		},
 	}
 	assert.DeepEqual(t, expectedErr, err)
@@ -1574,7 +1574,7 @@ type failingTextUnmarshaler struct{}
 var _ encoding.TextUnmarshaler = &failingTextUnmarshaler{}
 
 func (ft *failingTextUnmarshaler) UnmarshalText(b []byte) error {
-	return failingErr
+	return errFailing
 }
 
 func TestTextUnmarshalerError(t *testing.T) {
@@ -1587,7 +1587,7 @@ func TestTextUnmarshalerError(t *testing.T) {
 	err := yaml.Unmarshal([]byte(data), &dst)
 	expectedErr := &yaml.TypeError{
 		Errors: []*yaml.UnmarshalError{
-			{Line: 1, Column: 17, Err: failingErr},
+			{Line: 1, Column: 17, Err: errFailing},
 		},
 	}
 	assert.DeepEqual(t, expectedErr, err)
@@ -1871,8 +1871,8 @@ var unmarshalNullTests = []struct {
 	pristine, expected func() any
 }{{
 	"null",
-	func() any { var v any; v = "v"; return &v },
-	func() any { var v any; v = nil; return &v },
+	func() any { var v any = "v"; return &v },
+	func() any { var v any = nil; return &v },
 }, {
 	"null",
 	func() any { s := "s"; return &s },

--- a/encode_test.go
+++ b/encode_test.go
@@ -732,12 +732,12 @@ func TestMarshalerWholeDocument(t *testing.T) {
 type failingMarshaler struct{}
 
 func (ft *failingMarshaler) MarshalYAML() (any, error) {
-	return nil, failingErr
+	return nil, errFailing
 }
 
 func TestMarshalerError(t *testing.T) {
 	_, err := yaml.Marshal(&failingMarshaler{})
-	assert.ErrorIs(t, failingErr, err)
+	assert.ErrorIs(t, errFailing, err)
 }
 
 func TestSetIndent(t *testing.T) {

--- a/internal/testutil/assert/assert.go
+++ b/internal/testutil/assert/assert.go
@@ -1,3 +1,7 @@
+// Package assert provides assertion functions for tests.
+// This is an internal package that was created to provide a simple way to write tests.
+//
+// The idea was to do not add a dependency on a testing framework.
 package assert
 
 import (
@@ -21,12 +25,17 @@ func formatSuffix(msgFormat string, args ...any) string {
 	return " - " + fmt.Sprintf(msgFormat, args...)
 }
 
-// Comparable types (numbers, strings, pointers to the same object, etc.).
+// Equal asserts that two values are equal.
+//
+// It can be used with comparable types: numbers, strings, pointers to the same object, etc.
+//
+// For any other types, use [DeepEqual].
 func Equal(tb miniTB, want, got any) {
 	tb.Helper()
 	Equalf(tb, want, got, "")
 }
 
+// Equalf asserts that two values are equal, and reports a message if they are not.
 func Equalf(tb miniTB, want, got any, msgFormat string, args ...any) {
 	tb.Helper()
 	if got != want {
@@ -35,12 +44,17 @@ func Equalf(tb miniTB, want, got any, msgFormat string, args ...any) {
 	}
 }
 
-// Anything else (slices, maps, structs with slices...).
+// DeepEqual asserts that two values are deeply equal.
+//
+// It can be used with slices, maps, structs with slices...
+//
+// Please consider [Equal] for other types.
 func DeepEqual(tb miniTB, want, got any) {
 	tb.Helper()
 	DeepEqualf(tb, want, got, "")
 }
 
+// DeepEqualf asserts that two values are deeply equal, and reports a message if they are not.
 func DeepEqualf(tb miniTB, want, got any, msgFormat string, args ...any) {
 	tb.Helper()
 	if !reflect.DeepEqual(got, want) {
@@ -49,11 +63,13 @@ func DeepEqualf(tb miniTB, want, got any, msgFormat string, args ...any) {
 	}
 }
 
+// ErrorMatches asserts that an error matches a regular expression.
 func ErrorMatches(tb miniTB, pattern string, err error) {
 	tb.Helper()
 	ErrorMatchesf(tb, pattern, err, "")
 }
 
+// ErrorMatchesf asserts that an error matches a regular expression, and reports a message if it does not.
 func ErrorMatchesf(tb miniTB, pattern string, err error, msgFormat string, args ...any) {
 	tb.Helper()
 	if err == nil {
@@ -73,6 +89,7 @@ func ErrorMatchesf(tb miniTB, pattern string, err error, msgFormat string, args 
 	}
 }
 
+// ErrorIs asserts that two errors are equal by using [errors.Is].
 func ErrorIs(tb miniTB, got, want error) {
 	tb.Helper()
 	if !errors.Is(got, want) {
@@ -80,7 +97,7 @@ func ErrorIs(tb miniTB, got, want error) {
 	}
 }
 
-// errorAsNoPanic calls errors.As, but catch possible panic and returns it as an error
+// errorAsNoPanic calls [errors.As], but catch possible panic and returns it as an error
 func errorAsNoPanic(tb miniTB, err error, target interface{}) (ok bool, panic error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -93,6 +110,7 @@ func errorAsNoPanic(tb miniTB, err error, target interface{}) (ok bool, panic er
 	return errors.As(err, target), nil
 }
 
+// ErrorAs asserts that an error can be assigned to a target variable by using [errors.As].
 func ErrorAs(tb miniTB, err error, target interface{}) {
 	tb.Helper()
 
@@ -115,11 +133,13 @@ func ErrorAs(tb miniTB, err error, target interface{}) {
 	tb.Fatalf("got %#v; want %s", err, reflectedType.Elem())
 }
 
+// NoError asserts that an error is nil.
 func NoError(tb miniTB, err error) {
 	tb.Helper()
 	NoErrorf(tb, err, "")
 }
 
+// NoErrorf asserts that an error is nil, and reports a message if it is not.
 func NoErrorf(tb miniTB, err error, msgFormat string, args ...any) {
 	tb.Helper()
 	if err != nil {
@@ -128,11 +148,13 @@ func NoErrorf(tb miniTB, err error, msgFormat string, args ...any) {
 	}
 }
 
+// IsNil asserts that a value is nil.
 func IsNil(tb miniTB, v any) {
 	tb.Helper()
 	IsNilf(tb, v, "")
 }
 
+// IsNilf asserts that a value is nil, and reports a message if it is not.
 func IsNilf(tb miniTB, v any, msgFormat string, args ...any) {
 	tb.Helper()
 	if !isNil(v) {
@@ -141,11 +163,13 @@ func IsNilf(tb miniTB, v any, msgFormat string, args ...any) {
 	}
 }
 
+// NotNil asserts that a value is not nil.
 func NotNil(tb miniTB, v any) {
 	tb.Helper()
 	NotNilf(tb, v, "")
 }
 
+// NotNilf asserts that a value is not nil, and reports a message if it is.
 func NotNilf(tb miniTB, v any, msgFormat string, args ...any) {
 	tb.Helper()
 	if isNil(v) {
@@ -154,11 +178,13 @@ func NotNilf(tb miniTB, v any, msgFormat string, args ...any) {
 	}
 }
 
+// True asserts that a value is true.
 func True(tb miniTB, got bool) {
 	tb.Helper()
 	Truef(tb, got, "")
 }
 
+// Truef asserts that a value is true, and reports a message if it is not.
 func Truef(tb miniTB, got bool, msgFormat string, args ...any) {
 	tb.Helper()
 	if !got {
@@ -167,11 +193,13 @@ func Truef(tb miniTB, got bool, msgFormat string, args ...any) {
 	}
 }
 
+// False asserts that a value is false.
 func False(tb miniTB, got bool) {
 	tb.Helper()
 	Falsef(tb, got, "")
 }
 
+// Falsef asserts that a value is false, and reports a message if it is not.
 func Falsef(tb miniTB, got bool, msgFormat string, args ...any) {
 	tb.Helper()
 	if got {
@@ -180,11 +208,14 @@ func Falsef(tb miniTB, got bool, msgFormat string, args ...any) {
 	}
 }
 
+// PanicMatches asserts that a function panics with a message matching the given pattern.
 func PanicMatches(tb miniTB, pattern string, f func()) {
 	tb.Helper()
 	PanicMatchesf(tb, pattern, f, "")
 }
 
+// PanicMatchesf asserts that a function panics with a message matching the given pattern,
+// and reports a message if it does not.
 func PanicMatchesf(tb miniTB, pattern string, f func(), msgFormat string, args ...any) {
 	tb.Helper()
 	var pan any

--- a/node_test.go
+++ b/node_test.go
@@ -3018,7 +3018,7 @@ func TestNodeZeroEncodeDecode(t *testing.T) {
 	assert.Equal(t, "null\n", string(data))
 
 	// ... and decoding.
-	var v *struct{} = &struct{}{}
+	v := &struct{}{}
 	err = n.Decode(&v)
 	assert.NoError(t, err)
 	assert.IsNil(t, v)

--- a/parserc.go
+++ b/parserc.go
@@ -495,7 +495,8 @@ func (parser *yamlParser) parseNode(event *yamlEvent, block, indentless_sequence
 	var tag_token bool
 	var tag_handle, tag_suffix, anchor []byte
 	var tag_mark yamlMark
-	if token.typ == yaml_ANCHOR_TOKEN {
+	switch token.typ {
+	case yaml_ANCHOR_TOKEN:
 		anchor = token.value
 		start_mark = token.start_mark
 		end_mark = token.end_mark
@@ -516,7 +517,7 @@ func (parser *yamlParser) parseNode(event *yamlEvent, block, indentless_sequence
 				return false
 			}
 		}
-	} else if token.typ == yaml_TAG_TOKEN {
+	case yaml_TAG_TOKEN:
 		tag_token = true
 		tag_handle = token.value
 		tag_suffix = token.suffix
@@ -856,7 +857,8 @@ func (parser *yamlParser) parseBlockMappingKey(event *yamlEvent, first bool) boo
 		return true
 	}
 
-	if token.typ == yaml_KEY_TOKEN {
+	switch token.typ {
+	case yaml_KEY_TOKEN:
 		mark := token.end_mark
 		parser.skipToken()
 		token = parser.peekToken()
@@ -872,7 +874,7 @@ func (parser *yamlParser) parseBlockMappingKey(event *yamlEvent, first bool) boo
 			parser.state = yaml_PARSE_BLOCK_MAPPING_VALUE_STATE
 			return parser.processEmptyScalar(event, mark)
 		}
-	} else if token.typ == yaml_BLOCK_END_TOKEN {
+	case yaml_BLOCK_END_TOKEN:
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
 		parser.marks = parser.marks[:len(parser.marks)-1]
@@ -1197,7 +1199,8 @@ func (parser *yamlParser) processDirectives(version_directive_ref **yamlVersionD
 	}
 
 	for token.typ == yaml_VERSION_DIRECTIVE_TOKEN || token.typ == yaml_TAG_DIRECTIVE_TOKEN {
-		if token.typ == yaml_VERSION_DIRECTIVE_TOKEN {
+		switch token.typ {
+		case yaml_VERSION_DIRECTIVE_TOKEN:
 			if version_directive != nil {
 				parser.setParserError(
 					"found duplicate %YAML directive", token.start_mark)
@@ -1212,7 +1215,7 @@ func (parser *yamlParser) processDirectives(version_directive_ref **yamlVersionD
 				major: token.major,
 				minor: token.minor,
 			}
-		} else if token.typ == yaml_TAG_DIRECTIVE_TOKEN {
+		case yaml_TAG_DIRECTIVE_TOKEN:
 			value := yamlTagDirective{
 				handle: token.value,
 				prefix: token.prefix,

--- a/readerc.go
+++ b/readerc.go
@@ -120,6 +120,8 @@ func (parser *yamlParser) updateBuffer(length int) bool {
 	// for that to be the case, and there are tests
 
 	// If the EOF flag is set and the raw buffer is empty, do nothing.
+	//
+	//nolint:staticcheck // there is no problem with this empty branch as it's documentation.
 	if parser.eof && parser.raw_buffer_pos == len(parser.raw_buffer) {
 		// [Go] ACTUALLY! Read the documentation of this function above.
 		// This is just broken. To return true, we need to have the

--- a/resolve.go
+++ b/resolve.go
@@ -198,7 +198,7 @@ func resolve(tag string, in string) (rtag string, out any) {
 				}
 			}
 
-			plain := strings.Replace(in, "_", "", -1)
+			plain := strings.ReplaceAll(in, "_", "")
 			intv, err := strconv.ParseInt(plain, 0, 64)
 			if err == nil {
 				if intv == int64(int(intv)) {

--- a/scannerc.go
+++ b/scannerc.go
@@ -1294,7 +1294,8 @@ func (parser *yamlParser) fetchBlockEntry() bool {
 		if !parser.rollIndent(parser.mark.column, -1, yaml_BLOCK_SEQUENCE_START_TOKEN, parser.mark) {
 			return false
 		}
-	} else {
+	} else { //nolint:staticcheck // there is no problem with this empty branch as it's documentation.
+
 		// It is an error for the '-' indicator to occur in the flow context,
 		// but we let the Parser detect and report about it because the Parser
 		// is able to point to the context.

--- a/yaml.go
+++ b/yaml.go
@@ -641,7 +641,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		info := fieldInfo{Num: i}
 
 		tag := field.Tag.Get("yaml")
-		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
+		if tag == "" && !strings.Contains(string(field.Tag), ":") {
 			tag = string(field.Tag)
 		}
 		if tag == "-" {
@@ -660,7 +660,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 				case "inline":
 					inline = true
 				default:
-					return nil, errors.New(fmt.Sprintf("unsupported flag %q in tag %q of type %s", flag, tag, st))
+					return nil, fmt.Errorf("unsupported flag %q in tag %q of type %s", flag, tag, st)
 				}
 			}
 			tag = fields[0]


### PR DESCRIPTION
- **Enable staticcheck in golangci-lint**
- **Fix code according to staticcheck**
- **Fix code according to staticcheck**
- **Remove golangci-lint v1 default exclusions**
- **Fix all remaining staticcheck errors**
- **Add missing go doc to asserters**

This PR supersedes and replaces #29 that was left unfinished and was partially addressing staticcheck issues.

Closes #29 

- #29 