### PR TITLE
Include the content index in parsing errors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -160,6 +160,7 @@ func (p *parser) node(kind Kind, defaultTag, tag, value string) *Node {
 	if !p.textless {
 		n.Line = p.event.StartMark.Line + 1
 		n.Column = p.event.StartMark.Column + 1
+		n.Index = p.event.StartMark.Index
 		n.HeadComment = string(p.event.HeadComment)
 		n.LineComment = string(p.event.LineComment)
 		n.FootComment = string(p.event.FootComment)
@@ -350,6 +351,7 @@ func (d *decoder) terror(n *Node, tag string, out reflect.Value) {
 		Err:    fmt.Errorf("cannot unmarshal %s%s into %s", shortTag(tag), value, out.Type()),
 		Line:   n.Line,
 		Column: n.Column,
+		Index:  n.Index,
 	})
 }
 
@@ -366,6 +368,7 @@ func (d *decoder) callUnmarshaler(n *Node, u Unmarshaler) (good bool) {
 			Err:    err,
 			Line:   n.Line,
 			Column: n.Column,
+			Index:  n.Index,
 		})
 		return false
 	}
@@ -394,6 +397,7 @@ func (d *decoder) callObsoleteUnmarshaler(n *Node, u obsoleteUnmarshaler) (good 
 			Err:    err,
 			Line:   n.Line,
 			Column: n.Column,
+			Index:  n.Index,
 		})
 		return false
 	}
@@ -601,6 +605,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 					Err:    err,
 					Line:   n.Line,
 					Column: n.Column,
+					Index:  n.Index,
 				})
 				return false
 			}
@@ -788,6 +793,7 @@ func (d *decoder) mapping(n *Node, out reflect.Value) (good bool) {
 						Err:    fmt.Errorf("mapping key %#v already defined at line %d", nj.Value, ni.Line),
 						Line:   nj.Line,
 						Column: nj.Column,
+						Index:  nj.Index,
 					})
 				}
 			}
@@ -940,6 +946,7 @@ func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 						Err:    fmt.Errorf("field %s already set in type %s", name.String(), out.Type()),
 						Line:   ni.Line,
 						Column: ni.Column,
+						Index:  ni.Index,
 					})
 					continue
 				}
@@ -964,6 +971,7 @@ func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 				Err:    fmt.Errorf("field %s not found in type %s", name.String(), out.Type()),
 				Line:   ni.Line,
 				Column: ni.Column,
