### PR TITLE
Convert limits tests to subtests and refactor benchmarks

### DIFF
--- a/limit_test.go
+++ b/limit_test.go
@@ -47,12 +47,11 @@ var limitTests = []struct {
 }
 
 func TestLimits(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
 	for _, tc := range limitTests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			var v any
 			err := yaml.Unmarshal(tc.data, &v)
 			if tc.error != "" {


### PR DESCRIPTION
Refactor limit_test.go to use t.Run/b.Run subtests for each case, ensuring proper test isolation by capturing tc in the loop. Replace the previous ad-hoc benchmark helpers and multiple benchmark functions with a single BenchmarkLimits that iterates limitTests and runs each case under b.Run. Update TestLimits to run in parallel, which improves test suite performance and eliminates the need for skipping the tests in short mode.

These changes make tests and benchmarks clearer, avoid shared-loop closure bugs, and unify benchmarking into one runner for easier maintenance.