### PR TITLE
Bugfix/empty line at start parsing fixed

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -51,6 +51,7 @@ func init() {
 	encodeTypeRegistry.Register("map[string]uint64", map[string]uint64{})
 	encodeTypeRegistry.Register("map[string][]string", map[string][]string{})
 	encodeTypeRegistry.Register("map[string][]any", map[string][]any{})
+	encodeTypeRegistry.Register("map[string][]map[string]any", map[string][]map[string]any{})
 
 	// Register struct types
 	encodeTypeRegistry.Register("testStructHello", testStructHello{})
@@ -814,7 +815,7 @@ func TestNewLinePreserved(t *testing.T) {
 	data, err = yaml.Marshal(obj)
 	assert.NoError(t, err)
 	// the newline at the start of the file should be preserved
-	assert.Equal(t, "_: |4\n\n    a:\n            b:\n                    c: d\n", string(data))
+	assert.Equal(t, "_: |\n\n    a:\n            b:\n                    c: d\n", string(data))
 }
 
 // Scalar style tests for complex whitespace (tabs and Unicode)

--- a/internal/libyaml/emitter.go
+++ b/internal/libyaml/emitter.go
@@ -1909,7 +1909,9 @@ func (emitter *Emitter) writeDoubleQuotedScalar(value []byte, allow_breaks bool)
 }
 
 func (emitter *Emitter) writeBlockScalarHints(value []byte) error {
-	if isSpace(value, 0) || isLineBreak(value, 0) {
+	if isSpace(value, 0) {
+		// https://github.com/yaml/go-yaml/issues/65
+		// isLineBreak(value, 0) removed as the linebreak will only write the indentation value.
 		indent_hint := []byte{'0' + byte(emitter.BestIndent)}
 		if err := emitter.writeIndicator(indent_hint, false, false, false); err != nil {
 			return err

--- a/testdata/encode.yaml
+++ b/testdata/encode.yaml
@@ -256,6 +256,29 @@
               - 2
               - 3
 
+# Issue #65: Multiline strings starting with newline
+- encode:
+    name: string starting with newline in map
+    data:
+      v: "\nhi"
+    type: map[string]any
+    want: |
+      v: |-
+
+          hi
+
+- encode:
+    name: nested structure with leading newline
+    data:
+      v:
+        - v1: "\nhi"
+    type: map[string][]map[string]any
+    want: |
+      v:
+          - v1: |-
+
+              hi
+
 # Nested maps
 - encode:
     name: nested map


### PR DESCRIPTION
Fix parsing when multiline strings start with a line-ending (resolves #65)
Updated tests to validate the behaviour and did some code cleaning.