### PR TITLE
Add `Column` field to `ParserError`

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -121,13 +121,19 @@ func (p *parser) fail() {
 			line++
 		}
 	}
+	var column int
+	if p.parser.context_mark.column != 0 {
+		column = p.parser.context_mark.column
+	} else if p.parser.problem_mark.column != 0 {
+		column = p.parser.problem_mark.column
+	}
 	var msg string
 	if len(p.parser.problem) > 0 {
 		msg = p.parser.problem
 	} else {
 		msg = "unknown problem parsing YAML content"
 	}
-	fail(&ParserError{msg, line})
+	fail(&ParserError{msg, line, column})
 }
 
 func (p *parser) anchor(n *Node, anchor []byte) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -1145,19 +1145,32 @@ func TestDecoderErrors(t *testing.T) {
 	}
 }
 
-func TestParserError(t *testing.T) {
+func TestParserErrorUnmarshal(t *testing.T) {
 	var v struct {
 		A, B int
 	}
 	data := "a: 1\n=\nb: 2"
 	err := yaml.Unmarshal([]byte(data), &v)
 	asErr := new(yaml.ParserError)
-	if !errors.As(err, &asErr) {
-		t.Fatalf("error returned by Unmarshal doesn't unwrap into yaml.ParserError")
-	}
+	assert.ErrorAs(t, err, &asErr)
 	expectedErr := &yaml.ParserError{
 		Message: "could not find expected ':'",
 		Line:    2,
+		Column:  0,
+	}
+	assert.DeepEqual(t, expectedErr, asErr)
+}
+
+func TestParserErrorDecoder(t *testing.T) {
+	var v any
+	data := "value: -"
+	err := yaml.NewDecoder(strings.NewReader(data)).Decode(&v)
+	asErr := new(yaml.ParserError)
+	assert.ErrorAs(t, err, &asErr)
+	expectedErr := &yaml.ParserError{
+		Message: "block sequence entries are not allowed in this context",
+		Line:    0,
+		Column:  7,
 	}
 	assert.DeepEqual(t, expectedErr, asErr)
 }

--- a/yaml.go
+++ b/yaml.go
@@ -323,6 +323,7 @@ func failf(format string, args ...any) {
 type ParserError struct {
 	Message string
 	Line    int
+	Column  int
 }
 
 func (e *ParserError) Error() string {


### PR DESCRIPTION
`yaml.UnmarshalError` has `Column` field but `yaml.ParserError` doesn't. This PR adds the missing field so that users can report more accurate error position on their error handling.