### PR TITLE
Improve empty document handling

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -160,6 +160,15 @@ func (p *parser) parse() *Node {
 		return p.document()
 	case libyaml.STREAM_END_EVENT:
 		// Happens when attempting to decode an empty buffer.
+		if len(p.event.HeadComment) > 0 {
+			// The buffer is empty, but there is a comment.
+			// Create a document node which contains this comment.
+			// Without this, the comment would get lost since
+			// Node.Decode() would simply return io.EOF.
+			n := p.node(DocumentNode, "", "", "")
+			p.event.HeadComment = nil
+			return n
+		}
 		return nil
 	case libyaml.TAIL_COMMENT_EVENT:
 		panic("internal error: unexpected tail comment event (please report)")

--- a/decode_test.go
+++ b/decode_test.go
@@ -1102,6 +1102,244 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
+var decoderNodeTests = []struct {
+	data  string
+	nodes []*yaml.Node
+}{
+	{
+		"# foo\nkey: value\n",
+		[]*yaml.Node{
+			{
+				Kind:   yaml.DocumentNode,
+				Line:   2,
+				Column: 1,
+				Content: []*yaml.Node{{
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   2,
+					Column: 1,
+					Content: []*yaml.Node{{
+						Kind:        yaml.ScalarNode,
+						Value:       "key",
+						Tag:         "!!str",
+						Line:        2,
+						Column:      1,
+						HeadComment: "# foo",
+					}, {
+						Kind:   yaml.ScalarNode,
+						Value:  "value",
+						Tag:    "!!str",
+						Line:   2,
+						Column: 6,
+					}},
+				}},
+			},
+		},
+	},
+	{
+		"# foo\n---\n# bar\n---\nkey: value\n",
+		[]*yaml.Node{
+			{
+				Kind:        yaml.DocumentNode,
+				Line:        2,
+				Column:      1,
+				HeadComment: "# foo",
+				FootComment: "# bar",
+				Content: []*yaml.Node{{
+					Kind:   yaml.ScalarNode,
+					Value:  "",
+					Tag:    "!!null",
+					Line:   4,
+					Column: 1,
+				}},
+			}, {
+				Kind:   yaml.DocumentNode,
+				Line:   4,
+				Column: 1,
+				Content: []*yaml.Node{{
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   5,
+					Column: 1,
+					Content: []*yaml.Node{{
+						Kind:   yaml.ScalarNode,
+						Value:  "key",
+						Tag:    "!!str",
+						Line:   5,
+						Column: 1,
+					}, {
+						Kind:   yaml.ScalarNode,
+						Value:  "value",
+						Tag:    "!!str",
+						Line:   5,
+						Column: 6,
+					}},
+				}},
+			},
+		},
+	},
+	{
+		"# foo\n",
+		[]*yaml.Node{
+			{
+				Kind:        yaml.DocumentNode,
+				Line:        2,
+				Column:      1,
+				HeadComment: "# foo",
+			},
+		},
+	},
+	{
+		"# foo\n---\n",
+		[]*yaml.Node{
+			{
+				Kind:        yaml.DocumentNode,
+				Line:        2,
+				Column:      1,
+				HeadComment: "# foo",
+				Content: []*yaml.Node{{
+					Kind:   yaml.ScalarNode,
+					Tag:    "!!null",
+					Value:  "",
+					Line:   3,
+					Column: 1,
+				}},
+			},
+		},
+	},
+	{
+		"# foo\n---\nkey: value\n",
+		[]*yaml.Node{
+			{
+				Kind:        yaml.DocumentNode,
+				Line:        2,
+				Column:      1,
+				HeadComment: "# foo",
+				Content: []*yaml.Node{{
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   3,
+					Column: 1,
+					Content: []*yaml.Node{{
+						Kind:   yaml.ScalarNode,
+						Value:  "key",
+						Tag:    "!!str",
+						Line:   3,
+						Column: 1,
+					}, {
+						Kind:   yaml.ScalarNode,
+						Value:  "value",
+						Tag:    "!!str",
+						Line:   3,
+						Column: 6,
+					}},
+				}},
+			},
+		},
+	},
+	{
+		"# foo\n---\n# bar\nkey: value\n",
+		[]*yaml.Node{
+			{
+				Kind:        yaml.DocumentNode,
+				Line:        2,
+				Column:      1,
+				HeadComment: "# foo",
+				Content: []*yaml.Node{{
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   4,
+					Column: 1,
+					Content: []*yaml.Node{{
+						Kind:        yaml.ScalarNode,
+						Value:       "key",
+						Tag:         "!!str",
+						Line:        4,
+						Column:      1,
+						HeadComment: "# bar",
+					}, {
+						Kind:   yaml.ScalarNode,
+						Value:  "value",
+						Tag:    "!!str",
+						Line:   4,
+						Column: 6,
+					}},
+				}},
+			},
+		},
+	},
+	{
+		"key: value\n\n# foo\n---\nkey: value\n",
+		[]*yaml.Node{
+			{
+				Kind:        yaml.DocumentNode,
+				Line:        1,
+				Column:      1,
+				FootComment: "# foo",
+				Content: []*yaml.Node{{
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   1,
+					Column: 1,
+					Content: []*yaml.Node{{
+						Kind:   yaml.ScalarNode,
+						Value:  "key",
+						Tag:    "!!str",
+						Line:   1,
+						Column: 1,
+					}, {
+						Kind:   yaml.ScalarNode,
+						Value:  "value",
+						Tag:    "!!str",
+						Line:   1,
+						Column: 6,
+					}},
+				}},
+			}, {
+				Kind:   yaml.DocumentNode,
+				Line:   4,
+				Column: 1,
+				Content: []*yaml.Node{{
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   5,
+					Column: 1,
+					Content: []*yaml.Node{{
+						Kind:   yaml.ScalarNode,
+						Value:  "key",
+						Tag:    "!!str",
+						Line:   5,
+						Column: 1,
+					}, {
+						Kind:   yaml.ScalarNode,
+						Value:  "value",
+						Tag:    "!!str",
+						Line:   5,
+						Column: 6,
+					}},
+				}},
+			},
+		},
+	},
+}
+
+func TestDecoderNodes(t *testing.T) {
+	for i, item := range decoderNodeTests {
+		var nodes []*yaml.Node
+		d := yaml.NewDecoder(bytes.NewReader([]byte(item.data)))
+		for {
+			node := &yaml.Node{}
+			err := d.Decode(node)
+			if err == io.EOF {
+				break
+			}
+			assert.NoError(t, err)
+			nodes = append(nodes, node)
+		}
+		assert.DeepEqualf(t, nodes, item.nodes, "test %d failed: %q", i, item.data)
+	}
+}
+
 type errReader struct{}
 
 func (errReader) Read([]byte) (int, error) {

--- a/internal/libyaml/emitter.go
+++ b/internal/libyaml/emitter.go
@@ -361,6 +361,7 @@ func (emitter *Emitter) emitStreamStart(event *Event) error {
 // Expect DOCUMENT-START or STREAM-END.
 func (emitter *Emitter) emitDocumentStart(event *Event, first bool) error {
 	if event.Type == DOCUMENT_START_EVENT {
+		isEmpty := emitter.events_head+1 < len(emitter.events) && emitter.events[emitter.events_head+1].Type == DOCUMENT_END_EVENT
 
 		if event.version_directive != nil {
 			if err := emitter.analyzeVersionDirective(event.version_directive); err != nil {
@@ -452,12 +453,19 @@ func (emitter *Emitter) emitDocumentStart(event *Event, first bool) error {
 			if err := emitter.processHeadComment(); err != nil {
 				return err
 			}
-			if err := emitter.putLineBreak(); err != nil {
-				return err
+			if !isEmpty {
+				if err := emitter.putLineBreak(); err != nil {
+					return err
+				}
 			}
 		}
 
 		emitter.state = EMIT_DOCUMENT_CONTENT_STATE
+		if isEmpty {
+			// Prevent serialization error if there is a DocumentNode with
+			// HeadComment but no content.
+			emitter.state = EMIT_DOCUMENT_END_STATE
+		}
 		return nil
 	}
 

--- a/internal/libyaml/parser.go
+++ b/internal/libyaml/parser.go
@@ -336,6 +336,8 @@ func (parser *Parser) parseDocumentStart(event *Event, implicit bool) bool {
 			tag_directives:    tag_directives,
 			Implicit:          false,
 		}
+		// Without the next line, comments before `---` would be attributed wrongly.
+		parser.setEventComments(event)
 		parser.skipToken()
 
 	} else {
@@ -346,6 +348,9 @@ func (parser *Parser) parseDocumentStart(event *Event, implicit bool) bool {
 			StartMark: token.StartMark,
 			EndMark:   token.EndMark,
 		}
+		// Without this, a document only consisting out of comments would result
+		// in no node since the comment would not be added to any event.
+		parser.setEventComments(event)
 		parser.skipToken()
 	}
 

--- a/node_test.go
+++ b/node_test.go
@@ -49,6 +49,28 @@ var nodeTests = []struct {
 		"[encode]null\n",
 		yaml.Node{},
 	}, {
+		"[decode]\n",
+		yaml.Node{
+			Kind:    0,
+			Line:    0,
+			Column:  0,
+			Content: []*yaml.Node(nil),
+		},
+	}, {
+		"[decode]---\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.ScalarNode,
+				Tag:    "!!null",
+				Value:  "",
+				Line:   2,
+				Column: 1,
+			}},
+		},
+	}, {
 		"foo\n",
 		yaml.Node{
 			Kind:   yaml.DocumentNode,
@@ -2789,6 +2811,88 @@ var nodeTests = []struct {
 						HeadComment: "# HB1\n# HB2",
 						LineComment: "# IB",
 						FootComment: "# FB1\n# FB2",
+					},
+				},
+			}},
+		},
+	}, {
+		"# foo\n",
+		yaml.Node{
+			Kind:        yaml.DocumentNode,
+			Line:        2,
+			Column:      1,
+			HeadComment: "# foo",
+			Content:     []*yaml.Node(nil),
+		},
+	}, {
+		"[decode]# foo\n---\n",
+		yaml.Node{
+			Kind:        yaml.DocumentNode,
+			Line:        2,
+			Column:      1,
+			HeadComment: "# foo",
+			Content: []*yaml.Node{{
+				Kind:   yaml.ScalarNode,
+				Tag:    "!!null",
+				Value:  "",
+				Line:   3,
+				Column: 1,
+			}},
+		},
+	}, {
+		"[encode]# foo\n\n\n",
+		yaml.Node{
+			Kind:        yaml.DocumentNode,
+			Line:        2,
+			Column:      1,
+			HeadComment: "# foo",
+			Content: []*yaml.Node{{
+				Kind:   yaml.ScalarNode,
+				Tag:    "!!null",
+				Value:  "",
+				Line:   3,
+				Column: 1,
+			}},
+		},
+	}, {
+		"# beginning\na:\n  ## foo\n  ##\n  b:\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   2,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.MappingNode,
+				Tag:    "!!map",
+				Line:   2,
+				Column: 1,
+				Content: []*yaml.Node{
+					{
+						Kind:        yaml.ScalarNode,
+						Tag:         "!!str",
+						Line:        2,
+						Column:      1,
+						Value:       "a",
+						HeadComment: "# beginning",
+					}, {
+						Kind:   yaml.MappingNode,
+						Tag:    "!!map",
+						Line:   5,
+						Column: 3,
+						Content: []*yaml.Node{
+							{
+								Kind:        yaml.ScalarNode,
+								Tag:         "!!str",
+								Line:        5,
+								Column:      3,
+								Value:       "b",
+								HeadComment: "## foo\n##",
+							}, {
+								Kind:   yaml.ScalarNode,
+								Tag:    "!!null",
+								Line:   5,
+								Column: 5,
+							},
+						},
 					},
 				},
 			}},


### PR DESCRIPTION
Rebased from https://github.com/go-yaml/yaml/pull/690.

~~Fixes #122.~~

Allows to correctly parse and serialize
```
# comment
```
without losing the comment (parsing), or getting some error (serialization).