### PR TITLE
add Node.DecodeWithOptions

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -3174,6 +3174,46 @@ func TestNodeOmitEmpty(t *testing.T) {
 	assert.ErrorMatches(t, "yaml: cannot encode node with unknown kind 0", err)
 }
 
+func TestNodeDecodeWithOptions(t *testing.T) {
+	node := yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{{
+			Kind:  yaml.ScalarNode,
+			Value: "a",
+			Tag:   "!!str",
+		}, {
+			Kind:  yaml.ScalarNode,
+			Value: "1",
+			Tag:   "!!int",
+		}, {
+			Kind:  yaml.ScalarNode,
+			Value: "c",
+			Tag:   "!!str",
+		}, {
+			Kind:  yaml.ScalarNode,
+			Value: "2",
+			Tag:   "!!int",
+		}},
+	}
+	var value, res1, res2 struct {
+		A int
+	}
+	value.A = 1
+
+	err := node.DecodeWithOptions(&res1, yaml.DecodeOptions{KnownFields: true})
+	if err == nil || !strings.Contains(err.Error(), "field c not found in type struct") {
+		t.Fatalf("expected error about unknown field c, got: %v", err)
+	}
+	err = node.DecodeWithOptions(&res2, yaml.DecodeOptions{KnownFields: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2 != value {
+		t.Fatalf("unexpected result: want: %#v got: %#v", value, res2)
+	}
+}
+
 func fprintComments(tb testing.TB, out io.Writer, node *yaml.Node, indent string) {
 	tb.Helper()
 

--- a/yaml.go
+++ b/yaml.go
@@ -107,7 +107,7 @@ func NewDecoder(r io.Reader) *Decoder {
 	}
 }
 
-// KnownFields ensures that the keys in decoded mappings to
+// KnownFields ensures that the keys in decoded mappings
 // exist as fields in the struct being decoded into.
 func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
@@ -142,7 +142,24 @@ func (dec *Decoder) Decode(v any) (err error) {
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
 func (n *Node) Decode(v any) (err error) {
+	return n.DecodeWithOptions(v, DecodeOptions{})
+}
+
+// DecodeOptions specifies the options to use when decoding a node.
+type DecodeOptions struct {
+	// KnownFields ensures that the keys in decoded mappings exist as fields in
+	// the struct being decoded into.
+	KnownFields bool
+}
+
+// DecodeWithOptions decodes the node using the given options and stores its
+// data into the value pointed to by v.
+//
+// See the documentation for Unmarshal for details about the conversion of YAML
+// into a Go value.
+func (n *Node) DecodeWithOptions(v any, o DecodeOptions) (err error) {
 	d := newDecoder()
+	d.knownFields = o.KnownFields
 	defer handleErr(&err)
 	out := reflect.ValueOf(v)
 	if out.Kind() == reflect.Pointer && !out.IsNil() {


### PR DESCRIPTION
This PR adds a `DecodeWithOptions()` method to `Node` which allows strict unmarshaling. Without this, it is impossible to require strict unmarshaling from inside a custom `UnmarshalYAML(node *yaml.Node)` handler. This is important for many applications where we don't want a typo in a configuration file to be silently ignored.

See https://github.com/go-yaml/yaml/issues/460 for more info. Note that this is functionally a regression in v3/v4; in v2 the decoder flags are automatically used by custom unmarshalers.

This is an adaptation of https://github.com/go-yaml/yaml/pull/691