### PR TITLE
GNUmakefile fixes for testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,10 +105,11 @@ foo: &a1 bar
 - Fork and clone the repository
 - Make your changes
 - Run tests, linters and formatters
-  - `make test-all`
-  - `make lint`
   - `make fmt`
   - `make tidy`
+  - `make lint`
+  - `make test`
+  - You can use `make check` to run all of the above
 - Submit a [Pull Request](https://github.com/yaml/go-yaml/pulls)
 
 


### PR DESCRIPTION
This PR is needed to fix a currently broken GNUmakefile

* Fixed 'make test' after 'make distclean'
* make test - now runs all tests
* make check - runs fmt tidy lint and test
* Test targets now clear the go testcache
* Fix broken 'make clean' to remove the CLI again