### PR TITLE
Remove unused parser states

### DIFF
--- a/internal/libyaml/parser.go
+++ b/internal/libyaml/parser.go
@@ -169,12 +169,6 @@ func (parser *Parser) stateMachine(event *Event) bool {
 	case PARSE_BLOCK_NODE_STATE:
 		return parser.parseNode(event, true, false)
 
-	case PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE:
-		return parser.parseNode(event, true, true)
-
-	case PARSE_FLOW_NODE_STATE:
-		return parser.parseNode(event, false, false)
-
 	case PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE:
 		return parser.parseBlockSequenceEntry(event, true)
 

--- a/internal/libyaml/yaml.go
+++ b/internal/libyaml/yaml.go
@@ -482,8 +482,6 @@ const (
 	PARSE_DOCUMENT_CONTENT_STATE                  // Expect the content of a document.
 	PARSE_DOCUMENT_END_STATE                      // Expect DOCUMENT-END.
 	PARSE_BLOCK_NODE_STATE                        // Expect a block node.
-	PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE // Expect a block node or indentless sequence.
-	PARSE_FLOW_NODE_STATE                         // Expect a flow node.
 	PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE        // Expect the first entry of a block sequence.
 	PARSE_BLOCK_SEQUENCE_ENTRY_STATE              // Expect an entry of a block sequence.
 	PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE         // Expect an entry of an indentless sequence.
@@ -516,10 +514,6 @@ func (ps ParserState) String() string {
 		return "PARSE_DOCUMENT_END_STATE"
 	case PARSE_BLOCK_NODE_STATE:
 		return "PARSE_BLOCK_NODE_STATE"
-	case PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE:
-		return "PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE"
-	case PARSE_FLOW_NODE_STATE:
-		return "PARSE_FLOW_NODE_STATE"
 	case PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE:
 		return "PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE"
 	case PARSE_BLOCK_SEQUENCE_ENTRY_STATE:


### PR DESCRIPTION
These states `PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE` and `PARSE_FLOW_NODE_STATE` are not used anywhere.