### PR TITLE
ci: pin github actions versions

### DIFF
--- a/.github/workflows/check-commit-message.yaml
+++ b/.github/workflows/check-commit-message.yaml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       with:
         fetch-depth: 0  # Fetch all history to ensure all SHAs are available
     - name: Check PR Commits

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,7 +27,7 @@ jobs:
           build-mode: autobuild
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/files.yaml
+++ b/.github/workflows/files.yaml
@@ -13,28 +13,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout-action
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
     - name: actionlint
-      uses: raven-actions/actionlint@v2.0.1
+      uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc
 
   yamllint:
     runs-on: ubuntu-latest
     steps:
     - name: checkout-action
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
     - name: yamllint
-      uses: ibiqlik/action-yamllint@v3
+      uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c
 
   ls-lint:
     runs-on: ubuntu-latest
     steps:
     - name: checkout-action
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
     - name: ls-lint
-      uses: ls-lint/action@v2
+      uses: ls-lint/action@02e380fe8733d499cbfc9e22276de5085508a5bd
       with:
         config: .ls-lint.yaml
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout-action
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
     - name: typos-action
-      uses: crate-ci/typos@v1
+      uses: crate-ci/typos@85f62a8a84f939ae994ab3763f01a0296d61a7ee

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,9 +10,9 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
       with:
         go-version: stable
     - name: Run go fmt
@@ -27,12 +27,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
       with:
         go-version: stable
-    - uses: golangci/golangci-lint-action@v8
+    - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
       with:
         version: v2.4
   build:
@@ -43,9 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true  # make sure to run all versions, even if one fails
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
       with:
         go-version: ${{ matrix.go-versions }}
     - name: Run go vet


### PR DESCRIPTION
this is recommended to prevent supply chain attacks, as tags can be changed (and the `@v[single digit]` constantly are.

dependabot will still update these - the downside is that there will be more dependabot PRs.