### PR TITLE
Fix decoding !!float tags with uint64 values

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -570,6 +570,14 @@ var unmarshalTests = []struct {
 		map[string]any{"v": float64(-1)},
 	},
 	{
+		"v: !!float 9223372036854775807",
+		map[string]any{"v": float64(math.MaxInt64)},
+	},
+	{
+		"v: !!float 18446744073709551615",
+		map[string]any{"v": float64(math.MaxUint64)},
+	},
+	{
 		"v: !!null ''",
 		map[string]any{"v": nil},
 	},

--- a/resolve.go
+++ b/resolve.go
@@ -150,6 +150,10 @@ func resolve(tag string, in string) (rtag string, out any) {
 					rtag = floatTag
 					out = float64(v)
 					return
+				case uint64:
+					rtag = floatTag
+					out = float64(v)
+					return
 				case int:
 					rtag = floatTag
 					out = float64(v)


### PR DESCRIPTION
`!!float 18446744073709551615` cannot be decoded into `float64`.
