### PR TITLE
Fixes #70 with go-version-action

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -40,7 +40,6 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-versions }}
-        check-latest: true
     - name: Run go vet
       run: go vet ./...
     - name: Run yaml-test-suit tests


### PR DESCRIPTION
Based on feedback in #116, this _only_ adds the `go-version-action` action to test across multiple versions of Go more dynamically. It introduces no additional changes that existed in #116. If this were to be merged, I'd be happy to iterate on this further in additional PRs after further discussion and agreement in doing so. Thanks again for your time.