### PR TITLE
Return `ParserError` on unknown anchor reference

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -216,7 +216,8 @@ func (p *parser) alias() *Node {
 	n := p.node(AliasNode, "", "", string(p.event.Anchor))
 	n.Alias = p.anchors[n.Value]
 	if n.Alias == nil {
-		failf("unknown anchor '%s' referenced", n.Value)
+		msg := fmt.Sprintf("unknown anchor '%s' referenced", n.Value)
+		fail(&ParserError{msg, n.Line, n.Column})
 	}
 	p.expect(libyaml.ALIAS_EVENT)
 	return n


### PR DESCRIPTION
Fixes #190

This PR makes the decoder return `ParserError` instead of standard `fmt.Errorf` when detecting a reference to an unknown anchor so that it can keep the source location.