### PR TITLE
ci: Disable actions/checkout's persist-credentials

### DIFF
--- a/.github/workflows/check-commit-message.yaml
+++ b/.github/workflows/check-commit-message.yaml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         fetch-depth: 0  # Fetch all history to ensure all SHAs are available
+        persist-credentials: false
     - name: Check PR Commits
       run:
         util/check-commit-messages.sh

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/files.yaml
+++ b/.github/workflows/files.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: checkout-action
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     - name: actionlint
       uses: raven-actions/actionlint@v2.0.1
@@ -23,6 +25,8 @@ jobs:
     steps:
     - name: checkout-action
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     - name: yamllint
       uses: ibiqlik/action-yamllint@v3
@@ -32,6 +36,8 @@ jobs:
     steps:
     - name: checkout-action
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     - name: ls-lint
       uses: ls-lint/action@v2
@@ -43,6 +49,8 @@ jobs:
     steps:
     - name: checkout-action
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     - name: typos-action
       uses: crate-ci/typos@v1

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
@@ -36,6 +38,8 @@ jobs:
         go-versions: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Set up Go
       uses: actions/setup-go@v6
       with:


### PR DESCRIPTION
- https://github.com/yaml/go-yaml/issues/118

## What?

This pull request disables actions/checkout's persist-credentials.

## Why?

To apply a security best practice of GitHub Actions.

https://github.com/suzuki-shunsuke/disable-checkout-persist-credentials
https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/013.md
- https://github.com/actions/checkout/issues/485

> Persisting token allows every step after actions/checkout to access token. This is a security risk.