### PR TITLE
Minimal fix for 2 Makefile bugs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -58,7 +58,7 @@ SHELL-NAME := makes go-yaml
 include $(MAKES)/clean.mk
 include $(MAKES)/shell.mk
 
-MAKES-CLEAN := $(dir $(YTS-DIR)) $(GOLANGCI-LINT)
+MAKES-CLEAN += $(dir $(YTS-DIR)) $(GOLANGCI-LINT)
 
 v ?=
 count ?= 1
@@ -66,7 +66,7 @@ count ?= 1
 
 # Test rules:
 test: $(GO-DEPS)
-	go test$(if $v, -v) -vet=off ./...
+	go test$(if $v, -v) -vet=off .
 
 test-data: $(YTS-DIR)
 


### PR DESCRIPTION
'make test' was not working from a clean state.
'make clean' was not removing the go-yaml CLI.

I want the repo to not be broken asap. 
We have #171, #172, #173 and #174 but no agreement.
This fixes the current bugs. Then we can move on from there.