+				Index:  ni.Index,
 			})
 		}
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1145,7 +1145,7 @@ func TestUnmarshalerError(t *testing.T) {
 	err := yaml.Unmarshal([]byte(data), &dst)
 	expectedErr := &yaml.TypeError{
 		Errors: []*yaml.UnmarshalError{
-			{Line: 1, Column: 17, Err: errFailing},
+			{Line: 1, Column: 17, Index: 16, Err: errFailing},
 		},
 	}
 	assert.DeepEqual(t, expectedErr, err)
@@ -1171,7 +1171,7 @@ func TestObsoleteUnmarshalerError(t *testing.T) {
 	err := yaml.Unmarshal([]byte(data), &dst)
 	expectedErr := &yaml.TypeError{
 		Errors: []*yaml.UnmarshalError{
-			{Line: 1, Column: 17, Err: errFailing},
+			{Line: 1, Column: 17, Index: 16, Err: errFailing},
 		},
 	}
 	assert.DeepEqual(t, expectedErr, err)
@@ -1199,7 +1199,7 @@ func TestTextUnmarshalerError(t *testing.T) {
 	err := yaml.Unmarshal([]byte(data), &dst)
 	expectedErr := &yaml.TypeError{
 		Errors: []*yaml.UnmarshalError{
-			{Line: 1, Column: 17, Err: errFailing},
+			{Line: 1, Column: 17, Index: 16, Err: errFailing},
 		},
 	}
 	assert.DeepEqual(t, expectedErr, err)

--- a/testdata/node.yaml
+++ b/testdata/node.yaml
@@ -13,6 +13,8 @@
 #       node: Expected node structure (as NodeInfo)
 #       decode: false  # Optional: skip decode test
 #       encode: false  # Optional: skip encode test
+#       with:          # Optional: test options
+#         full-details: true  # Enable position tracking verification
 #
 # Test Types:
 #   node-test - Validates YAML node structure and round-trip encoding/decoding
@@ -23,6 +25,8 @@
 #   node   - Expected node structure in NodeInfo format
 #   decode - Set to false to skip decode test (default: true)
 #   encode - Set to false to skip encode test (default: true)
+#   with   - Optional test configuration (map)
+#     full-details - When true, verify Line/Column/Index position fields (default: false)
 #
 # NodeInfo Format:
 #   kind    - Node kind: Document, Sequence, Mapping, Scalar, Alias
@@ -34,6 +38,11 @@
 #   foot    - FootComment text (optional)
 #   text    - Scalar value (for Scalar nodes only)
 #   content - Array of child nodes (for Document, Sequence, Mapping)
+#
+# Position Fields (only checked when with.full-details: true):
+#   linenum - Line number in input (1-indexed)
+#   col     - Column number in input (1-indexed)
+#   index   - Byte offset in input (0-indexed)
 
 - node-test:
     name: null value
@@ -2472,3 +2481,85 @@
         - kind: Mapping
           style: Flow
           content: [{kind: Scalar, text: qux}, {kind: Scalar, tag: '!!int', text: '1'}]
+
+# Position tracking tests (with full-details: true)
+- node-test:
+    name: simple scalar with position tracking
+    with:
+      full-details: true
+    yaml: "hello\n"
+    node:
+      kind: Document
+      linenum: 1
+      col: 1
+      index: 0
+      content:
+      - kind: Scalar
+        text: hello
+        linenum: 1
+        col: 1
+        index: 0
+
+- node-test:
+    name: simple mapping with position tracking
+    with:
+      full-details: true
+    yaml: "foo: bar\n"
+    node:
+      kind: Document
+      linenum: 1
+      col: 1
+      index: 0
+      content:
+      - kind: Mapping
+        linenum: 1
+        col: 1
+        index: 0
+        content:
+        - kind: Scalar
+          text: foo
+          linenum: 1
+          col: 1
+          index: 0
+        - kind: Scalar
+          text: bar
+          linenum: 1
+          col: 6
+          index: 5
+
+- node-test:
+    name: multiline mapping with position tracking
+    with:
+      full-details: true
+    yaml: "key1: value1\nkey2: value2\n"
+    node:
+      kind: Document
+      linenum: 1
+      col: 1
+      index: 0
+      content:
+      - kind: Mapping
+        linenum: 1
+        col: 1
+        index: 0
+        content:
+        - kind: Scalar
+          text: key1
+          linenum: 1
+          col: 1
+          index: 0
+        - kind: Scalar
+          text: value1
+          linenum: 1
+          col: 7
+          index: 6
+        - kind: Scalar
+          text: key2
+          linenum: 2
+          col: 1
+          index: 13
+        - kind: Scalar
+          text: value2
+          linenum: 2
+          col: 7
+          index: 19

--- a/yaml.go
+++ b/yaml.go
@@ -629,6 +629,7 @@ type UnmarshalError struct {
 	Err    error
 	Line   int
 	Column int
+	Index  int
 }
 
 func (e *UnmarshalError) Error() string {
@@ -773,16 +774,17 @@ type Node struct {
 	// FootComment holds any comments following the node and before empty lines.
 	FootComment string
 
-	// Line and Column hold the node position in the decoded YAML text.
+	// Line, Column and Index hold the node position in the decoded YAML text.
 	// These fields are not respected when encoding the node.
 	Line   int
 	Column int
+	Index  int
 }
 
 // IsZero returns whether the node has all of its fields unset.
 func (n *Node) IsZero() bool {
 	return n.Kind == 0 && n.Style == 0 && n.Tag == "" && n.Value == "" && n.Anchor == "" && n.Alias == nil && n.Content == nil &&
-		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0
+		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0 && n.Index == 0
 }
 
 // LongTag returns the long form of the tag that indicates the data type for


### PR DESCRIPTION
Adding the index to the parsing errors is useful for identifying the error position for package users.
