### PR TITLE
Data driven tests for internal/libyaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.cache/
+/.claude/
 /yts/testdata/
 /go-yaml

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -66,7 +66,7 @@ count ?= 1
 
 # Test rules:
 test: $(GO-DEPS)
-	go test$(if $v, -v) -vet=off .
+	go test$(if $v, -v) -vet=off --cover . ./internal/...
 
 test-data: $(YTS-DIR)
 

--- a/internal/libyaml/README.md
+++ b/internal/libyaml/README.md
@@ -1,0 +1,533 @@
+# internal/libyaml
+
+This package provides low-level YAML processing functionality through a 3-stage
+pipeline: Scanner → Parser → Emitter.
+It implements the libyaml C library functionality in Go.
+
+## Directory Overview
+
+The `internal/libyaml` package implements the core YAML processing stages:
+
+1. **Scanner** - Tokenizes YAML text into tokens
+2. **Parser** - Converts tokens into events following YAML grammar rules
+3. **Emitter** - Serializes events back into YAML text
+
+## File Organization
+
+### Main Source Files
+
+- **scanner.go** - YAML scanner/tokenizer implementation
+- **parser.go** - YAML parser (tokens → events)
+- **emitter.go** - YAML emitter (events → YAML output)
+- **api.go** - Public API for Parser and Emitter types
+- **yaml.go** - Core types and constants (Event, Token, enums)
+- **reader.go** - Input handling and encoding detection
+- **writer.go** - Output handling
+- **yamlprivate.go** - Internal types and helper functions
+
+### Test Files
+
+- **scanner_test.go** - Scanner tests
+- **parser_test.go** - Parser tests
+- **emitter_test.go** - Emitter tests
+- **api_test.go** - API tests
+- **yaml_test.go** - Utility function tests
+- **reader_test.go** - Reader tests
+- **writer_test.go** - Writer tests
+- **yamlprivate_test.go** - Character classification tests
+- **loader_test.go** - Data loader scalar resolution tests
+- **yamldatatest_test.go** - YAML test data loading framework
+- **yamldatatest_loader.go** - YAML test data loader with scalar type resolution (exported for reuse)
+
+### Test Data Files (in `testdata/`)
+
+- **scanner.yaml** - Scanner test cases
+- **parser.yaml** - Parser test cases
+- **emitter.yaml** - Emitter test cases
+- **api.yaml** - API test cases
+- **yaml.yaml** - Utility function test cases
+- **reader.yaml** - Reader test cases
+- **writer.yaml** - Writer test cases
+- **yamlprivate.yaml** - Character classification test cases
+- **loader.yaml** - Data loader scalar resolution test cases
+
+## Processing Pipeline
+
+### 1. Scanner (scanner.go)
+
+The scanner converts YAML text into tokens.
+
+**Input**: Raw YAML text (string or []byte)
+**Output**: Stream of tokens
+
+**Token types include**:
+- `SCALAR_TOKEN` - Plain, quoted, or block scalar values
+- `KEY_TOKEN`, `VALUE_TOKEN` - Mapping key/value indicators
+- `BLOCK_MAPPING_START_TOKEN`, `FLOW_MAPPING_START_TOKEN` - Mapping delimiters
+- `BLOCK_SEQUENCE_START_TOKEN`, `FLOW_SEQUENCE_START_TOKEN` - Sequence delimiters
+- `ANCHOR_TOKEN`, `ALIAS_TOKEN` - Anchor definitions and references
+- `TAG_TOKEN` - Type tags
+- `DOCUMENT_START_TOKEN`, `DOCUMENT_END_TOKEN` - Document boundaries
+
+**Responsibilities**:
+- Character encoding detection (UTF-8, UTF-16LE, UTF-16BE)
+- Line break normalization
+- Indentation tracking
+- Quote and escape sequence handling
+
+### 2. Parser (parser.go)
+
+The parser converts tokens into events following YAML grammar rules.
+
+**Input**: Stream of tokens from Scanner
+**Output**: Stream of events
+
+**Event types include**:
+- `STREAM_START_EVENT`, `STREAM_END_EVENT` - Stream boundaries
+- `DOCUMENT_START_EVENT`, `DOCUMENT_END_EVENT` - Document boundaries
+- `SCALAR_EVENT` - Scalar values
+- `MAPPING_START_EVENT`, `MAPPING_END_EVENT` - Mapping boundaries
+- `SEQUENCE_START_EVENT`, `SEQUENCE_END_EVENT` - Sequence boundaries
+- `ALIAS_EVENT` - Anchor references
+
+**Responsibilities**:
+- Implementing YAML grammar and validation
+- Managing document directives (%YAML, %TAG)
+- Resolving anchors and aliases
+- Tracking implicit vs explicit markers
+- Style preservation (plain, single-quoted, double-quoted, literal, folded)
+
+### 3. Emitter (emitter.go)
+
+The emitter converts events back into YAML text.
+
+**Input**: Stream of events
+**Output**: YAML text
+
+**Responsibilities**:
+- Style selection (plain/quoted scalars, block/flow collections)
+- Formatting control (canonical mode, indentation, line width)
+- Character encoding
+- Anchor and tag serialization
+- Document marker generation (---, ...)
+
+**Configuration options**:
+- `Canonical` - Emit in canonical YAML form
+- `Indent` - Indentation width (2-9 spaces)
+- `Width` - Line width (-1 for unlimited)
+- `Unicode` - Enable Unicode character output
+- `LineBreak` - Line break style (LN, CR, CRLN)
+
+## Testing Framework
+
+### Test Architecture
+
+The testing framework uses a data-driven approach:
+
+1. **Test data** is stored in YAML files in the `testdata/` directory
+2. **Test logic** is implemented in Go files (`*_test.go`)
+3. **One-to-one pairing**: Each `testdata/foo.yaml` has a corresponding `foo_test.go`
+
+**Benefits**:
+- Easy to add new test cases without writing Go code
+- Test data is human-readable and self-documenting
+- Test logic is reusable across many test cases
+- Test data is separated from test code for clarity
+- Tests can become a common suite for multiple YAML frameworks
+
+### Test Data Files
+
+Each YAML file contains test cases for a specific component:
+
+- **scanner.yaml** - Scanner/tokenization tests
+  - Token sequence verification
+  - Token property validation (value, style)
+  - Error detection
+
+- **parser.yaml** - Parser/event generation tests
+  - Event sequence verification
+  - Event property validation (anchor, tag, value, directives)
+  - Error detection
+
+- **emitter.yaml** - Emitter/serialization tests
+  - Event-to-YAML conversion
+  - Configuration options testing
+  - Roundtrip testing (parse → emit)
+  - Writer integration
+
+- **api.yaml** - API constructor and method tests
+  - Constructor validation
+  - Method behavior and state changes
+  - Panic conditions
+  - Cleanup verification
+
+- **yaml.yaml** - Utility function tests
+  - Enum String() methods
+  - Style accessor methods
+
+- **reader.yaml** - Reader/input handling tests
+  - Encoding detection (UTF-8, UTF-16LE, UTF-16BE)
+  - Buffer management
+  - Error handling
+
+- **writer.yaml** - Writer/output handling tests
+  - Buffer flushing
+  - Output handlers (string, io.Writer)
+  - Error conditions
+
+- **yamlprivate.yaml** - Character classification tests
+  - Character type predicates (isAlpha, isDigit, isHex, etc.)
+  - Character conversion functions (asDigit, asHex, width)
+  - Unicode handling
+
+- **loader.yaml** - Data loader scalar resolution tests
+  - Numeric type resolution (integers, floats)
+  - Boolean and null value handling
+  - String vs numeric type disambiguation
+  - Mixed-type collections
+
+### Test Framework Implementation
+
+The test framework is implemented in `yamldatatest_loader.go` and `yamldatatest_test.go`:
+
+**Core functions**:
+- `LoadYAML(data []byte) (interface{}, error)` - Parses YAML using libyaml parser with scalar type resolution (exported)
+- `UnmarshalStruct(target interface{}, data map[string]interface{}) error` - Populates structs (exported)
+- `LoadTestCases(filename string) ([]TestCase, error)` - Loads and parses test YAML files
+- `coerceScalar(value string) interface{}` - Resolves scalar strings to appropriate Go types (int, float64, bool, nil, string)
+
+**Core types**:
+- `TestCase` struct - Umbrella structure containing fields for all test types
+  - Uses `interface{}` for flexible field types
+  - Post-processing converts generic fields to specific types
+
+**Post-processing**:
+After loading, the framework processes test data:
+- Converts `Want` (interface{}) to `WantEvents`, `WantTokens`, or `WantSpecs` based on test type
+- Converts `Want` (interface{}) to `WantContains` (handles both scalar and sequence)
+- Converts `Checks` to field validation specifications
+
+### Test Types
+
+#### Scanner Tests
+
+**scan-tokens** - Verify token sequence
+
+```yaml
+- scan-tokens:
+    name: Simple scalar
+    yaml: |-
+      hello
+    want:
+    - STREAM_START_TOKEN
+    - SCALAR_TOKEN
+    - STREAM_END_TOKEN
+```
+
+**scan-tokens-detailed** - Verify token properties
+
+```yaml
+- scan-tokens-detailed:
+    name: Single quoted scalar
+    yaml: |-
+      'hello world'
+    want:
+    - STREAM_START_TOKEN
+    - SCALAR_TOKEN:
+        style: SINGLE_QUOTED_SCALAR_STYLE
+        value: hello world
+    - STREAM_END_TOKEN
+```
+
+**scan-error** - Verify error detection
+
+```yaml
+- scan-error:
+    name: Invalid character
+    yaml: "\x01"
+```
+
+#### Parser Tests
+
+**parse-events** - Verify event sequence
+
+```yaml
+- parse-events:
+    name: Simple mapping
+    yaml: |
+      key: value
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+```
+
+**parse-events-detailed** - Verify event properties
+
+```yaml
+- parse-events-detailed:
+    name: Anchor and alias
+    yaml: |
+      - &anchor value
+      - *anchor
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - SEQUENCE_START_EVENT
+    - SCALAR_EVENT:
+        anchor: anchor
+        value: value
+    - ALIAS_EVENT:
+        anchor: anchor
+    - SEQUENCE_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+```
+
+**parse-error** - Verify error detection
+
+```yaml
+- parse-error:
+    name: Error state
+    yaml: |
+      key: : invalid
+```
+
+#### Emitter Tests
+
+**emit** - Emit events and verify output contains expected strings
+
+```yaml
+- emit:
+    name: Simple scalar
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        value: hello
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: hello
+```
+
+**emit-config** - Emit with configuration
+
+```yaml
+- emit-config:
+    name: Custom indent
+    conf:
+      indent: 4
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: BLOCK_MAPPING_STYLE
+    # ... more events
+    want: key
+```
+
+**roundtrip** - Parse → emit, verify output
+
+```yaml
+- roundtrip:
+    name: Roundtrip
+    yaml: |
+      key: value
+      list:
+        - item1
+        - item2
+    want:
+    - key
+    - value
+    - item1
+```
+
+**emit-writer** - Emit to io.Writer
+
+```yaml
+- emit-writer:
+    name: Writer
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    # ... more events
+    want: test
+```
+
+#### API Tests
+
+**api-new** - Test constructors
+
+```yaml
+- api-new:
+    name: New parser
+    with: NewParser
+    test:
+    - nil: [raw-buffer, false]
+    - cap: [raw-buffer, 512]
+    - nil: [buffer, false]
+    - cap: [buffer, 1536]
+```
+
+**api-method** - Test methods and field state
+
+```yaml
+- api-method:
+    name: Parser set input string
+    with: NewParser
+    byte: true
+    call: [SetInputString, 'key: value']
+    test:
+    - eq: [input, 'key: value']
+    - eq: [input-pos, 0]
+    - nil: [read-handler, false]
+```
+
+**api-panic** - Test methods that should panic
+
+```yaml
+- api-panic:
+    name: Parser set input string twice
+    with: NewParser
+    byte: true
+    init: [SetInputString, first]
+    call: [SetInputString, second]
+    want: must set the input source only once
+```
+
+**api-delete** - Test cleanup
+
+```yaml
+- api-delete:
+    name: Parser delete
+    with: NewParser
+    byte: true
+    init: [SetInputString, test]
+    test:
+    - len: [input, 0]
+    - len: [buffer, 0]
+```
+
+**api-new-event** - Test event constructors
+
+```yaml
+- api-new-event:
+    name: New stream start event
+    call: [NewStreamStartEvent, UTF8_ENCODING]
+    test:
+    - eq: [Type, STREAM_START_EVENT]
+    - eq: [encoding, UTF8_ENCODING]
+```
+
+#### Utility Tests
+
+**enum-string** - Test String() methods of enums
+
+```yaml
+- enum-string:
+    name: Scalar style plain
+    enum: [ScalarStyle, PLAIN_SCALAR_STYLE]
+    want: Plain
+```
+
+**style-accessor** - Test style accessor methods
+
+```yaml
+- style-accessor:
+    name: Event scalar style
+    test: [ScalarStyle, DOUBLE_QUOTED_SCALAR_STYLE]
+```
+
+#### Loader Tests
+
+**scalar-resolution** - Test scalar type resolution
+
+```yaml
+- scalar-resolution:
+    name: Positive integer
+    yaml: "42"
+    want: 42
+
+- scalar-resolution:
+    name: Negative float
+    yaml: "-2.5"
+    want: -2.5
+```
+
+**Resolution order**:
+1. Boolean (true, false)
+2. Null (null keyword only)
+3. Hexadecimal integer (0x prefix)
+4. Float (contains .)
+5. Decimal integer
+6. String (fallback)
+
+### Common Keys in Test YAML Files
+
+Test cases use a **type-as-key** format where the test type is the map key:
+
+```yaml
+- test-type:
+    name: Test case name
+    # ... other fields
+```
+
+**Common fields**:
+- **name** - Test case name (title case convention)
+- **yaml** - Input YAML string to test
+- **want** - Expected result (format varies by test type)
+  - For api-panic: string containing expected panic message substring
+  - For scan-error/parse-error: boolean (defaults to true if omitted; set to false if no error expected)
+  - For enum-string: string representing expected String() output
+  - For other types: varies (may be sequence or scalar)
+- **data** - For emitter tests: list of event specifications to emit
+- **conf** - For emitter config tests: emitter configuration options
+- **with** - For API tests: constructor name (NewParser, NewEmitter)
+- **call** - For API tests: method call [MethodName, arg1, arg2, ...]
+- **init** - For API panic tests: setup method call before main method
+- **byte** - For API tests: boolean flag to convert string args to []byte
+- **test** - For API tests: list of field validation checks in format `operator: [field, value]` where operator is one of: nil, cap, len, eq, gte, len-gt.
+- **test** - For style-accessor tests: array of [Method, STYLE] where Method is the accessor method (e.g., ScalarStyle) and STYLE is the style constant (e.g., DOUBLE_QUOTED_SCALAR_STYLE).
+- **enum** - For enum tests: array of [Type, Value] where Type is the enum type (e.g., ScalarStyle) and Value is the constant (e.g., PLAIN_SCALAR_STYLE)
+
+**Note on scalar type resolution**: Unquoted scalar values in test data are automatically resolved to appropriate Go types (int, float64, bool, nil) by the `LoadYAML` function. Quoted scalars remain as strings.
+
+### Running Tests
+
+```bash
+# Run all tests in the package
+go test ./internal/libyaml
+
+# Run specific test file
+go test ./internal/libyaml -run TestScanner
+go test ./internal/libyaml -run TestParser
+go test ./internal/libyaml -run TestEmitter
+go test ./internal/libyaml -run TestAPI
+go test ./internal/libyaml -run TestYAML
+go test ./internal/libyaml -run TestLoader
+
+# Run specific test case (using subtest name)
+go test ./internal/libyaml -run TestScanner/Block_sequence
+go test ./internal/libyaml -run TestParser/Anchor_and_alias
+go test ./internal/libyaml -run TestEmitter/Flow_mapping
+go test ./internal/libyaml -run TestLoader/Scientific_notation_lowercase_e
+
+# Run with verbose output
+go test -v ./internal/libyaml
+
+# Run with coverage
+go test -cover ./internal/libyaml
+```

--- a/internal/libyaml/api_test.go
+++ b/internal/libyaml/api_test.go
@@ -1,0 +1,627 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestAPI(t *testing.T) {
+	RunTestCases(t, "api.yaml", map[string]TestHandler{
+		"api-new":       runAPINewTest,
+		"api-method":    runAPIMethodTest,
+		"api-panic":     runAPIPanicTest,
+		"api-delete":    runAPIDeleteTest,
+		"api-new-event": runAPINewEventTest,
+	})
+}
+
+func runAPINewTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	obj := createObject(t, tc.Constructor)
+	runFieldChecks(t, obj, tc.Checks)
+}
+
+func runAPIMethodTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	obj := createObject(t, tc.Constructor)
+
+	// Run setup if any
+	if tc.Setup != nil {
+		if setupList, ok := tc.Setup.([]interface{}); ok && len(setupList) > 0 {
+			callMethodFromList(t, obj, setupList, tc.Bytes)
+		}
+	}
+
+	// Call the main method
+	callMethodFromList(t, obj, tc.Method, tc.Bytes)
+
+	// Run checks
+	runFieldChecks(t, obj, tc.Checks)
+}
+
+func runAPIPanicTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	obj := createObject(t, tc.Constructor)
+
+	// Run setup if any
+	if tc.Setup != nil {
+		if setupList, ok := tc.Setup.([]interface{}); ok && len(setupList) > 0 {
+			callMethodFromList(t, obj, setupList, tc.Bytes)
+		}
+	}
+
+	// The main method call should panic
+	// Want can be either a string or a single-element sequence
+	var wantMsg string
+	switch v := tc.Want.(type) {
+	case string:
+		wantMsg = v
+	case []interface{}:
+		if len(v) > 0 {
+			msg, ok := v[0].(string)
+			assert.Truef(t, ok, "Want[0] should be string, got %T", v[0])
+			wantMsg = msg
+		} else {
+			t.Fatalf("Want slice is empty, expected at least one element")
+		}
+	default:
+		t.Fatalf("want must be a string or sequence, got %T", tc.Want)
+	}
+	assert.PanicMatchesf(t, wantMsg, func() {
+		callMethodFromList(t, obj, tc.Method, tc.Bytes)
+	}, "Expected panic: %s", wantMsg)
+}
+
+func runAPIDeleteTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	obj := createObject(t, tc.Constructor)
+
+	// Run setup if any
+	if tc.Setup != nil {
+		if setupList, ok := tc.Setup.([]interface{}); ok && len(setupList) > 0 {
+			callMethodFromList(t, obj, setupList, tc.Bytes)
+		}
+	}
+
+	// Call Delete method
+	callMethodFromList(t, obj, []interface{}{"Delete"}, false)
+
+	// Run checks after delete
+	runFieldChecks(t, obj, tc.Checks)
+}
+
+func runAPINewEventTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	event := createEventFromList(t, tc.Method, tc.Bytes)
+	runFieldChecks(t, &event, tc.Checks)
+}
+
+// createObject creates a Parser or Emitter based on constructor name
+func createObject(t *testing.T, constructor string) interface{} {
+	t.Helper()
+	switch constructor {
+	case "NewParser":
+		p := NewParser()
+		return &p
+	case "NewEmitter":
+		e := NewEmitter()
+		return &e
+	default:
+		t.Fatalf("unknown constructor: %s", constructor)
+	}
+	return nil
+}
+
+// createEventFromList creates an Event from a method list [constructor, args...]
+func createEventFromList(t *testing.T, methodList []interface{}, useBytes bool) Event {
+	t.Helper()
+	if len(methodList) == 0 {
+		t.Fatalf("empty method list")
+	}
+
+	constructor, ok := methodList[0].(string)
+	if !ok {
+		t.Fatalf("constructor should be string, got %T", methodList[0])
+	}
+	args := methodList[1:]
+
+	switch constructor {
+	case "NewStreamStartEvent":
+		if len(args) != 1 {
+			t.Fatalf("%s expects 1 argument, got %d", constructor, len(args))
+		}
+		encoding := parseArg(t, args[0])
+		return NewStreamStartEvent(Encoding(encoding))
+	case "NewStreamEndEvent":
+		if len(args) != 0 {
+			t.Fatalf("%s expects 0 arguments, got %d", constructor, len(args))
+		}
+		return NewStreamEndEvent()
+	case "NewDocumentEndEvent":
+		if len(args) != 1 {
+			t.Fatalf("%s expects 1 argument, got %d", constructor, len(args))
+		}
+		implicit := parseBoolArg(t, args[0])
+		return NewDocumentEndEvent(implicit)
+	case "NewAliasEvent":
+		if len(args) != 1 {
+			t.Fatalf("%s expects 1 argument, got %d", constructor, len(args))
+		}
+		anchor := parseStringArg(t, args[0], useBytes)
+		return NewAliasEvent([]byte(anchor))
+	case "NewSequenceEndEvent":
+		if len(args) != 0 {
+			t.Fatalf("%s expects 0 arguments, got %d", constructor, len(args))
+		}
+		return NewSequenceEndEvent()
+	case "NewMappingEndEvent":
+		if len(args) != 0 {
+			t.Fatalf("%s expects 0 arguments, got %d", constructor, len(args))
+		}
+		return NewMappingEndEvent()
+	default:
+		t.Fatalf("unknown event constructor: %s", constructor)
+	}
+	return Event{}
+}
+
+// callMethodFromList calls a method from a list [methodName, args...]
+func callMethodFromList(t *testing.T, obj interface{}, methodList []interface{}, useBytes bool) {
+	t.Helper()
+	if len(methodList) == 0 {
+		t.Fatalf("empty method list")
+	}
+
+	methodName, ok := methodList[0].(string)
+	if !ok {
+		t.Fatalf("method name should be string, got %T", methodList[0])
+	}
+	args := methodList[1:]
+
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	m := v.Addr().MethodByName(methodName)
+	if !m.IsValid() {
+		t.Fatalf("method not found: %s", methodName)
+	}
+
+	methodType := m.Type()
+	numParams := methodType.NumIn()
+
+	// Validate argument count
+	if len(args) != numParams {
+		t.Fatalf("method %s expects %d arguments, got %d", methodName, numParams, len(args))
+	}
+
+	// Build argument list
+	var callArgs []reflect.Value
+	for i, arg := range args {
+		paramType := methodType.In(i)
+
+		// Handle different parameter types
+		if paramType.Kind() == reflect.Bool {
+			val := parseBoolArg(t, arg)
+			callArgs = append(callArgs, reflect.ValueOf(val))
+		} else if paramType.Kind() == reflect.Slice && paramType.Elem().Kind() == reflect.Uint8 {
+			// Byte slice parameter
+			str := parseStringArg(t, arg, useBytes)
+			callArgs = append(callArgs, reflect.ValueOf([]byte(str)))
+		} else {
+			// Try parsing as constant/int
+			val := parseArg(t, arg)
+			convertedVal := reflect.ValueOf(val).Convert(paramType)
+			callArgs = append(callArgs, convertedVal)
+		}
+	}
+
+	// Call the method
+	m.Call(callArgs)
+}
+
+// parseArg parses an argument which could be int, bool, or string constant
+func parseArg(t *testing.T, arg interface{}) int {
+	t.Helper()
+	switch v := arg.(type) {
+	case int:
+		return v
+	case string:
+		if looksLikeConstant(v) {
+			return parseConstant(t, v)
+		}
+		// Try parsing as int
+		if val, err := strconv.Atoi(v); err == nil {
+			return val
+		}
+		t.Fatalf("cannot parse arg as int: %v", arg)
+	default:
+		t.Fatalf("unsupported arg type: %T", arg)
+	}
+	return 0
+}
+
+// parseBoolArg parses a boolean argument
+func parseBoolArg(t *testing.T, arg interface{}) bool {
+	t.Helper()
+	switch v := arg.(type) {
+	case bool:
+		return v
+	case string:
+		switch v {
+		case "true":
+			return true
+		case "false":
+			return false
+		default:
+			t.Fatalf("cannot parse string as bool (expected 'true' or 'false'): %q", v)
+		}
+	default:
+		t.Fatalf("cannot parse arg as bool: %v (type %T)", arg, arg)
+	}
+	return false
+}
+
+// parseStringArg parses a string argument
+func parseStringArg(t *testing.T, arg interface{}, useBytes bool) string {
+	t.Helper()
+	switch v := arg.(type) {
+	case string:
+		return v
+	default:
+		t.Fatalf("cannot parse arg as string: %v (type %T)", arg, arg)
+	}
+	return ""
+}
+
+// looksLikeConstant checks if a string looks like a constant name
+func looksLikeConstant(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	// Check if it's all uppercase letters, digits, and underscores
+	for _, c := range s {
+		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// parseConstant parses a constant name to its integer value
+func parseConstant(t *testing.T, name string) int {
+	t.Helper()
+	// Handle boolean values
+	if name == "true" {
+		return 1
+	}
+	if name == "false" {
+		return 0
+	}
+
+	// Try parsing as int first
+	if val, err := strconv.Atoi(name); err == nil {
+		return val
+	}
+
+	// Use IntOrStr to parse other constants
+	ios := IntOrStr{}
+	err := ios.FromValue(name)
+	if err != nil {
+		t.Fatalf("failed to parse constant %q: %v", name, err)
+	}
+	return ios.Value
+}
+
+// hasLength checks if a slice has exactly the expected length
+// Returns true if length matches, false if empty, and fails fatally otherwise
+func hasLength(t *testing.T, slice []interface{}, expected int) bool {
+	t.Helper()
+	if len(slice) == 0 {
+		return false
+	}
+	if len(slice) != expected {
+		t.Fatalf("expected exactly %d args, got %d", expected, len(slice))
+	}
+	return true
+}
+
+// runFieldChecks runs field checks on an object
+func runFieldChecks(t *testing.T, obj interface{}, checks []FieldCheck) {
+	t.Helper()
+
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	for _, check := range checks {
+		// Handle nil checks
+		if hasLength(t, check.Nil, 2) {
+			fieldName, ok := check.Nil[0].(string)
+			if !ok {
+				t.Fatalf("Nil[0] should be string, got %T", check.Nil[0])
+			}
+			wantNil, ok := check.Nil[1].(bool)
+			if !ok {
+				t.Fatalf("Nil[1] should be bool, got %T", check.Nil[1])
+			}
+			field := getField(t, v, fieldName)
+			if field.IsValid() {
+				isNil := field.IsNil()
+				if wantNil != isNil {
+					if wantNil {
+						t.Errorf("%s should be nil", fieldName)
+					} else {
+						t.Errorf("%s should not be nil", fieldName)
+					}
+				}
+			}
+		}
+
+		// Handle cap checks
+		if hasLength(t, check.Cap, 2) {
+			fieldName, ok := check.Cap[0].(string)
+			if !ok {
+				t.Fatalf("Cap[0] should be string, got %T", check.Cap[0])
+			}
+			wantCap, ok := check.Cap[1].(int)
+			if !ok {
+				t.Fatalf("Cap[1] should be int, got %T", check.Cap[1])
+			}
+			field := getField(t, v, fieldName)
+			if field.IsValid() && wantCap > 0 {
+				if field.Cap() != wantCap {
+					t.Errorf("%s cap = %d, want %d", fieldName, field.Cap(), wantCap)
+				}
+			}
+		}
+
+		// Handle len checks
+		if hasLength(t, check.Len, 2) {
+			fieldName, ok := check.Len[0].(string)
+			if !ok {
+				t.Fatalf("Len[0] should be string, got %T", check.Len[0])
+			}
+			wantLen, ok := check.Len[1].(int)
+			if !ok {
+				t.Fatalf("Len[1] should be int, got %T", check.Len[1])
+			}
+			field := getField(t, v, fieldName)
+			if field.IsValid() && wantLen > 0 {
+				if field.Len() != wantLen {
+					t.Errorf("%s len = %d, want %d", fieldName, field.Len(), wantLen)
+				}
+			}
+		}
+
+		// Handle len-gt checks
+		if hasLength(t, check.LenGt, 2) {
+			fieldName, ok := check.LenGt[0].(string)
+			if !ok {
+				t.Fatalf("LenGt[0] should be string, got %T", check.LenGt[0])
+			}
+			minLen, ok := check.LenGt[1].(int)
+			if !ok {
+				t.Fatalf("LenGt[1] should be int, got %T", check.LenGt[1])
+			}
+			field := getField(t, v, fieldName)
+			if field.IsValid() && minLen > 0 {
+				if field.Len() <= minLen {
+					t.Errorf("%s len = %d, want > %d", fieldName, field.Len(), minLen)
+				}
+			}
+		}
+
+		// Handle eq checks
+		if hasLength(t, check.Eq, 2) {
+			fieldName, ok := check.Eq[0].(string)
+			if !ok {
+				t.Fatalf("Eq[0] should be string, got %T", check.Eq[0])
+			}
+			expectedValue := check.Eq[1]
+			checkEqual(t, v, fieldName, expectedValue)
+		}
+
+		// Handle gte checks
+		if hasLength(t, check.Gte, 2) {
+			fieldName, ok := check.Gte[0].(string)
+			if !ok {
+				t.Fatalf("Gte[0] should be string, got %T", check.Gte[0])
+			}
+			minValue, ok := check.Gte[1].(int)
+			if !ok {
+				t.Fatalf("Gte[1] should be int, got %T", check.Gte[1])
+			}
+			field := getField(t, v, fieldName)
+			if field.IsValid() {
+				got := getIntValue(t, field, fieldName)
+				if got < minValue {
+					t.Errorf("%s = %d, want >= %d", fieldName, got, minValue)
+				}
+			}
+		}
+	}
+}
+
+// getField retrieves a field from a struct, handling special field names
+func getField(t *testing.T, v reflect.Value, fieldName string) reflect.Value {
+	t.Helper()
+
+	// Handle special field names like buffer-0, buffer-1
+	if strings.HasPrefix(fieldName, "buffer-") {
+		var bufferIndex int
+		_, err := fmt.Sscanf(fieldName, "buffer-%d", &bufferIndex)
+		if err == nil {
+			// Validate that buffer index is non-negative
+			if bufferIndex < 0 {
+				t.Fatalf("invalid buffer index: %s (index must be non-negative)", fieldName)
+			}
+			// Return invalid value - buffer index checks are handled separately
+			return reflect.Value{}
+		}
+	}
+
+	// Convert hyphenated YAML key to underscored Go field name
+	goFieldName := strings.ReplaceAll(fieldName, "-", "_")
+	field := v.FieldByName(goFieldName)
+	if !field.IsValid() {
+		t.Fatalf("field not found: %s (looking for %s)", fieldName, goFieldName)
+	}
+	return field
+}
+
+// getIntValue extracts an integer value from a field
+func getIntValue(t *testing.T, field reflect.Value, fieldName string) int {
+	t.Helper()
+
+	// Use reflection Kind() instead of type assertions
+	switch field.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return int(field.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int(field.Uint())
+	default:
+		t.Fatalf("%s: expected numeric field, got %s", fieldName, field.Kind())
+	}
+	return 0
+}
+
+// checkEqual performs an equality check on a field
+func checkEqual(t *testing.T, v reflect.Value, fieldName string, expectedValue interface{}) {
+	t.Helper()
+
+	// Handle buffer-N special case
+	var bufferIndex int
+	isBufferIndex := false
+	if strings.HasPrefix(fieldName, "buffer-") {
+		_, err := fmt.Sscanf(fieldName, "buffer-%d", &bufferIndex)
+		if err == nil {
+			// Validate that buffer index is non-negative
+			if bufferIndex < 0 {
+				t.Fatalf("invalid buffer index: %s (index must be non-negative)", fieldName)
+			}
+			isBufferIndex = true
+		}
+	}
+
+	var field reflect.Value
+	if isBufferIndex {
+		field = v.FieldByName("buffer")
+		if !field.IsValid() {
+			t.Fatalf("buffer field not found for %s", fieldName)
+		}
+		// Check specific byte in buffer
+		if field.Kind() == reflect.Slice && field.Type().Elem().Kind() == reflect.Uint8 {
+			if bufferIndex >= field.Len() {
+				t.Errorf("%s: index %d out of range (buffer len=%d)", fieldName, bufferIndex, field.Len())
+				return
+			}
+			got := int(field.Index(bufferIndex).Uint())
+			expected := expectedValue
+			if str, ok := expectedValue.(string); ok && looksLikeConstant(str) {
+				expected = parseConstant(t, str)
+			} else if intVal, ok := expectedValue.(int); ok {
+				expected = intVal
+			}
+			if got != expected {
+				t.Errorf("%s = %v, want %v", fieldName, got, expected)
+			}
+			return
+		} else {
+			t.Errorf("%s: buffer field is not a byte slice", fieldName)
+			return
+		}
+	}
+
+	field = getField(t, v, fieldName)
+	if !field.IsValid() {
+		return
+	}
+
+	// Parse constant if it's a string that looks like a constant name
+	var expectedInt int
+	var hasExpectedInt bool
+	expected := expectedValue
+	if str, ok := expectedValue.(string); ok && looksLikeConstant(str) {
+		expectedInt = parseConstant(t, str)
+		hasExpectedInt = true
+	} else if intVal, ok := expectedValue.(int); ok {
+		expectedInt = intVal
+		hasExpectedInt = true
+	}
+
+	// Get value based on type (handle unexported fields)
+	var got interface{}
+
+	if field.CanInterface() {
+		// For exported fields, convert expected to field's type
+		if hasExpectedInt {
+			expected = reflect.ValueOf(expectedInt).Convert(field.Type()).Interface()
+		}
+		got = field.Interface()
+
+		// Handle byte slice comparison
+		if field.Type().Kind() == reflect.Slice && field.Type().Elem().Kind() == reflect.Uint8 {
+			if str, ok := expected.(string); ok {
+				expected = []byte(str)
+			}
+		}
+	} else {
+		// For unexported fields, use type-specific accessors
+		switch field.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			val := field.Int()
+			if val > int64(int(^uint(0)>>1)) || val < int64(-int(^uint(0)>>1)-1) {
+				t.Errorf("field %s value %d overflows int", fieldName, val)
+				return
+			}
+			got = int(val)
+			if hasExpectedInt {
+				expected = expectedInt
+			}
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			val := field.Uint()
+			if val > uint64(int(^uint(0)>>1)) {
+				t.Errorf("field %s value %d overflows int", fieldName, val)
+				return
+			}
+			got = int(val)
+			if hasExpectedInt {
+				expected = expectedInt
+			}
+		case reflect.Bool:
+			got = field.Bool()
+		case reflect.String:
+			got = field.String()
+		case reflect.Slice:
+			// Handle byte slice comparison
+			if field.Type().Elem().Kind() == reflect.Uint8 {
+				got = field.Bytes()
+				if str, ok := expected.(string); ok {
+					expected = []byte(str)
+				}
+			}
+		default:
+			t.Errorf("cannot compare unexported field %s of kind %s", fieldName, field.Kind())
+			return
+		}
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("%s = %v, want %v", fieldName, got, expected)
+	}
+}

--- a/internal/libyaml/emitter.go
+++ b/internal/libyaml/emitter.go
@@ -1544,7 +1544,6 @@ func (emitter *Emitter) writeIndent() error {
 		}
 	}
 	emitter.whitespace = true
-	// emitter.indention = true
 	emitter.space_above = false
 	emitter.foot_indent = -1
 	return nil
@@ -1673,7 +1672,6 @@ func (emitter *Emitter) writePlainScalar(value []byte, allow_breaks bool) error 
 			if err := emitter.writeLineBreak(value, &i); err != nil {
 				return err
 			}
-			// emitter.indention = true
 			breaks = true
 		} else {
 			if breaks {
@@ -1730,7 +1728,6 @@ func (emitter *Emitter) writeSingleQuotedScalar(value []byte, allow_breaks bool)
 			if err := emitter.writeLineBreak(value, &i); err != nil {
 				return err
 			}
-			// emitter.indention = true
 			breaks = true
 		} else {
 			if breaks {
@@ -1932,7 +1929,6 @@ func (emitter *Emitter) writeLiteralScalar(value []byte) error {
 	if err := emitter.processLineCommentLinebreak(true); err != nil {
 		return err
 	}
-	// emitter.indention = true
 	emitter.whitespace = true
 	breaks := true
 	for i := 0; i < len(value); {
@@ -1940,7 +1936,6 @@ func (emitter *Emitter) writeLiteralScalar(value []byte) error {
 			if err := emitter.writeLineBreak(value, &i); err != nil {
 				return err
 			}
-			// emitter.indention = true
 			breaks = true
 		} else {
 			if breaks {
@@ -1970,7 +1965,6 @@ func (emitter *Emitter) writeFoldedScalar(value []byte) error {
 		return err
 	}
 
-	// emitter.indention = true
 	emitter.whitespace = true
 
 	breaks := true
@@ -1991,7 +1985,6 @@ func (emitter *Emitter) writeFoldedScalar(value []byte) error {
 			if err := emitter.writeLineBreak(value, &i); err != nil {
 				return err
 			}
-			// emitter.indention = true
 			breaks = true
 		} else {
 			if breaks {
@@ -2025,7 +2018,6 @@ func (emitter *Emitter) writeComment(comment []byte) error {
 			if err := emitter.writeLineBreak(comment, &i); err != nil {
 				return err
 			}
-			// emitter.indention = true
 			breaks = true
 			pound = false
 		} else {
@@ -2059,6 +2051,5 @@ func (emitter *Emitter) writeComment(comment []byte) error {
 	}
 
 	emitter.whitespace = true
-	// emitter.indention = true
 	return nil
 }

--- a/internal/libyaml/emitter_test.go
+++ b/internal/libyaml/emitter_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"bytes"
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestEmitter(t *testing.T) {
+	RunTestCases(t, "emitter.yaml", map[string]TestHandler{
+		"emit":        RunEmitTest,
+		"emit-config": RunEmitTest,
+		"roundtrip":   RunRoundTripTest,
+		"emit-writer": runEmitWriterTest,
+	})
+}
+
+func runEmitWriterTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	var events []Event
+	for _, eventSpec := range tc.Events {
+		events = append(events, CreateEventFromSpec(t, eventSpec))
+	}
+
+	emitter := NewEmitter()
+	var buf bytes.Buffer
+	emitter.SetOutputWriter(&buf)
+
+	for i := range events {
+		err := emitter.Emit(&events[i])
+		assert.NoErrorf(t, err, "Emit() error: %v", err)
+	}
+
+	result := buf.String()
+	for _, expected := range tc.WantContains {
+		assert.Truef(t, bytes.Contains([]byte(result), []byte(expected)),
+			"output should contain %q, got %q", expected, result)
+	}
+}

--- a/internal/libyaml/loader_test.go
+++ b/internal/libyaml/loader_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"reflect"
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestLoader(t *testing.T) {
+	RunTestCases(t, "loader.yaml", map[string]TestHandler{
+		"scalar-resolution": func(t *testing.T, tc TestCase) {
+			t.Helper()
+
+			// Load the YAML
+			result, err := LoadYAML([]byte(tc.Yaml))
+			assert.NoErrorf(t, err, "LoadYAML() error: %v", err)
+
+			// Compare the result with expected value
+			if !reflect.DeepEqual(result, tc.Want) {
+				t.Errorf("LoadYAML() = %v (type: %T), want %v (type: %T)",
+					result, result, tc.Want, tc.Want)
+			}
+		},
+	})
+}

--- a/internal/libyaml/parser_test.go
+++ b/internal/libyaml/parser_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"bytes"
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestParser(t *testing.T) {
+	RunTestCases(t, "parser.yaml", map[string]TestHandler{
+		"parse-events":          runParseEventsTest,
+		"parse-events-detailed": runParseEventsDetailedTest,
+		"parse-error":           runParseErrorTest,
+	})
+}
+
+func runParseEventsTest(t *testing.T, tc TestCase) {
+	types, ok := parseEvents(tc.Yaml)
+	assert.Truef(t, ok, "parseEvents() = %v, want true", ok)
+
+	// Convert Want from interface{} to []string
+	wantSlice, ok := tc.Want.([]interface{})
+	assert.Truef(t, ok, "Want should be []interface{}")
+
+	var expected []EventType
+	for _, item := range wantSlice {
+		eventStr, ok := item.(string)
+		assert.Truef(t, ok, "Want item should be string")
+		expected = append(expected, ParseEventType(t, eventStr))
+	}
+
+	assert.Equalf(t, len(expected), len(types), "parseEvents() types length = %d, want %d", len(types), len(expected))
+	for i, et := range expected {
+		assert.Equalf(t, et, types[i], "parseEvents() types[%d] = %v, want %v", i, types[i], et)
+	}
+}
+
+func runParseEventsDetailedTest(t *testing.T, tc TestCase) {
+	events, ok := parseEventsDetailed(tc.Yaml)
+	assert.Truef(t, ok, "parseEventsDetailed() = %v, want true", ok)
+
+	assert.Equalf(t, len(tc.WantSpecs), len(events), "parseEventsDetailed() events length = %d, want %d", len(events), len(tc.WantSpecs))
+
+	for i, wantSpec := range tc.WantSpecs {
+		event := events[i]
+		wantType := ParseEventType(t, wantSpec.Type)
+
+		assert.Equalf(t, wantType, event.Type, "event[%d].Type = %v, want %v", i, event.Type, wantType)
+
+		// Check specific event properties if specified
+		if wantSpec.Anchor != "" {
+			assert.Truef(t, bytes.Equal(event.Anchor, []byte(wantSpec.Anchor)),
+				"event[%d].Anchor = %q, want %q", i, event.Anchor, wantSpec.Anchor)
+		}
+
+		if wantSpec.Tag != "" {
+			assert.Truef(t, bytes.Equal(event.Tag, []byte(wantSpec.Tag)),
+				"event[%d].Tag = %q, want %q", i, event.Tag, wantSpec.Tag)
+		}
+
+		if wantSpec.Value != "" {
+			assert.Truef(t, bytes.Equal(event.Value, []byte(wantSpec.Value)),
+				"event[%d].Value = %q, want %q", i, event.Value, wantSpec.Value)
+		}
+
+		if wantSpec.VersionDirective != nil {
+			assert.NotNilf(t, event.version_directive, "event[%d].version_directive should not be nil", i)
+			assert.Equalf(t, wantSpec.VersionDirective.Major, int(event.version_directive.major),
+				"event[%d].version_directive.major = %d, want %d", i, event.version_directive.major, wantSpec.VersionDirective.Major)
+			assert.Equalf(t, wantSpec.VersionDirective.Minor, int(event.version_directive.minor),
+				"event[%d].version_directive.minor = %d, want %d", i, event.version_directive.minor, wantSpec.VersionDirective.Minor)
+		}
+
+		if len(wantSpec.TagDirectives) > 0 {
+			assert.Equalf(t, len(wantSpec.TagDirectives), len(event.tag_directives),
+				"event[%d].tag_directives length = %d, want %d", i, len(event.tag_directives), len(wantSpec.TagDirectives))
+			for j, wantTd := range wantSpec.TagDirectives {
+				assert.Truef(t, bytes.Equal(event.tag_directives[j].handle, []byte(wantTd.Handle)),
+					"event[%d].tag_directives[%d].handle = %q, want %q", i, j, event.tag_directives[j].handle, wantTd.Handle)
+				assert.Truef(t, bytes.Equal(event.tag_directives[j].prefix, []byte(wantTd.Prefix)),
+					"event[%d].tag_directives[%d].prefix = %q, want %q", i, j, event.tag_directives[j].prefix, wantTd.Prefix)
+			}
+		}
+	}
+}
+
+func runParseErrorTest(t *testing.T, tc TestCase) {
+	parser := NewParser()
+	parser.SetInputString([]byte(tc.Yaml))
+
+	var event Event
+	for parser.Parse(&event) && event.Type != STREAM_END_EVENT {
+	}
+
+	// Convert Want from interface{} to check for error
+	// Want can be either a boolean or a single-element sequence
+	// Defaults to true if not specified
+	wantError := true
+	if tc.Want != nil {
+		switch v := tc.Want.(type) {
+		case bool:
+			wantError = v
+		case []interface{}:
+			if len(v) > 0 {
+				if boolVal, ok := v[0].(bool); ok {
+					wantError = boolVal
+				}
+			}
+		}
+	}
+	if wantError {
+		assert.Truef(t, parser.ErrorType != NO_ERROR, "Expected parser error, but got none")
+	} else {
+		assert.Truef(t, parser.ErrorType == NO_ERROR, "Expected no parser error, but got %v", parser.ErrorType)
+	}
+}

--- a/internal/libyaml/reader_test.go
+++ b/internal/libyaml/reader_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestReader(t *testing.T) {
+	RunTestCases(t, "reader.yaml", map[string]TestHandler{
+		"reader-set-error":          runReaderSetErrorTest,
+		"reader-determine-encoding": runReaderDetermineEncodingTest,
+		"reader-update-raw-buffer":  runReaderUpdateRawBufferTest,
+		"reader-update-buffer":      runReaderUpdateBufferTest,
+		"reader-panic":              runReaderPanicTest,
+	})
+}
+
+func runReaderSetErrorTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	parser := NewParser()
+
+	// args should be [problem, offset, value]
+	assert.Truef(t, len(tc.Args) >= 3, "Args should have at least 3 elements, got %d", len(tc.Args))
+	problem, ok := tc.Args[0].(string)
+	assert.Truef(t, ok, "Args[0] should be string, got %T", tc.Args[0])
+	offset, ok := tc.Args[1].(int)
+	assert.Truef(t, ok, "Args[1] should be int, got %T", tc.Args[1])
+	value, ok := tc.Args[2].(int)
+	assert.Truef(t, ok, "Args[2] should be int, got %T", tc.Args[2])
+
+	result := parser.setReaderError(problem, offset, value)
+
+	// Check return value
+	want, ok := tc.Want.(bool)
+	assert.Truef(t, ok, "Want should be bool, got %T", tc.Want)
+	assert.Equalf(t, want, result, "setReaderError() = %v, want %v", result, want)
+
+	// Run field checks
+	runFieldChecks(t, &parser, tc.Checks)
+}
+
+func runReaderDetermineEncodingTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	parser := NewParser()
+	parser.SetInputString(tc.Input)
+
+	result := parser.determineEncoding()
+
+	// Check return value (defaults to true)
+	want := WantBool(t, tc.Want, true)
+	assert.Equalf(t, want, result, "determineEncoding() = %v, want %v", result, want)
+
+	// Run field checks
+	runFieldChecks(t, &parser, tc.Checks)
+}
+
+func runReaderUpdateRawBufferTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	parser := NewParser()
+	parser.SetInputString(tc.Input)
+
+	// Apply any setup
+	if tc.Setup != nil {
+		applySetup(t, &parser, tc.Setup)
+	}
+
+	result := parser.updateRawBuffer()
+
+	// Check return value (defaults to true)
+	want := WantBool(t, tc.Want, true)
+	assert.Equalf(t, want, result, "updateRawBuffer() = %v, want %v", result, want)
+
+	// Run field checks
+	runFieldChecks(t, &parser, tc.Checks)
+}
+
+func runReaderUpdateBufferTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	parser := NewParser()
+	parser.SetInputString(tc.Input)
+
+	// Apply any setup
+	if tc.Setup != nil {
+		applySetup(t, &parser, tc.Setup)
+	}
+
+	// Get the length argument
+	assert.Truef(t, len(tc.Args) >= 1, "Args should have at least 1 element, got %d", len(tc.Args))
+	length, ok := tc.Args[0].(int)
+	assert.Truef(t, ok, "Args[0] should be int, got %T", tc.Args[0])
+
+	result := parser.updateBuffer(length)
+
+	// Check return value (defaults to true)
+	want := WantBool(t, tc.Want, true)
+	assert.Equalf(t, want, result, "updateBuffer(%d) = %v, want %v", length, result, want)
+
+	// Run field checks
+	runFieldChecks(t, &parser, tc.Checks)
+}
+
+func runReaderPanicTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	parser := NewParser()
+
+	wantMsg, ok := tc.Want.(string)
+	assert.Truef(t, ok, "Want should be string, got %T", tc.Want)
+
+	assert.PanicMatchesf(t, wantMsg, func() {
+		switch tc.Function {
+		case "updateBuffer":
+			assert.Truef(t, len(tc.Args) >= 1, "Args should have at least 1 element, got %d", len(tc.Args))
+			length, ok := tc.Args[0].(int)
+			assert.Truef(t, ok, "Args[0] should be int, got %T", tc.Args[0])
+			parser.updateBuffer(length)
+		default:
+			t.Fatalf("unknown function: %s", tc.Function)
+		}
+	}, "Expected panic: %s", wantMsg)
+}
+
+func applySetup(t *testing.T, parser *Parser, setup interface{}) {
+	t.Helper()
+
+	if setup == nil {
+		return
+	}
+
+	setupMap, ok := setup.(map[string]interface{})
+	if !ok {
+		t.Fatalf("setup must be a map, got %T", setup)
+	}
+
+	for key, value := range setupMap {
+		switch key {
+		case "eof":
+			boolVal, ok := value.(bool)
+			assert.Truef(t, ok, "setup.eof should be bool, got %T", value)
+			parser.eof = boolVal
+		default:
+			t.Fatalf("unknown setup key: %s", key)
+		}
+	}
+}

--- a/internal/libyaml/scanner_test.go
+++ b/internal/libyaml/scanner_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"bytes"
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestScanner(t *testing.T) {
+	RunTestCases(t, "scanner.yaml", map[string]TestHandler{
+		"scan-tokens":          runScanTokensTest,
+		"scan-tokens-detailed": runScanTokensDetailedTest,
+		"scan-error":           runScanErrorTest,
+	})
+}
+
+func runScanTokensTest(t *testing.T, tc TestCase) {
+	types, ok := scanTokens(tc.Yaml)
+	assert.Truef(t, ok, "scanTokens() failed")
+
+	// Convert Want from interface{} to []string
+	wantSlice, ok := tc.Want.([]interface{})
+	assert.Truef(t, ok, "Want should be []interface{}")
+
+	var expected []TokenType
+	for _, item := range wantSlice {
+		tokenStr, ok := item.(string)
+		assert.Truef(t, ok, "Want item should be string")
+		expected = append(expected, ParseTokenType(t, tokenStr))
+	}
+
+	assert.Equalf(t, len(expected), len(types), "scanTokens() got %d tokens, want %d", len(types), len(expected))
+	for i, tt := range expected {
+		assert.Equalf(t, tt, types[i], "token[%d] = %v, want %v", i, types[i], tt)
+	}
+}
+
+func runScanTokensDetailedTest(t *testing.T, tc TestCase) {
+	tokens, ok := scanTokensDetailed(tc.Yaml)
+	assert.Truef(t, ok, "scanTokensDetailed() failed")
+
+	assert.Equalf(t, len(tc.WantTokens), len(tokens), "scanTokensDetailed() got %d tokens, want %d", len(tokens), len(tc.WantTokens))
+
+	for i, wantSpec := range tc.WantTokens {
+		token := tokens[i]
+		wantType := ParseTokenType(t, wantSpec.Type)
+
+		assert.Equalf(t, wantType, token.Type, "token[%d].Type = %v, want %v", i, token.Type, wantType)
+
+		// Check specific token properties if specified
+		if wantSpec.Value != "" {
+			assert.Truef(t, bytes.Equal(token.Value, []byte(wantSpec.Value)),
+				"token[%d].Value = %q, want %q", i, token.Value, wantSpec.Value)
+		}
+
+		if wantSpec.Style != "" {
+			wantStyle := ParseScalarStyle(t, wantSpec.Style)
+			assert.Equalf(t, wantStyle, token.Style, "token[%d].Style = %v, want %v", i, token.Style, wantStyle)
+		}
+	}
+}
+
+func runScanErrorTest(t *testing.T, tc TestCase) {
+	parser := NewParser()
+	parser.SetInputString([]byte(tc.Yaml))
+
+	var token Token
+	for parser.Scan(&token) && token.Type != STREAM_END_TOKEN {
+	}
+
+	// Convert Want from interface{} to check for error
+	// Want can be either a boolean or a single-element sequence
+	// Defaults to true if not specified
+	wantError := true
+	if tc.Want != nil {
+		switch v := tc.Want.(type) {
+		case bool:
+			wantError = v
+		case []interface{}:
+			if len(v) > 0 {
+				if boolVal, ok := v[0].(bool); ok {
+					wantError = boolVal
+				}
+			}
+		}
+	}
+	if wantError {
+		assert.Truef(t, parser.ErrorType != NO_ERROR, "Expected scanner error, but got none")
+	} else {
+		assert.Truef(t, parser.ErrorType == NO_ERROR, "Expected no scanner error, but got %v", parser.ErrorType)
+	}
+}

--- a/internal/libyaml/testdata/api.yaml
+++ b/internal/libyaml/testdata/api.yaml
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+# API tests for constructors and methods
+#
+# Purpose: Tests the public API of Parser and Emitter types (constructors, methods, cleanup).
+#
+# Test Types:
+#   api-new       - Tests constructors (NewParser, NewEmitter)
+#   api-method    - Tests methods and resulting field state
+#   api-panic     - Tests methods that should panic under certain conditions
+#   api-delete    - Tests cleanup via Delete() method
+#   api-new-event - Tests event constructor functions
+#
+# Common Keys:
+#   name  - Test case name (string)
+#   type  - Test type (api-new | api-method | api-panic | api-delete | api-new-event)
+#   with - Constructor name (NewParser | NewEmitter) - which type to instantiate
+#   call - Method call specification [MethodName, arg1, arg2, ...] - method to call with arguments
+#   init - Setup method call [MethodName, arg1, arg2, ...] - called before main method (for api-panic)
+#   byte - Boolean flag, when true converts string arguments to []byte
+#   test - Field validation specifications (for api-new, api-method, api-delete):
+#          List of field checks, each in format: operator: [field, value]
+#          Operators:
+#          * nil - Boolean, check if field is nil (true) or not nil (false)
+#          * cap - Integer, check slice capacity equals this value
+#          * len - Integer, check length (for slices/strings) equals this value
+#          * eq  - Value, check field equals this value
+#          * gte - Integer, check value is greater than or equal
+#          * len-gt - Integer, check length is greater than this value
+#          Examples:
+#          * nil: [buffer, false]         - buffer is not nil
+#          * cap: [buffer, 512]            - buffer has capacity 512
+#          * eq: [input, 'test']           - input field equals 'test'
+#   want  - Expected result (format varies by test type):
+#           * For api-panic: string containing expected panic message substring
+#           * For other types: format varies
+
+# Constructor tests
+- api-new:
+    name: New parser
+    with: NewParser
+    test:
+    - nil: [raw-buffer, false]
+    - cap: [raw-buffer, 512]  # input_raw_buffer_size
+    - nil: [buffer, false]
+    - cap: [buffer, 1536]  # input_buffer_size
+
+- api-new:
+    name: New emitter
+    with: NewEmitter
+    test:
+    - nil: [buffer, false]
+    - len: [buffer, 128]  # output_buffer_size
+    - nil: [raw-buffer, false]
+    - nil: [states, false]
+    - nil: [events, false]
+    - eq: [best-width, -1]
+
+# Method tests
+- api-method:
+    name: Parser set input string
+    with: NewParser
+    byte: true
+    call: [SetInputString, 'key: value']
+    test:
+    - eq: [input, 'key: value']
+    - eq: [input-pos, 0]
+    - nil: [read-handler, false]
+
+- api-method:
+    name: Parser set encoding
+    with: NewParser
+    call: [SetEncoding, UTF8_ENCODING]
+    test:
+    - eq: [encoding, UTF8_ENCODING]
+
+- api-method:
+    name: Emitter set canonical true
+    with: NewEmitter
+    call: [SetCanonical, true]
+    test:
+    - eq: [canonical, true]
+
+- api-method:
+    name: Emitter set canonical false
+    with: NewEmitter
+    call: [SetCanonical, false]
+    test:
+    - eq: [canonical, false]
+
+- api-method:
+    name: Emitter set indent 2
+    with: NewEmitter
+    call: [SetIndent, 2]
+    test:
+    - eq: [BestIndent, 2]
+
+- api-method:
+    name: Emitter set indent 5
+    with: NewEmitter
+    call: [SetIndent, 5]
+    test:
+    - eq: [BestIndent, 5]
+
+- api-method:
+    name: Emitter set indent clamp low
+    with: NewEmitter
+    call: [SetIndent, 1]
+    test:
+    - eq: [BestIndent, 2]
+
+- api-method:
+    name: Emitter set indent clamp high
+    with: NewEmitter
+    call: [SetIndent, 10]
+    test:
+    - eq: [BestIndent, 2]
+
+- api-method:
+    name: Emitter set width 80
+    with: NewEmitter
+    call: [SetWidth, 80]
+    test:
+    - eq: [best-width, 80]
+
+- api-method:
+    name: Emitter set width -1
+    with: NewEmitter
+    call: [SetWidth, -1]
+    test:
+    - eq: [best-width, -1]
+
+- api-method:
+    name: Emitter set width clamp
+    with: NewEmitter
+    call: [SetWidth, -10]
+    test:
+    - eq: [best-width, -1]
+
+- api-method:
+    name: Emitter set unicode true
+    with: NewEmitter
+    call: [SetUnicode, true]
+    test:
+    - eq: [unicode, true]
+
+- api-method:
+    name: Emitter set unicode false
+    with: NewEmitter
+    call: [SetUnicode, false]
+    test:
+    - eq: [unicode, false]
+
+- api-method:
+    name: Emitter set line break
+    with: NewEmitter
+    call: [SetLineBreak, LN_BREAK]
+    test:
+    - eq: [line-break, LN_BREAK]
+
+# Panic tests
+- api-panic:
+    name: Parser set input string twice
+    with: NewParser
+    byte: true
+    init: [SetInputString, first]
+    call: [SetInputString, second]
+    want: must set the input source only once
+
+- api-panic:
+    name: Parser set encoding twice
+    with: NewParser
+    init: [SetEncoding, UTF8_ENCODING]
+    call: [SetEncoding, UTF16LE_ENCODING]
+    want: must set the encoding only once
+
+- api-panic:
+    name: Emitter set encoding twice
+    with: NewEmitter
+    init: [SetEncoding, UTF8_ENCODING]
+    call: [SetEncoding, UTF16LE_ENCODING]
+    want: must set the output encoding only once
+
+# Delete tests
+- api-delete:
+    name: Parser delete
+    with: NewParser
+    byte: true
+    init: [SetInputString, test]
+    test:
+    - len: [input, 0]
+    - len: [buffer, 0]
+
+- api-delete:
+    name: Emitter delete
+    with: NewEmitter
+    test:
+    - nil: [output-buffer, true]
+    - len: [buffer, 0]
+
+# Event constructor tests
+- api-new-event:
+    name: New stream start event
+    call: [NewStreamStartEvent, UTF8_ENCODING]
+    test:
+    - eq: [Type, STREAM_START_EVENT]
+    - eq: [encoding, UTF8_ENCODING]
+
+- api-new-event:
+    name: New stream end event
+    call: [NewStreamEndEvent]
+    test:
+    - eq: [Type, STREAM_END_EVENT]
+
+- api-new-event:
+    name: New document end event
+    call: [NewDocumentEndEvent, false]
+    test:
+    - eq: [Type, DOCUMENT_END_EVENT]
+    - eq: [Implicit, false]
+
+- api-new-event:
+    name: New alias event
+    byte: true
+    call: [NewAliasEvent, myanchor]
+    test:
+    - eq: [Type, ALIAS_EVENT]
+    - eq: [Anchor, myanchor]
+
+- api-new-event:
+    name: New sequence end event
+    call: [NewSequenceEndEvent]
+    test:
+    - eq: [Type, SEQUENCE_END_EVENT]
+
+- api-new-event:
+    name: New mapping end event
+    call: [NewMappingEndEvent]
+    test:
+    - eq: [Type, MAPPING_END_EVENT]

--- a/internal/libyaml/testdata/emitter.yaml
+++ b/internal/libyaml/testdata/emitter.yaml
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+# Emitter test cases for libyaml emitter
+#
+# Purpose: Tests the YAML emitter that converts events into YAML text output.
+#
+# Format: Test cases use type-as-key format:
+#   - test-type:
+#       name: Test case name
+#       ...
+#
+# Test Types:
+#   emit        - Emit events to string, verify output contains expected strings
+#   emit-config - Emit events with specific emitter configuration
+#   roundtrip   - Parse input YAML, emit it back, verify output contains expected strings
+#   emit-writer - Emit events to io.Writer, verify output contains expected strings
+#
+# Common Keys:
+#   name - Test case name (string)
+#   data - List of event specifications to emit (for emit, emit-config, emit-writer)
+#   conf - Emitter configuration map (for emit-config type only):
+#          * canonical - Boolean, emit in canonical YAML form
+#          * indent    - Integer (2-9), indentation width in spaces
+#          * width     - Integer, line width (-1 for unlimited, or positive number)
+#          * unicode   - Boolean, enable Unicode character output
+#   yaml - Input YAML string (for roundtrip type only)
+#   want - Expected result (format varies by test type)
+#
+# Event Specification Format (for data lists):
+#   Simplified (type only): - EVENT_TYPE
+#   Detailed (with fields): - EVENT_TYPE:
+#                               encoding: ...  (for STREAM_START_EVENT)
+#                               value: ...     (for SCALAR_EVENT)
+#                               anchor: ...    (for SCALAR_EVENT, ALIAS_EVENT)
+#                               tag: ...       (for SCALAR_EVENT)
+#                               implicit: ...  (for various events)
+#                               style: ...     (PLAIN_SCALAR_STYLE, SINGLE_QUOTED_SCALAR_STYLE,
+#                                               DOUBLE_QUOTED_SCALAR_STYLE, LITERAL_SCALAR_STYLE,
+#                                               FOLDED_SCALAR_STYLE, BLOCK_SEQUENCE_STYLE,
+#                                               FLOW_SEQUENCE_STYLE, BLOCK_MAPPING_STYLE,
+#                                               FLOW_MAPPING_STYLE)
+
+# Simple emit tests
+- emit:
+    name: Simple scalar
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        value: hello
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: hello
+
+- emit:
+    name: Simple mapping
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: BLOCK_MAPPING_STYLE
+    - SCALAR_EVENT:
+        value: key
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: value
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want:
+    - key
+    - value
+
+- emit:
+    name: Block sequence
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SEQUENCE_START_EVENT:
+        implicit: true
+        style: BLOCK_SEQUENCE_STYLE
+    - SCALAR_EVENT:
+        value: item1
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: item2
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SEQUENCE_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want:
+    - item1
+    - item2
+    - '-'
+
+- emit:
+    name: Flow sequence
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SEQUENCE_START_EVENT:
+        implicit: true
+        style: FLOW_SEQUENCE_STYLE
+    - SCALAR_EVENT:
+        value: '1'
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: '2'
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: '3'
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SEQUENCE_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want:
+    - '['
+    - ']'
+
+- emit:
+    name: Flow mapping
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: FLOW_MAPPING_STYLE
+    - SCALAR_EVENT:
+        value: a
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: '1'
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: b
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: '2'
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want:
+    - '{'
+    - '}'
+
+- emit:
+    name: Explicit document
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: false
+    - SCALAR_EVENT:
+        value: value
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: false
+    - STREAM_END_EVENT
+    want:
+    - '---'
+    - '...'
+
+- emit:
+    name: Anchor and alias
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SEQUENCE_START_EVENT:
+        implicit: true
+        style: BLOCK_SEQUENCE_STYLE
+    - SCALAR_EVENT:
+        anchor: myanchor
+        value: value
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - ALIAS_EVENT:
+        anchor: myanchor
+    - SEQUENCE_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want:
+    - '&myanchor'
+    - '*myanchor'
+
+- emit:
+    name: Tag
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        tag: 'tag:yaml.org,2002:str'
+        value: value
+        implicit: false
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: '!!str'
+
+- emit:
+    name: Single quoted scalar
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        value: quoted value
+        implicit: true
+        style: SINGLE_QUOTED_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: "'"
+
+- emit:
+    name: Double quoted scalar
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        value: quoted value
+        implicit: true
+        style: DOUBLE_QUOTED_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: '"'
+
+- emit:
+    name: Literal scalar
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: BLOCK_MAPPING_STYLE
+    - SCALAR_EVENT:
+        value: key
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: "line1\nline2\n"
+        implicit: true
+        style: LITERAL_SCALAR_STYLE
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: '|'
+
+- emit:
+    name: Folded scalar
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: BLOCK_MAPPING_STYLE
+    - SCALAR_EVENT:
+        value: key
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: "folded text\n"
+        implicit: true
+        style: FOLDED_SCALAR_STYLE
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: '>'
+
+# Config tests
+- emit-config:
+    name: Canonical mode
+    conf:
+      canonical: true
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: false
+    - SCALAR_EVENT:
+        value: value
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: false
+    - STREAM_END_EVENT
+    want: ---
+
+- emit-config:
+    name: Custom indent
+    conf:
+      indent: 4
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: BLOCK_MAPPING_STYLE
+    - SCALAR_EVENT:
+        value: key
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: BLOCK_MAPPING_STYLE
+    - SCALAR_EVENT:
+        value: nested
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: value
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - MAPPING_END_EVENT
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: key
+
+- emit-config:
+    name: Custom width
+    conf:
+      width: 40
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        value: short
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: short
+
+- emit-config:
+    name: Unicode mode
+    conf:
+      unicode: true
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        value: "unicode: \u00e9"
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: unicode
+
+- emit:
+    name: Multiple documents
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: false
+    - SCALAR_EVENT:
+        value: doc1
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: false
+    - DOCUMENT_START_EVENT:
+        implicit: false
+    - SCALAR_EVENT:
+        value: doc2
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: false
+    - STREAM_END_EVENT
+    want: ---
+
+- emit:
+    name: Nested structures
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: BLOCK_MAPPING_STYLE
+    - SCALAR_EVENT:
+        value: parent
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SEQUENCE_START_EVENT:
+        implicit: true
+        style: BLOCK_SEQUENCE_STYLE
+    - MAPPING_START_EVENT:
+        implicit: true
+        style: BLOCK_MAPPING_STYLE
+    - SCALAR_EVENT:
+        value: child
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - SCALAR_EVENT:
+        value: value
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - MAPPING_END_EVENT
+    - SEQUENCE_END_EVENT
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want:
+    - parent
+    - child
+
+# Roundtrip test
+- roundtrip:
+    name: Roundtrip
+    yaml: |
+      key: value
+      list:
+      - item1
+      - item2
+    want:
+    - key
+    - value
+    - item1
+
+# Writer test
+- emit-writer:
+    name: Writer
+    data:
+    - STREAM_START_EVENT:
+        encoding: UTF8_ENCODING
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        value: test
+        implicit: true
+        style: PLAIN_SCALAR_STYLE
+    - DOCUMENT_END_EVENT:
+        implicit: true
+    - STREAM_END_EVENT
+    want: test

--- a/internal/libyaml/testdata/loader.yaml
+++ b/internal/libyaml/testdata/loader.yaml
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Data loader test cases for scalar type resolution
+#
+# Purpose: Tests the YAML data loader's ability to correctly parse and resolve
+# different numeric types (positive/negative integers, floats, scientific notation)
+#
+# Test Types:
+#   scalar-resolution - Verifies that scalar values are resolved to correct Go types
+
+- scalar-resolution:
+    name: Positive integer
+    yaml: "42"
+    want: 42
+
+- scalar-resolution:
+    name: Negative integer
+    yaml: "-42"
+    want: -42
+
+- scalar-resolution:
+    name: Zero
+    yaml: "0"
+    want: 0
+
+- scalar-resolution:
+    name: Hex integer lowercase
+    yaml: "0xff"
+    want: 255
+
+- scalar-resolution:
+    name: Hex integer uppercase
+    yaml: "0XFF"
+    want: 255
+
+- scalar-resolution:
+    name: Float with decimal point
+    yaml: "3.14"
+    want: 3.14
+
+- scalar-resolution:
+    name: Negative float
+    yaml: "-2.5"
+    want: -2.5
+
+- scalar-resolution:
+    name: Float starting with decimal
+    yaml: ".5"
+    want: 0.5
+
+- scalar-resolution:
+    name: Float with trailing zeros
+    yaml: "1.500"
+    want: 1.5
+
+- scalar-resolution:
+    name: Boolean true
+    yaml: "true"
+    want: true
+
+- scalar-resolution:
+    name: Boolean false
+    yaml: "false"
+    want: false
+
+- scalar-resolution:
+    name: Null keyword
+    yaml: 'null'
+    want: null
+
+- scalar-resolution:
+    name: String value
+    yaml: "hello"
+    want: 'hello'
+
+- scalar-resolution:
+    name: String that looks like number but quoted
+    yaml: '"42"'
+    want: '42'
+
+- scalar-resolution:
+    name: Mapping with numeric values
+    yaml: |
+      int: 42
+      neg: -10
+      float: 3.14
+    want:
+      int: 42
+      neg: -10
+      float: 3.14
+
+- scalar-resolution:
+    name: Sequence with mixed numeric types
+    yaml: |
+      - 42
+      - -10
+      - 3.14
+    want:
+    - 42
+    - -10
+    - 3.14

--- a/internal/libyaml/testdata/parser.yaml
+++ b/internal/libyaml/testdata/parser.yaml
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+# Parser test cases for libyaml parser
+#
+# Purpose: Tests the YAML parser that converts tokens into events following YAML grammar rules.
+#
+# Format: Test cases use type-as-key format:
+#   - test-type:
+#       name: Test case name
+#       ...
+#
+# Test Types:
+#   parse-events          - Verifies event sequence only
+#   parse-events-detailed - Verifies complete event properties (anchor, tag, value, etc.)
+#   parse-error           - Validates error detection for invalid input
+#
+# Common Keys:
+#   name - Test case name (string)
+#   yaml - Input YAML string to parse
+#   want - Expected result (format varies by test type):
+#          * For parse-error: boolean (defaults to true if omitted; set to false if no error expected)
+#          * For parse-events: list of event type names (scalars or type-as-key format)
+#          * For parse-events-detailed: list of event specifications (type-as-key format)
+#
+# Event Specification Format (for want lists):
+#   Simplified (type only): - EVENT_TYPE
+#   Detailed (with fields): - EVENT_TYPE:
+#                               value: ...
+#                               anchor: ...
+#                               tag: ...
+#                               implicit: ...
+#                               style: ...
+#                               version-directive: {major: N, minor: N}
+#                               tag-directives: [{handle: ..., prefix: ...}]
+
+# Simple event type tests (just checking event type sequence)
+- parse-events:
+    name: Simple scalar
+    yaml: |
+      hello
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - SCALAR_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Simple mapping
+    yaml: |
+      key: value
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Block sequence
+    yaml: |
+      - item1
+      - item2
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - SEQUENCE_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SEQUENCE_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Flow sequence
+    yaml: |
+      [1, 2, 3]
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - SEQUENCE_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SEQUENCE_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Flow mapping
+    yaml: |
+      {a: 1, b: 2}
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Empty input
+    yaml: ''
+    want:
+    - STREAM_START_EVENT
+    - STREAM_END_EVENT
+
+# Detailed tests (checking event properties like anchor, tag, value)
+- parse-events-detailed:
+    name: Explicit document
+    yaml: |
+      ---
+      key: value
+      ...
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT:
+        implicit: false
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT:
+        value: key
+    - SCALAR_EVENT:
+        value: value
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events-detailed:
+    name: Anchor and alias
+    yaml: |
+      - &anchor value
+      - *anchor
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - SEQUENCE_START_EVENT
+    - SCALAR_EVENT:
+        anchor: anchor
+        value: value
+    - ALIAS_EVENT:
+        anchor: anchor
+    - SEQUENCE_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events-detailed:
+    name: Tag
+    yaml: |
+      !!str value
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - SCALAR_EVENT:
+        tag: tag:yaml.org,2002:str
+        value: value
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events-detailed:
+    name: Scalar value
+    yaml: |
+      key: hello world
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT:
+        value: key
+    - SCALAR_EVENT:
+        value: hello world
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events-detailed:
+    name: Implicit document
+    yaml: |
+      value
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT:
+        implicit: true
+    - SCALAR_EVENT:
+        value: value
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events-detailed:
+    name: Version directive
+    yaml: |
+      %YAML 1.1
+      ---
+      key: value
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT:
+        version-directive:
+          major: 1
+          minor: 1
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT:
+        value: key
+    - SCALAR_EVENT:
+        value: value
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events-detailed:
+    name: Tag directive
+    yaml: |
+      %TAG !yaml! tag:yaml.org,2002:
+      ---
+      key: value
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT:
+        tag-directives:
+        - handle: '!yaml!'
+          prefix: 'tag:yaml.org,2002:'
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT:
+        value: key
+    - SCALAR_EVENT:
+        value: value
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+# Structural tests (complex structures)
+- parse-events:
+    name: Nested structures
+    yaml: |
+      parent:
+      - item1
+      - item2:
+          nested: value
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SEQUENCE_START_EVENT
+    - SCALAR_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - MAPPING_END_EVENT
+    - MAPPING_END_EVENT
+    - SEQUENCE_END_EVENT
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Multiple documents
+    yaml: |
+      ---
+      doc1
+      ---
+      doc2
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - SCALAR_EVENT
+    - DOCUMENT_END_EVENT
+    - DOCUMENT_START_EVENT
+    - SCALAR_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Complex mapping
+    yaml: |
+      ? key1
+      : value1
+      ? key2
+      : value2
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Flow sequence in mapping
+    yaml: |
+      key: [1, 2, 3]
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SEQUENCE_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - SEQUENCE_END_EVENT
+    - MAPPING_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+- parse-events:
+    name: Block mapping in sequence
+    yaml: |
+      - key1: value1
+      - key2: value2
+    want:
+    - STREAM_START_EVENT
+    - DOCUMENT_START_EVENT
+    - SEQUENCE_START_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - MAPPING_END_EVENT
+    - MAPPING_START_EVENT
+    - SCALAR_EVENT
+    - SCALAR_EVENT
+    - MAPPING_END_EVENT
+    - SEQUENCE_END_EVENT
+    - DOCUMENT_END_EVENT
+    - STREAM_END_EVENT
+
+# Error tests
+- parse-error:
+    name: Error state
+    yaml: |
+      key: : invalid

--- a/internal/libyaml/testdata/reader.yaml
+++ b/internal/libyaml/testdata/reader.yaml
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Reader tests for Parser input handling
+#
+# Purpose: Tests Parser methods that handle reading and processing YAML input,
+#          including encoding detection, buffer management, and error handling.
+#
+# Format: Test cases use type-as-key format:
+#   - test-type:
+#       name: Test case name
+#       ...
+#
+# Test Types:
+#   reader-set-error          - Tests setReaderError method
+#   reader-determine-encoding - Tests determineEncoding method
+#   reader-update-raw-buffer  - Tests updateRawBuffer method
+#   reader-update-buffer      - Tests updateBuffer method
+#   reader-panic              - Tests methods that should panic
+#
+# Common Keys:
+#   name - Test case name (string, title case)
+#   data - Input bytes (string or hex byte array like [0xEF, 0xBB, 0xBF])
+#   args - Arguments to pass to method (scalar value or array of values)
+#   init - Setup to perform before test (map of field: value)
+#          * eof: true - Set parser.eof to true before test
+#   want  - Expected return value:
+#           * For reader-set-error: boolean (false for error cases)
+#           * For reader-determine-encoding: boolean (defaults to true if omitted)
+#           * For reader-update-raw-buffer: boolean (defaults to true if omitted)
+#           * For reader-update-buffer: boolean (defaults to true if omitted)
+#           * For reader-panic: panic message substring (string)
+#   func - Function to call for panic tests (updateBuffer, etc.)
+#   test - Field checks to perform after method call (list of operator: [field, value])
+#          Field check operators:
+#          * eq: [field, value]      - Equals (supports constants like UTF8_ENCODING or hex like 0x61)
+#          * len-gt: [field, N]      - Length greater than N
+#          * gte: [field, N]         - Greater than or equal to N
+#          * eq: [buffer-N, X]       - Check byte at index N equals X (e.g., eq: [buffer-0, 0x61])
+
+# setReaderError tests
+- reader-set-error:
+    name: Set reader error
+    args: [test problem, 10, 0x1234]
+    want: false
+    test:
+    - eq: [ErrorType, READER_ERROR]
+    - eq: [Problem, test problem]
+    - eq: [ProblemOffset, 10]
+    - eq: [ProblemValue, 0x1234]
+
+# determineEncoding tests
+- reader-determine-encoding:
+    name: Determine encoding UTF-8 with BOM
+    data: [0xEF, 0xBB, 0xBF, 0x74, 0x65, 0x73, 0x74]
+    test:
+    - eq: [encoding, UTF8_ENCODING]
+    - eq: [raw_buffer_pos, 3]
+
+- reader-determine-encoding:
+    name: Determine encoding UTF-16LE
+    data: [0xFF, 0xFE, 0x74, 0x65, 0x73, 0x74]
+    test:
+    - eq: [encoding, UTF16LE_ENCODING]
+
+- reader-determine-encoding:
+    name: Determine encoding UTF-16BE
+    data: [0xFE, 0xFF, 0x74, 0x65, 0x73, 0x74]
+    test:
+    - eq: [encoding, UTF16BE_ENCODING]
+
+- reader-determine-encoding:
+    name: Determine encoding default UTF-8
+    data: "test: value"
+    test:
+    - eq: [encoding, UTF8_ENCODING]
+
+# updateRawBuffer tests
+- reader-update-raw-buffer:
+    name: Update raw buffer with data
+    data: test data
+    test:
+    - len-gt: [raw_buffer, 0]
+
+- reader-update-raw-buffer:
+    name: Update raw buffer at EOF
+    data: ''
+
+- reader-update-raw-buffer:
+    name: Update raw buffer when already EOF
+    data: ''
+    init:
+      eof: true
+
+# updateBuffer tests
+- reader-update-buffer:
+    name: Update buffer single byte UTF-8
+    data: abc
+    args: 3
+    test:
+    - gte: [unread, 3]
+    - eq: [buffer-0, 0x61]
+    - eq: [buffer-1, 0x62]
+    - eq: [buffer-2, 0x63]
+
+- reader-update-buffer:
+    name: Update buffer multi-byte UTF-8
+    data: [0x61, 0xC2, 0xA9, 0x62]
+    args: 3
+    test:
+    - gte: [unread, 3]
+
+- reader-update-buffer:
+    name: Update buffer control character error
+    data: [0x01]
+    args: 1
+    want: false
+    test:
+    - eq: [ErrorType, READER_ERROR]
+
+- reader-update-buffer:
+    name: Update buffer allowed control characters
+    data: [0x09, 0x0A, 0x0D]
+    args: 3
+
+- reader-update-buffer:
+    name: Update buffer UTF-16LE
+    data: [0xFF, 0xFE, 0x61, 0x00]
+    args: 1
+    test:
+    - eq: [encoding, UTF16LE_ENCODING]
+
+- reader-update-buffer:
+    name: Update buffer UTF-16BE
+    data: [0xFE, 0xFF, 0x00, 0x61]
+    args: 1
+    test:
+    - eq: [encoding, UTF16BE_ENCODING]
+
+- reader-update-buffer:
+    name: Update buffer surrogate pair UTF-16
+    data: [0xFF, 0xFE, 0x3D, 0xD8, 0x4A, 0xDC]
+    args: 1
+    test:
+    - gte: [unread, 1]
+
+- reader-update-buffer:
+    name: Update buffer invalid surrogate pair
+    data: [0xFF, 0xFE, 0x3D, 0xD8, 0x00, 0x00]
+    args: 1
+    want: false
+    test:
+    - eq: [ErrorType, READER_ERROR]
+
+- reader-update-buffer:
+    name: Update buffer unexpected low surrogate
+    data: [0xFF, 0xFE, 0x00, 0xDC, 0x00, 0x00]
+    args: 1
+    want: false
+    test:
+    - eq: [ErrorType, READER_ERROR]
+
+# Panic tests
+- reader-panic:
+    name: Update buffer without read handler
+    func: updateBuffer
+    args: 1
+    want: read handler must be set

--- a/internal/libyaml/testdata/scanner.yaml
+++ b/internal/libyaml/testdata/scanner.yaml
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+# Scanner test cases for libyaml scanner
+#
+# Purpose: Tests the YAML scanner/tokenizer that converts YAML text into tokens.
+#
+# Format: Test cases use type-as-key format:
+#   - test-type:
+#       name: Test case name
+#       ...
+#
+# Test Types:
+#   scan-tokens          - Verifies token sequence only
+#   scan-tokens-detailed - Verifies complete token properties (value, style, etc.)
+#   scan-error           - Validates error detection for invalid input
+#
+# Common Keys:
+#   name - Test case name (string)
+#   yaml - Input YAML string to scan
+#   want - Expected result (format varies by test type):
+#          * For scan-error: boolean (defaults to true if omitted; set to false if no error expected)
+#          * For scan-tokens: list of token type names (scalars or type-as-key format)
+#          * For scan-tokens-detailed: list of token specifications (type-as-key format)
+#
+# Token Specification Format (for want lists):
+#   Simplified (type only): - TOKEN_TYPE
+#   Detailed (with fields): - TOKEN_TYPE:
+#                               value: ...
+#                               style: ...
+
+# Simple token type tests
+- scan-tokens:
+    name: Simple scalar
+    yaml: |-
+      hello
+    want:
+    - STREAM_START_TOKEN
+    - SCALAR_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens:
+    name: Simple mapping
+    yaml: |-
+      key: value
+    want:
+    - STREAM_START_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN
+    - VALUE_TOKEN
+    - SCALAR_TOKEN
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens:
+    name: Block sequence
+    yaml: |
+      - item1
+      - item2
+    want:
+    - STREAM_START_TOKEN
+    - BLOCK_SEQUENCE_START_TOKEN
+    - BLOCK_ENTRY_TOKEN
+    - SCALAR_TOKEN
+    - BLOCK_ENTRY_TOKEN
+    - SCALAR_TOKEN
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens:
+    name: Flow sequence
+    yaml: |-
+      [1, 2, 3]
+    want:
+    - STREAM_START_TOKEN
+    - FLOW_SEQUENCE_START_TOKEN
+    - SCALAR_TOKEN
+    - FLOW_ENTRY_TOKEN
+    - SCALAR_TOKEN
+    - FLOW_ENTRY_TOKEN
+    - SCALAR_TOKEN
+    - FLOW_SEQUENCE_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens:
+    name: Flow mapping
+    yaml: |-
+      {a: 1, b: 2}
+    want:
+    - STREAM_START_TOKEN
+    - FLOW_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN
+    - VALUE_TOKEN
+    - SCALAR_TOKEN
+    - FLOW_ENTRY_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN
+    - VALUE_TOKEN
+    - SCALAR_TOKEN
+    - FLOW_MAPPING_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens:
+    name: Document markers
+    yaml: |
+      ---
+      key: value
+      ...
+    want:
+    - STREAM_START_TOKEN
+    - DOCUMENT_START_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN
+    - VALUE_TOKEN
+    - SCALAR_TOKEN
+    - BLOCK_END_TOKEN
+    - DOCUMENT_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens:
+    name: Empty input
+    yaml: |-
+    want:
+    - STREAM_START_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens:
+    name: Complex nesting
+    yaml: |
+      parent:
+        - item1
+        - nested:
+            key: value
+    want:
+    - STREAM_START_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN
+    - VALUE_TOKEN
+    - BLOCK_SEQUENCE_START_TOKEN
+    - BLOCK_ENTRY_TOKEN
+    - SCALAR_TOKEN
+    - BLOCK_ENTRY_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN
+    - VALUE_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN
+    - VALUE_TOKEN
+    - SCALAR_TOKEN
+    - BLOCK_END_TOKEN
+    - BLOCK_END_TOKEN
+    - BLOCK_END_TOKEN
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+
+# Detailed token tests (checking token properties)
+- scan-tokens-detailed:
+    name: Anchor and alias
+    yaml: |
+      - &anchor value
+      - *anchor
+    want:
+    - STREAM_START_TOKEN
+    - BLOCK_SEQUENCE_START_TOKEN
+    - BLOCK_ENTRY_TOKEN
+    - ANCHOR_TOKEN:
+        value: anchor
+    - SCALAR_TOKEN:
+        value: value
+    - BLOCK_ENTRY_TOKEN
+    - ALIAS_TOKEN:
+        value: anchor
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens-detailed:
+    name: Tag
+    yaml: |-
+      !!str value
+    want:
+    - STREAM_START_TOKEN
+    - TAG_TOKEN:
+        value: '!!'
+    - SCALAR_TOKEN:
+        value: value
+    - STREAM_END_TOKEN
+
+- scan-tokens-detailed:
+    name: Single quoted scalar
+    yaml: |-
+      'hello world'
+    want:
+    - STREAM_START_TOKEN
+    - SCALAR_TOKEN:
+        style: SINGLE_QUOTED_SCALAR_STYLE
+        value: hello world
+    - STREAM_END_TOKEN
+
+- scan-tokens-detailed:
+    name: Double quoted scalar
+    yaml: |-
+      "hello world"
+    want:
+    - STREAM_START_TOKEN
+    - SCALAR_TOKEN:
+        style: DOUBLE_QUOTED_SCALAR_STYLE
+        value: hello world
+    - STREAM_END_TOKEN
+
+- scan-tokens-detailed:
+    name: Literal scalar
+    yaml: |
+      key: |
+        line1
+        line2
+    want:
+    - STREAM_START_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN:
+        value: key
+    - VALUE_TOKEN
+    - SCALAR_TOKEN:
+        style: LITERAL_SCALAR_STYLE
+        value: "line1\nline2\n"
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens-detailed:
+    name: Folded scalar
+    yaml: |
+      key: >
+        folded text
+    want:
+    - STREAM_START_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN:
+        value: key
+    - VALUE_TOKEN
+    - SCALAR_TOKEN:
+        style: FOLDED_SCALAR_STYLE
+        value: "folded text\n"
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens-detailed:
+    name: Version directive
+    yaml: |
+      %YAML 1.1
+      ---
+      key: value
+    want:
+    - STREAM_START_TOKEN
+    - VERSION_DIRECTIVE_TOKEN
+    - DOCUMENT_START_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN:
+        value: key
+    - VALUE_TOKEN
+    - SCALAR_TOKEN:
+        value: value
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens-detailed:
+    name: Tag directive
+    yaml: |
+      %TAG !yaml! tag:yaml.org,2002:
+      ---
+      key: value
+    want:
+    - STREAM_START_TOKEN
+    - TAG_DIRECTIVE_TOKEN
+    - DOCUMENT_START_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - KEY_TOKEN
+    - SCALAR_TOKEN:
+        value: key
+    - VALUE_TOKEN
+    - SCALAR_TOKEN:
+        value: value
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+
+- scan-tokens-detailed:
+    name: Escape sequences
+    yaml: |-
+      "hello\nworld"
+    want:
+    - STREAM_START_TOKEN
+    - SCALAR_TOKEN:
+        style: DOUBLE_QUOTED_SCALAR_STYLE
+        value: "hello\nworld"
+    - STREAM_END_TOKEN
+
+# Error test
+- scan-error:
+    name: Invalid character
+    yaml: "\x01"

--- a/internal/libyaml/testdata/writer.yaml
+++ b/internal/libyaml/testdata/writer.yaml
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Writer tests for Emitter output handling
+#
+# Purpose: Tests Emitter methods that handle writing and flushing output,
+#          including buffer management and write handlers.
+#
+# Format: Test cases use type-as-key format:
+#   - test-type:
+#       name: Test case name
+#       ...
+#
+# Test Types:
+#   writer-flush - Tests flush method with various scenarios
+#   writer-error - Tests flush with error conditions
+#   writer-panic - Tests methods that should panic
+#
+# Common Keys:
+#   name - Test case name (string, title case)
+#   type - Output handler type (string | writer | error-writer)
+#   data - Data to write to buffer (string or hex byte array)
+#   data2 - Second data chunk for multi-flush tests (optional)
+#   func - Function to call for panic tests (flush, etc.)
+#   want - Expected result:
+#          * For writer-flush: expected output string
+#          * For writer-error: error message substring
+#          * For writer-panic: panic message substring
+#   test - Field checks to perform after flush (list of operator: [field, value])
+#          Field check operators:
+#          * eq: [field, value]  - Equals
+#          * len: [field, N]     - Length equals N
+#
+# flush tests
+- writer-flush:
+    name: Flush empty buffer
+    type: string
+    want: ''
+    test:
+    - eq: [buffer_pos, 0]
+
+- writer-flush:
+    name: Flush with data
+    type: string
+    data: test data
+    want: test data
+    test:
+    - eq: [buffer_pos, 0]
+
+- writer-flush:
+    name: Flush multiple times
+    type: string
+    data: first
+    data2: second
+    want: firstsecond
+
+- writer-flush:
+    name: Flush with writer
+    type: writer
+    data: test data
+    want: test data
+
+# error tests
+- writer-error:
+    name: Flush with write error
+    type: error-writer
+    data: test
+    want: write error
+
+# panic tests
+- writer-panic:
+    name: Flush without write handler
+    func: flush
+    data: test
+    want: write handler not set

--- a/internal/libyaml/testdata/yaml.yaml
+++ b/internal/libyaml/testdata/yaml.yaml
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# YAML helper function tests
+#
+# Purpose: Tests utility functions and type conversions (String() methods, style accessors).
+#
+# Format: Test cases use type-as-key format:
+#   - test-type:
+#       name: Test case name
+#       ...
+#
+# Test Types:
+#   enum-string    - Tests String() methods of enum types (converts enum value to string)
+#   style-accessor - Tests style accessor methods on Event type
+#
+# Common Keys:
+#   name - Test case name (string)
+#   enum - Enum type and value to test (for enum-string): [Type, VALUE]
+#          Type: ScalarStyle | TokenType | EventType | ParserState
+#          VALUE: integer or constant name
+#   want - Expected result (for enum-string): string representing the expected String() output
+#   test - Style accessor method and value (for style-accessor): [Method, STYLE]
+#          Method: ScalarStyle | SequenceStyle | MappingStyle
+#          STYLE: style constant name
+
+# ScalarStyle.String() tests
+- enum-string:
+    name: Scalar style plain
+    enum: [ScalarStyle, PLAIN_SCALAR_STYLE]
+    want: Plain
+
+- enum-string:
+    name: Scalar style single
+    enum: [ScalarStyle, SINGLE_QUOTED_SCALAR_STYLE]
+    want: Single
+
+- enum-string:
+    name: Scalar style double
+    enum: [ScalarStyle, DOUBLE_QUOTED_SCALAR_STYLE]
+    want: Double
+
+- enum-string:
+    name: Scalar style literal
+    enum: [ScalarStyle, LITERAL_SCALAR_STYLE]
+    want: Literal
+
+- enum-string:
+    name: Scalar style folded
+    enum: [ScalarStyle, FOLDED_SCALAR_STYLE]
+    want: Folded
+
+- enum-string:
+    name: Scalar style any
+    enum: [ScalarStyle, ANY_SCALAR_STYLE]
+    want: ''
+
+- enum-string:
+    name: Scalar style unknown
+    enum: [ScalarStyle, 99]
+    want: ''
+
+# TokenType.String() tests
+- enum-string:
+    name: Token no token
+    enum: [TokenType, NO_TOKEN]
+    want: NO_TOKEN
+
+- enum-string:
+    name: Token stream start
+    enum: [TokenType, STREAM_START_TOKEN]
+    want: STREAM_START_TOKEN
+
+- enum-string:
+    name: Token scalar
+    enum: [TokenType, SCALAR_TOKEN]
+    want: SCALAR_TOKEN
+
+- enum-string:
+    name: Token unknown
+    enum: [TokenType, 99]
+    want: <unknown token>
+
+# EventType.String() tests
+- enum-string:
+    name: Event no event
+    enum: [EventType, NO_EVENT]
+    want: none
+
+- enum-string:
+    name: Event stream start
+    enum: [EventType, STREAM_START_EVENT]
+    want: stream start
+
+- enum-string:
+    name: Event scalar
+    enum: [EventType, SCALAR_EVENT]
+    want: scalar
+
+- enum-string:
+    name: Event unknown
+    enum: [EventType, 99]
+    want: unknown event 99
+
+# ParserState.String() tests
+- enum-string:
+    name: Parser state stream start
+    enum: [ParserState, PARSE_STREAM_START_STATE]
+    want: PARSE_STREAM_START_STATE
+
+- enum-string:
+    name: Parser state end
+    enum: [ParserState, PARSE_END_STATE]
+    want: PARSE_END_STATE
+
+- enum-string:
+    name: Parser state unknown
+    enum: [ParserState, 99]
+    want: <unknown parser state>
+
+# Event style accessor tests
+- style-accessor:
+    name: Event scalar style
+    test: [ScalarStyle, DOUBLE_QUOTED_SCALAR_STYLE]
+
+- style-accessor:
+    name: Event sequence style
+    test: [SequenceStyle, FLOW_SEQUENCE_STYLE]
+
+- style-accessor:
+    name: Event mapping style
+    test: [MappingStyle, BLOCK_MAPPING_STYLE]

--- a/internal/libyaml/testdata/yamlprivate.yaml
+++ b/internal/libyaml/testdata/yamlprivate.yaml
@@ -1,0 +1,615 @@
+# SPDX-License-Identifier: Apache-2.0
+# Character classification and utility function tests
+#
+# Purpose: Tests internal character classification and conversion functions used
+#          throughout the YAML parser and emitter.
+#
+# Format: Test cases use type-as-key format:
+#   - test-type:
+#       name: Test case name
+#       ...
+#
+# Test Types:
+#   char-predicate - Tests is* functions that return boolean
+#   char-convert   - Tests as* and width functions that return integer
+#
+# Common Keys:
+#   name  - Test case name (string)
+#   func  - Function to call (isAlpha, isDigit, asHex, width, etc.)
+#   data  - Input bytes (string or hex bytes like [0x00])
+#   index - Byte index to test (integer, defaults to 0)
+#   want  - Expected result:
+#           * For char-predicate: boolean (defaults to true if omitted; set to false if needed)
+#           * For char-convert: integer (required)
+
+# isAlpha tests
+- char-predicate:
+    name: Is alpha - letters
+    func: isAlpha
+    data: abc
+
+- char-predicate:
+    name: Is alpha - uppercase
+    func: isAlpha
+    data: ABC
+
+- char-predicate:
+    name: Is alpha - digits
+    func: isAlpha
+    data: '123'
+
+- char-predicate:
+    name: Is alpha - underscore
+    func: isAlpha
+    data: _-
+
+- char-predicate:
+    name: Is alpha - dash at index 1
+    func: isAlpha
+    data: _-
+    index: 1
+
+- char-predicate:
+    name: Is alpha - space
+    func: isAlpha
+    data: ' '
+    want: false
+
+- char-predicate:
+    name: Is alpha - exclamation
+    func: isAlpha
+    data: '!'
+    want: false
+
+- char-predicate:
+    name: Is alpha - at sign
+    func: isAlpha
+    data: '@'
+    want: false
+
+# isFlowIndicator tests
+- char-predicate:
+    name: Is flow indicator - left bracket
+    func: isFlowIndicator
+    data: '['
+
+- char-predicate:
+    name: Is flow indicator - right bracket
+    func: isFlowIndicator
+    data: ']'
+
+- char-predicate:
+    name: Is flow indicator - left brace
+    func: isFlowIndicator
+    data: '{'
+
+- char-predicate:
+    name: Is flow indicator - right brace
+    func: isFlowIndicator
+    data: '}'
+
+- char-predicate:
+    name: Is flow indicator - comma
+    func: isFlowIndicator
+    data: ','
+
+- char-predicate:
+    name: Is flow indicator - letter
+    func: isFlowIndicator
+    data: a
+    want: false
+
+- char-predicate:
+    name: Is flow indicator - colon
+    func: isFlowIndicator
+    data: ':'
+    want: false
+
+# isAnchorChar tests
+- char-predicate:
+    name: Is anchor char - letters
+    func: isAnchorChar
+    data: abc
+
+- char-predicate:
+    name: Is anchor char - digits
+    func: isAnchorChar
+    data: '123'
+
+- char-predicate:
+    name: Is anchor char - underscore dash
+    func: isAnchorChar
+    data: _-
+
+- char-predicate:
+    name: Is anchor char - colon
+    func: isAnchorChar
+    data: ':'
+    want: false
+
+- char-predicate:
+    name: Is anchor char - left bracket
+    func: isAnchorChar
+    data: '['
+    want: false
+
+- char-predicate:
+    name: Is anchor char - space
+    func: isAnchorChar
+    data: ' '
+    want: false
+
+- char-predicate:
+    name: Is anchor char - newline
+    func: isAnchorChar
+    data: "\n"
+    want: false
+
+- char-predicate:
+    name: Is anchor char - BOM
+    func: isAnchorChar
+    data: [0xEF, 0xBB, 0xBF]
+    want: false
+
+# isColon tests
+- char-predicate:
+    name: Is colon - colon
+    func: isColon
+    data: ':'
+
+- char-predicate:
+    name: Is colon - letter
+    func: isColon
+    data: a
+    want: false
+
+# isDigit tests
+- char-predicate:
+    name: Is digit - zero
+    func: isDigit
+    data: '0'
+
+- char-predicate:
+    name: Is digit - five
+    func: isDigit
+    data: '5'
+
+- char-predicate:
+    name: Is digit - nine
+    func: isDigit
+    data: '9'
+
+- char-predicate:
+    name: Is digit - letter
+    func: isDigit
+    data: a
+    want: false
+
+- char-predicate:
+    name: Is digit - space
+    func: isDigit
+    data: ' '
+    want: false
+
+# isHex tests
+- char-predicate:
+    name: Is hex - zero
+    func: isHex
+    data: '0'
+
+- char-predicate:
+    name: Is hex - nine
+    func: isHex
+    data: '9'
+
+- char-predicate:
+    name: Is hex - uppercase A
+    func: isHex
+    data: A
+
+- char-predicate:
+    name: Is hex - uppercase F
+    func: isHex
+    data: F
+
+- char-predicate:
+    name: Is hex - lowercase a
+    func: isHex
+    data: a
+
+- char-predicate:
+    name: Is hex - lowercase f
+    func: isHex
+    data: f
+
+- char-predicate:
+    name: Is hex - uppercase G
+    func: isHex
+    data: G
+    want: false
+
+- char-predicate:
+    name: Is hex - lowercase g
+    func: isHex
+    data: g
+    want: false
+
+# isASCII tests
+- char-predicate:
+    name: Is ASCII - letter
+    func: isASCII
+    data: a
+
+- char-predicate:
+    name: Is ASCII - 0x7F
+    func: isASCII
+    data: [0x7F]
+
+- char-predicate:
+    name: Is ASCII - 0x80
+    func: isASCII
+    data: [0x80]
+    want: false
+
+- char-predicate:
+    name: Is ASCII - 0xFF
+    func: isASCII
+    data: [0xFF]
+    want: false
+
+# isPrintable tests
+- char-predicate:
+    name: Is printable - LF
+    func: isPrintable
+    data: [0x0A]
+
+- char-predicate:
+    name: Is printable - space
+    func: isPrintable
+    data: [0x20]
+
+- char-predicate:
+    name: Is printable - tilde
+    func: isPrintable
+    data: [0x7E]
+
+- char-predicate:
+    name: Is printable - nbsp
+    func: isPrintable
+    data: [0xC2, 0xA0]
+
+- char-predicate:
+    name: Is printable - null
+    func: isPrintable
+    data: [0x00]
+    want: false
+
+- char-predicate:
+    name: Is printable - control char
+    func: isPrintable
+    data: [0x19]
+    want: false
+
+# isZeroChar tests
+- char-predicate:
+    name: Is zero char - null
+    func: isZeroChar
+    data: [0x00]
+
+- char-predicate:
+    name: Is zero char - letter
+    func: isZeroChar
+    data: a
+    want: false
+
+# isBOM tests
+- char-predicate:
+    name: Is BOM - UTF-8 BOM
+    func: isBOM
+    data: [0xEF, 0xBB, 0xBF]
+
+- char-predicate:
+    name: Is BOM - regular text
+    func: isBOM
+    data: abc
+    want: false
+
+# isSpace tests
+- char-predicate:
+    name: Is space - space
+    func: isSpace
+    data: ' '
+
+- char-predicate:
+    name: Is space - letter
+    func: isSpace
+    data: a
+    want: false
+
+# isTab tests
+- char-predicate:
+    name: Is tab - tab
+    func: isTab
+    data: "\t"
+
+- char-predicate:
+    name: Is tab - space
+    func: isTab
+    data: ' '
+    want: false
+
+# isBlank tests
+- char-predicate:
+    name: Is blank - space
+    func: isBlank
+    data: ' '
+
+- char-predicate:
+    name: Is blank - tab
+    func: isBlank
+    data: "\t"
+
+- char-predicate:
+    name: Is blank - letter
+    func: isBlank
+    data: a
+    want: false
+
+- char-predicate:
+    name: Is blank - newline
+    func: isBlank
+    data: "\n"
+    want: false
+
+# isLineBreak tests
+- char-predicate:
+    name: Is line break - CR
+    func: isLineBreak
+    data: "\r"
+
+- char-predicate:
+    name: Is line break - LF
+    func: isLineBreak
+    data: "\n"
+
+- char-predicate:
+    name: Is line break - NEL
+    func: isLineBreak
+    data: [0xC2, 0x85]
+
+- char-predicate:
+    name: Is line break - LS
+    func: isLineBreak
+    data: [0xE2, 0x80, 0xA8]
+
+- char-predicate:
+    name: Is line break - PS
+    func: isLineBreak
+    data: [0xE2, 0x80, 0xA9]
+
+- char-predicate:
+    name: Is line break - letter
+    func: isLineBreak
+    data: a
+    want: false
+
+- char-predicate:
+    name: Is line break - space
+    func: isLineBreak
+    data: ' '
+    want: false
+
+# isCRLF tests
+- char-predicate:
+    name: Is CRLF - CRLF
+    func: isCRLF
+    data: "\r\n"
+
+- char-predicate:
+    name: Is CRLF - LF only
+    func: isCRLF
+    data: [0x0A, 0x00]
+    want: false
+
+- char-predicate:
+    name: Is CRLF - CR only
+    func: isCRLF
+    data: [0x0D, 0x00]
+    want: false
+
+# isBreakOrZero tests
+- char-predicate:
+    name: Is break or zero - CR
+    func: isBreakOrZero
+    data: "\r"
+
+- char-predicate:
+    name: Is break or zero - LF
+    func: isBreakOrZero
+    data: "\n"
+
+- char-predicate:
+    name: Is break or zero - null
+    func: isBreakOrZero
+    data: [0x00]
+
+- char-predicate:
+    name: Is break or zero - NEL
+    func: isBreakOrZero
+    data: [0xC2, 0x85]
+
+- char-predicate:
+    name: Is break or zero - letter
+    func: isBreakOrZero
+    data: a
+    want: false
+
+# isSpaceOrZero tests
+- char-predicate:
+    name: Is space or zero - space
+    func: isSpaceOrZero
+    data: ' '
+
+- char-predicate:
+    name: Is space or zero - CR
+    func: isSpaceOrZero
+    data: "\r"
+
+- char-predicate:
+    name: Is space or zero - LF
+    func: isSpaceOrZero
+    data: "\n"
+
+- char-predicate:
+    name: Is space or zero - null
+    func: isSpaceOrZero
+    data: [0x00]
+
+- char-predicate:
+    name: Is space or zero - letter
+    func: isSpaceOrZero
+    data: a
+    want: false
+
+# isBlankOrZero tests
+- char-predicate:
+    name: Is blank or zero - space
+    func: isBlankOrZero
+    data: ' '
+
+- char-predicate:
+    name: Is blank or zero - tab
+    func: isBlankOrZero
+    data: "\t"
+
+- char-predicate:
+    name: Is blank or zero - CR
+    func: isBlankOrZero
+    data: "\r"
+
+- char-predicate:
+    name: Is blank or zero - LF
+    func: isBlankOrZero
+    data: "\n"
+
+- char-predicate:
+    name: Is blank or zero - null
+    func: isBlankOrZero
+    data: [0x00]
+
+- char-predicate:
+    name: Is blank or zero - letter
+    func: isBlankOrZero
+    data: a
+    want: false
+
+# Converter functions - asDigit tests
+- char-convert:
+    name: As digit - zero
+    func: asDigit
+    data: '0'
+    want: 0
+
+- char-convert:
+    name: As digit - five
+    func: asDigit
+    data: '5'
+    want: 5
+
+- char-convert:
+    name: As digit - nine
+    func: asDigit
+    data: '9'
+    want: 9
+
+# asHex tests
+- char-convert:
+    name: As hex - zero
+    func: asHex
+    data: '0'
+    want: 0
+
+- char-convert:
+    name: As hex - nine
+    func: asHex
+    data: '9'
+    want: 9
+
+- char-convert:
+    name: As hex - uppercase A
+    func: asHex
+    data: A
+    want: 10
+
+- char-convert:
+    name: As hex - uppercase F
+    func: asHex
+    data: F
+    want: 15
+
+- char-convert:
+    name: As hex - lowercase a
+    func: asHex
+    data: a
+    want: 10
+
+- char-convert:
+    name: As hex - lowercase f
+    func: asHex
+    data: f
+    want: 15
+
+# width tests
+- char-convert:
+    name: Width - 0x00
+    func: width
+    data: [0x00]
+    want: 1
+
+- char-convert:
+    name: Width - 0x7F
+    func: width
+    data: [0x7F]
+    want: 1
+
+- char-convert:
+    name: Width - 0xC0
+    func: width
+    data: [0xC0]
+    want: 2
+
+- char-convert:
+    name: Width - 0xDF
+    func: width
+    data: [0xDF]
+    want: 2
+
+- char-convert:
+    name: Width - 0xE0
+    func: width
+    data: [0xE0]
+    want: 3
+
+- char-convert:
+    name: Width - 0xEF
+    func: width
+    data: [0xEF]
+    want: 3
+
+- char-convert:
+    name: Width - 0xF0
+    func: width
+    data: [0xF0]
+    want: 4
+
+- char-convert:
+    name: Width - 0xF7
+    func: width
+    data: [0xF7]
+    want: 4
+
+- char-convert:
+    name: Width - 0xF8
+    func: width
+    data: [0xF8]
+    want: 0

--- a/internal/libyaml/writer_test.go
+++ b/internal/libyaml/writer_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestWriter(t *testing.T) {
+	RunTestCases(t, "writer.yaml", map[string]TestHandler{
+		"writer-flush": runWriterFlushTest,
+		"writer-error": runWriterErrorTest,
+		"writer-panic": runWriterPanicTest,
+	})
+}
+
+func runWriterFlushTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	emitter := NewEmitter()
+	var output []byte
+	var buf bytes.Buffer
+
+	// Setup output handler
+	if tc.Output == "string" {
+		emitter.SetOutputString(&output)
+	} else {
+		emitter.SetOutputWriter(&buf)
+	}
+
+	// Helper to write data and flush
+	writeAndFlush := func(data string) {
+		if len(data) > 0 {
+			copy(emitter.buffer[:], []byte(data))
+			emitter.buffer_pos = len(data)
+		}
+		err := emitter.flush()
+		assert.NoErrorf(t, err, "flush() error: %v", err)
+	}
+
+	// Write and flush data (once or twice)
+	writeAndFlush(string(tc.Input))
+	if len(tc.Data2) > 0 {
+		writeAndFlush(tc.Data2)
+	}
+
+	// Check output
+	actual := output
+	if tc.Output == "writer" {
+		actual = buf.Bytes()
+	}
+	want, ok := tc.Want.(string)
+	assert.Truef(t, ok, "Want should be string, got %T", tc.Want)
+	assert.Equalf(t, want, string(actual), "flush() output = %q, want %q", string(actual), want)
+
+	// Run field checks
+	if tc.Checks != nil {
+		runFieldChecks(t, &emitter, tc.Checks)
+	}
+}
+
+func runWriterErrorTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	emitter := NewEmitter()
+	emitter.SetOutputWriter(&errorWriter{})
+
+	if len(tc.Input) > 0 {
+		copy(emitter.buffer[:], tc.Input)
+		emitter.buffer_pos = len(tc.Input)
+	}
+
+	err := emitter.flush()
+	want, ok := tc.Want.(string)
+	assert.Truef(t, ok, "Want should be string, got %T", tc.Want)
+	assert.ErrorMatchesf(t, want, err, "flush() should return error matching %q, got %v", want, err)
+}
+
+func runWriterPanicTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	emitter := NewEmitter()
+
+	if len(tc.Input) > 0 {
+		copy(emitter.buffer[:], tc.Input)
+		emitter.buffer_pos = len(tc.Input)
+	}
+
+	want, ok := tc.Want.(string)
+	assert.Truef(t, ok, "Want should be string, got %T", tc.Want)
+	assert.PanicMatchesf(t, want, func() {
+		_ = emitter.flush()
+	}, "Expected panic: %s", want)
+}
+
+// errorWriter is a writer that always returns an error
+type errorWriter struct{}
+
+func (w *errorWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("write error")
+}

--- a/internal/libyaml/yaml_test.go
+++ b/internal/libyaml/yaml_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestYAML(t *testing.T) {
+	RunTestCases(t, "yaml.yaml", map[string]TestHandler{
+		"enum-string":    runEnumStringTest,
+		"style-accessor": runStyleAccessorTest,
+	})
+}
+
+func runEnumStringTest(t *testing.T, tc TestCase) {
+	// Parse enum array: [Type, Value]
+	if len(tc.Enum) != 2 {
+		t.Fatalf("enum must be [Type, Value], got %v", tc.Enum)
+	}
+	enumType, ok := tc.Enum[0].(string)
+	if !ok {
+		t.Fatalf("enum type must be string, got %T", tc.Enum[0])
+	}
+
+	// Value can be int or string constant
+	var enumValue int
+	switch v := tc.Enum[1].(type) {
+	case int:
+		enumValue = v
+	case string:
+		// Parse as constant - this will be resolved by the constant lookup
+		enumValue = resolveConstant(t, v)
+	default:
+		t.Fatalf("enum value must be int or string, got %T", tc.Enum[1])
+	}
+
+	var got string
+	switch enumType {
+	case "ScalarStyle":
+		got = ScalarStyle(enumValue).String()
+	case "TokenType":
+		got = TokenType(enumValue).String()
+	case "EventType":
+		got = EventType(enumValue).String()
+	case "ParserState":
+		got = ParserState(enumValue).String()
+	default:
+		t.Fatalf("unknown enum type: %s", enumType)
+	}
+
+	// Want can be either a string or a single-element sequence
+	var want string
+	switch v := tc.Want.(type) {
+	case string:
+		want = v
+	case []interface{}:
+		if len(v) > 0 {
+			var ok bool
+			want, ok = v[0].(string)
+			if !ok {
+				t.Fatalf("want[0] must be string, got %T", v[0])
+			}
+		} else {
+			t.Fatalf("Want slice is empty, expected at least one element")
+		}
+	default:
+		t.Fatalf("want must be a string or sequence, got %T", tc.Want)
+	}
+	assert.Equalf(t, want, got, "%s(%d).String() = %q, want %q", enumType, enumValue, got, want)
+}
+
+func runStyleAccessorTest(t *testing.T, tc TestCase) {
+	// Parse test array: [Method, STYLE]
+	if len(tc.StyleTest) != 2 {
+		t.Fatalf("test must be [Method, STYLE], got %v", tc.StyleTest)
+	}
+	method, ok := tc.StyleTest[0].(string)
+	if !ok {
+		t.Fatalf("method must be string, got %T", tc.StyleTest[0])
+	}
+
+	// Style value can be int or string constant
+	var styleValue int
+	switch v := tc.StyleTest[1].(type) {
+	case int:
+		styleValue = v
+	case string:
+		styleValue = resolveConstant(t, v)
+	default:
+		t.Fatalf("style value must be int or string, got %T", tc.StyleTest[1])
+	}
+
+	event := Event{Style: Style(styleValue)}
+
+	var got int
+	switch method {
+	case "ScalarStyle":
+		got = int(event.ScalarStyle())
+	case "SequenceStyle":
+		got = int(event.SequenceStyle())
+	case "MappingStyle":
+		got = int(event.MappingStyle())
+	default:
+		t.Fatalf("unknown accessor: %s", method)
+	}
+
+	assert.Equalf(t, styleValue, got, "Event.%s() = %v, want %v", method, got, styleValue)
+}

--- a/internal/libyaml/yamldatatest_loader.go
+++ b/internal/libyaml/yamldatatest_loader.go
@@ -1,0 +1,529 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// coerceScalar converts a YAML scalar string to an appropriate Go type
+func coerceScalar(value string) interface{} {
+	// Try bool and null
+	switch value {
+	case "true":
+		return true
+	case "false":
+		return false
+	case "null":
+		return nil
+	}
+
+	// Try hex int (0x or 0X prefix) - needed for test data byte arrays
+	var intVal int
+	if _, err := fmt.Sscanf(strings.ToLower(value), "0x%x", &intVal); err == nil {
+		return intVal
+	}
+
+	// Try float (must check before int because %d will parse "1.5" as "1")
+	if strings.Contains(value, ".") {
+		var floatVal float64
+		if _, err := fmt.Sscanf(value, "%f", &floatVal); err == nil {
+			return floatVal
+		}
+	}
+
+	// Try decimal int
+	if _, err := fmt.Sscanf(value, "%d", &intVal); err == nil {
+		return intVal
+	}
+
+	// Default to string
+	return value
+}
+
+// LoadYAML parses YAML data using the native libyaml Parser.
+// This function is exported so it can be used by other packages for data-driven testing.
+// It returns a generic interface{} which is typically:
+//   - map[string]interface{} for YAML mappings
+//   - []interface{} for YAML sequences
+//   - scalar values, resolved according to the following rules:
+//   - Booleans: "true" and "false" are returned as bool (true/false).
+//   - Nulls: "null" is returned as nil.
+//   - Floats: values containing "." are parsed as float64.
+//   - Decimal integers: values matching integer format are parsed as int.
+//   - All other values are returned as string.
+//
+// This scalar resolution behavior matches the implementation in coerceScalar.
+func LoadYAML(data []byte) (interface{}, error) {
+	parser := NewParser()
+	parser.SetInputString(data)
+	defer parser.Delete()
+
+	type stackEntry struct {
+		container interface{} // map[string]interface{} or []interface{}
+		key       string      // for maps: current key waiting for value
+	}
+
+	var stack []stackEntry
+	var root interface{}
+
+	for {
+		var event Event
+		if !parser.Parse(&event) {
+			if parser.ErrorType != NO_ERROR {
+				return nil, fmt.Errorf("parse error: %s at line %d, column %d",
+					parser.Problem, parser.ProblemMark.Line, parser.ProblemMark.Column)
+			}
+			break
+		}
+
+		switch event.Type {
+		case STREAM_END_EVENT:
+			// End of stream, we're done
+			return root, nil
+
+		case STREAM_START_EVENT, DOCUMENT_START_EVENT:
+			// Structural markers, no action needed
+
+		case MAPPING_START_EVENT:
+			newMap := make(map[string]interface{})
+			stack = append(stack, stackEntry{container: newMap})
+
+		case MAPPING_END_EVENT:
+			if len(stack) > 0 {
+				popped := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+
+				// Add completed map to parent or set as root
+				if len(stack) == 0 {
+					root = popped.container
+				} else {
+					parent := &stack[len(stack)-1]
+					if m, ok := parent.container.(map[string]interface{}); ok {
+						m[parent.key] = popped.container
+						parent.key = "" // Reset key after use
+					} else if s, ok := parent.container.([]interface{}); ok {
+						parent.container = append(s, popped.container)
+					}
+				}
+			}
+
+		case SEQUENCE_START_EVENT:
+			newSlice := make([]interface{}, 0)
+			stack = append(stack, stackEntry{container: newSlice})
+
+		case SEQUENCE_END_EVENT:
+			if len(stack) > 0 {
+				popped := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+
+				// Add completed slice to parent or set as root
+				if len(stack) == 0 {
+					root = popped.container
+				} else {
+					parent := &stack[len(stack)-1]
+					if m, ok := parent.container.(map[string]interface{}); ok {
+						m[parent.key] = popped.container
+						parent.key = "" // Reset key after use
+					} else if s, ok := parent.container.([]interface{}); ok {
+						parent.container = append(s, popped.container)
+					}
+				}
+			}
+
+		case SCALAR_EVENT:
+			value := string(event.Value)
+			// Only coerce plain (unquoted) scalars
+			isQuoted := ScalarStyle(event.Style) != PLAIN_SCALAR_STYLE
+
+			if len(stack) == 0 {
+				// Scalar at root level
+				if isQuoted {
+					root = value
+				} else {
+					root = coerceScalar(value)
+				}
+			} else {
+				parent := &stack[len(stack)-1]
+				if m, ok := parent.container.(map[string]interface{}); ok {
+					if parent.key == "" {
+						// This scalar is a key - keep as string, don't coerce
+						parent.key = value
+					} else {
+						// This scalar is a value
+						if isQuoted {
+							m[parent.key] = value
+						} else {
+							m[parent.key] = coerceScalar(value)
+						}
+						parent.key = ""
+					}
+				} else if s, ok := parent.container.([]interface{}); ok {
+					// Add to sequence
+					if isQuoted {
+						parent.container = append(s, value)
+					} else {
+						parent.container = append(s, coerceScalar(value))
+					}
+				}
+			}
+
+		case DOCUMENT_END_EVENT:
+			// Document end marker, continue processing
+
+		case ALIAS_EVENT, TAIL_COMMENT_EVENT:
+			// For now, skip aliases and comments (not used in test data)
+		}
+	}
+
+	return root, nil
+}
+
+// UnmarshalStruct populates a struct from a map using reflection and yaml tags.
+// This function is exported so it can be used by other packages for data-driven testing.
+//
+// Example:
+//
+//	type TestCase struct {
+//	    Name string `yaml:"name"`
+//	    Data string `yaml:"data"`
+//	}
+//	var tc TestCase
+//	err := libyaml.UnmarshalStruct(&tc, map[string]interface{}{
+//	    "name": "test1",
+//	    "data": "hello",
+//	})
+func UnmarshalStruct(target interface{}, data map[string]interface{}) error {
+	v := reflect.ValueOf(target)
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("target must be pointer to struct, got %T", target)
+	}
+
+	v = v.Elem()
+	t := v.Type()
+
+	// Build map of yaml tag names to field indices (support multiple fields per tag)
+	fieldMap := make(map[string][]int)
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		yamlTag := field.Tag.Get("yaml")
+		if yamlTag != "" && yamlTag != "-" {
+			// Remove options like ",omitempty"
+			if idx := strings.Index(yamlTag, ","); idx != -1 {
+				yamlTag = yamlTag[:idx]
+			}
+			fieldMap[yamlTag] = append(fieldMap[yamlTag], i)
+		}
+	}
+
+	// Populate fields from map
+	for key, value := range data {
+		fieldIndices, ok := fieldMap[key]
+		if !ok {
+			// Skip unknown fields
+			continue
+		}
+
+		// Try each field with this tag until one succeeds
+		var lastErr error
+		for _, fieldIdx := range fieldIndices {
+			field := v.Field(fieldIdx)
+			if !field.CanSet() {
+				continue
+			}
+
+			if err := setField(field, value); err != nil {
+				lastErr = err
+				continue
+			}
+			// Success, move to next key
+			lastErr = nil
+			break
+		}
+
+		// If all fields failed, return the last error
+		if lastErr != nil {
+			return fmt.Errorf("field %s: %w", key, lastErr)
+		}
+	}
+
+	return nil
+}
+
+// setField sets a reflect.Value from an interface{} value
+func setField(field reflect.Value, value interface{}) error {
+	if !field.CanSet() {
+		return fmt.Errorf("field cannot be set")
+	}
+
+	if value == nil {
+		// Set zero value
+		field.Set(reflect.Zero(field.Type()))
+		return nil
+	}
+
+	fieldType := field.Type()
+
+	// Handle custom types with FromValue method (IntOrStr, ByteInput, Args)
+	if field.CanAddr() {
+		addr := field.Addr()
+		if converter, ok := addr.Interface().(interface{ FromValue(interface{}) error }); ok {
+			if err := converter.FromValue(value); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	// Handle basic types
+	valueRefl := reflect.ValueOf(value)
+	valueType := valueRefl.Type()
+
+	// Direct assignment if types match
+	if valueType.AssignableTo(fieldType) {
+		field.Set(valueRefl)
+		return nil
+	}
+
+	// Check if conversion is possible for compatible types
+	if valueType.ConvertibleTo(fieldType) && valueRefl.CanConvert(fieldType) {
+		field.Set(valueRefl.Convert(fieldType))
+		return nil
+	}
+
+	// Handle conversions
+	switch fieldType.Kind() {
+	case reflect.String:
+		if str, ok := value.(string); ok {
+			field.SetString(str)
+			return nil
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if !field.CanInt() {
+			return fmt.Errorf("field cannot store int values")
+		}
+		i64 := valueRefl.Int()
+		if field.OverflowInt(i64) {
+			return fmt.Errorf("value %v overflows %v", value, fieldType)
+		}
+		field.SetInt(i64)
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if !field.CanUint() {
+			return fmt.Errorf("field cannot store uint values")
+		}
+		if !valueRefl.CanUint() {
+			if valueRefl.Int() < 0 {
+				return fmt.Errorf("cannot convert negative %v to %v", value, fieldType)
+			}
+			return fmt.Errorf("cannot convert %v to %v", value, fieldType)
+		}
+		u64 := valueRefl.Uint()
+		if field.OverflowUint(u64) {
+			return fmt.Errorf("value %v overflows %v", value, fieldType)
+		}
+		field.SetUint(u64)
+		return nil
+	case reflect.Bool:
+		field.SetBool(valueRefl.Bool())
+	case reflect.Float32, reflect.Float64:
+		if !field.CanFloat() {
+			return fmt.Errorf("field cannot store float values")
+		}
+		f64 := valueRefl.Float()
+		if field.OverflowFloat(f64) {
+			return fmt.Errorf("value %f overflows %v", f64, fieldType)
+		}
+		field.SetFloat(f64)
+		return nil
+	case reflect.Slice:
+		return setSliceField(field, value)
+	case reflect.Map:
+		return setMapField(field, value)
+	case reflect.Struct:
+		// Recursively unmarshal nested structs
+		if m, ok := value.(map[string]interface{}); ok {
+			if !field.CanAddr() {
+				return fmt.Errorf("cannot take address of field for nested struct unmarshaling")
+			}
+			return UnmarshalStruct(field.Addr().Interface(), m)
+		}
+	case reflect.Interface:
+		// Just set the value directly
+		field.Set(valueRefl)
+		return nil
+	case reflect.Ptr:
+		// Handle pointer types
+		if fieldType.Elem().Kind() == reflect.Struct {
+			m, ok := value.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("expected map for struct pointer, got %T", value)
+			}
+			newStruct := reflect.New(fieldType.Elem())
+			if err := UnmarshalStruct(newStruct.Interface(), m); err != nil {
+				return err
+			}
+			field.Set(newStruct)
+			return nil
+		} else {
+			// Handle pointer to basic types (like *bool, *int, *string)
+			ptr := reflect.New(fieldType.Elem())
+			if err := setField(ptr.Elem(), value); err != nil {
+				return err
+			}
+			field.Set(ptr)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("cannot convert %T to %v", value, fieldType)
+}
+
+// normalizeTypeAsKey converts maps with type as key to standard format.
+// Example: {"SCALAR_TOKEN": {"value": "x"}} -> {"type": "SCALAR_TOKEN", "value": "x"}
+func normalizeTypeAsKey(itemMap map[string]interface{}) map[string]interface{} {
+	// Check if map has exactly one key and no "type" field
+	if len(itemMap) == 1 {
+		_, hasType := itemMap["type"]
+		if !hasType {
+			// Get the single key
+			for key, value := range itemMap {
+				// Check if key looks like a type constant (all uppercase with underscores)
+				if isTypeConstant(key) {
+					// Check if value is a map
+					if subMap, ok := value.(map[string]interface{}); ok {
+						// Create new map with "type" field for test type
+						newMap := map[string]interface{}{"type": key}
+						// Merge in the sub-map fields, but preserve sub-map's "type" as "output_type" if it exists
+						for k, v := range subMap {
+							if k == "type" {
+								// Sub-map has its own "type" field - preserve it as "output_type"
+								newMap["output_type"] = v
+							} else {
+								newMap[k] = v
+							}
+						}
+						return newMap
+					}
+				}
+			}
+		}
+	}
+	return itemMap
+}
+
+// isTypeConstant checks if a string looks like a type constant
+// Accepts: UPPERCASE_WITH_UNDERSCORES or lowercase-with-hyphens
+func isTypeConstant(s string) bool {
+	if s == "" {
+		return false
+	}
+	hasUpper := false
+	hasLower := false
+	for _, c := range s {
+		if c >= 'A' && c <= 'Z' {
+			hasUpper = true
+		} else if c >= 'a' && c <= 'z' {
+			hasLower = true
+		} else if !(c == '_' || c == '-' || c >= '0' && c <= '9') {
+			return false
+		}
+	}
+	// Either all uppercase (EVENT_TYPE) or has lowercase (test-type)
+	return hasUpper || hasLower
+}
+
+// setSliceField sets a slice field from a value
+func setSliceField(field reflect.Value, value interface{}) error {
+	sliceVal, ok := value.([]interface{})
+	if !ok {
+		return fmt.Errorf("expected []interface{} for slice, got %T", value)
+	}
+
+	elemType := field.Type().Elem()
+	newSlice := reflect.MakeSlice(field.Type(), len(sliceVal), len(sliceVal))
+
+	for i, item := range sliceVal {
+		elem := newSlice.Index(i)
+
+		// Handle struct elements
+		if elemType.Kind() == reflect.Struct {
+			var m map[string]interface{}
+
+			// Check if item is a scalar string (simplified format)
+			if strVal, ok := item.(string); ok {
+				// Convert scalar to map with type field
+				m = map[string]interface{}{"type": strVal}
+			} else {
+				m, ok = item.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("slice element %d: expected map for struct, got %T", i, item)
+				}
+				// Normalize type-as-key format
+				m = normalizeTypeAsKey(m)
+			}
+
+			if !elem.CanAddr() {
+				return fmt.Errorf("slice element %d: cannot take address for struct unmarshaling", i)
+			}
+			if err := UnmarshalStruct(elem.Addr().Interface(), m); err != nil {
+				return fmt.Errorf("slice element %d: %w", i, err)
+			}
+			continue
+		}
+
+		// Handle other types
+		if err := setField(elem, item); err != nil {
+			return fmt.Errorf("slice element %d: %w", i, err)
+		}
+	}
+
+	field.Set(newSlice)
+	return nil
+}
+
+// setMapField sets a map field from a value
+func setMapField(field reflect.Value, value interface{}) error {
+	mapVal, ok := value.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("expected map[string]interface{}, got %T", value)
+	}
+
+	mapType := field.Type()
+	if mapType.Key().Kind() != reflect.String {
+		return fmt.Errorf("only string keys supported for maps")
+	}
+
+	newMap := reflect.MakeMap(mapType)
+	valueType := mapType.Elem()
+
+	for k, v := range mapVal {
+		keyRefl := reflect.ValueOf(k)
+		valueRefl := reflect.New(valueType).Elem()
+
+		// Handle struct values
+		if valueType.Kind() == reflect.Struct {
+			m, ok := v.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("map value for key %s: expected map for struct, got %T", k, v)
+			}
+			if !valueRefl.CanAddr() {
+				return fmt.Errorf("map value for key %s: cannot take address for struct unmarshaling", k)
+			}
+			if err := UnmarshalStruct(valueRefl.Addr().Interface(), m); err != nil {
+				return fmt.Errorf("map value for key %s: %w", k, err)
+			}
+		} else {
+			if err := setField(valueRefl, v); err != nil {
+				return fmt.Errorf("map value for key %s: %w", k, err)
+			}
+		}
+
+		newMap.SetMapIndex(keyRefl, valueRefl)
+	}
+
+	field.Set(newMap)
+	return nil
+}

--- a/internal/libyaml/yamldatatest_test.go
+++ b/internal/libyaml/yamldatatest_test.go
@@ -1,0 +1,1071 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+// TestCase represents a single test case loaded from YAML
+type TestCase struct {
+	Name string `yaml:"name"`
+	Type string `yaml:"type"`
+
+	// Common fields
+	Yaml       string      `yaml:"yaml"`
+	InputHex   string      `yaml:"input_hex"`
+	InputBytes string      `yaml:"input_bytes"`
+	Want       interface{} `yaml:"want"`
+	WantSpecs  []EventSpec // Populated from Want for detailed tests
+
+	// scan_tokens_detailed
+	WantTokens []TokenSpec // Populated from Want for detailed tests
+
+	// emit tests
+	Events       []EventSpec   `yaml:"data"`
+	WantContains []string      // Populated from Want for emit tests
+	Config       EmitterConfig `yaml:"conf"`
+
+	// style_accessor tests (must come before Checks due to shared yaml:"test" tag)
+	StyleTest []interface{} `yaml:"test"` // [Method, STYLE] where Method is string and STYLE is int or string constant
+
+	// api_new tests
+	Constructor string       `yaml:"with"`
+	Checks      []FieldCheck `yaml:"test"`
+
+	// encoding_detect tests
+	WantEncoding string `yaml:"want_encoding"`
+
+	// char_classify tests
+	Cases []CharTestCase `yaml:"cases"`
+
+	// yamlprivate tests (char-predicate, char-convert)
+	Function string    `yaml:"func"`  // Function to call
+	Input    ByteInput `yaml:"data"`  // Can be string or []int (hex bytes)
+	Index    int       `yaml:"index"` // Defaults to 0
+
+	// reader tests
+	Args Args `yaml:"args"` // Arguments to pass to method (can be scalar or array)
+
+	// writer tests
+	Output string `yaml:"output_type"` // Output handler type (string, writer, error-writer)
+	Data2  string `yaml:"data2"`       // Second data chunk for multi-flush tests
+
+	// read_handler tests
+	Handler  string `yaml:"handler"`
+	ReadSize int    `yaml:"read_size"`
+	WantData string `yaml:"want_data"`
+	WantEOF  bool   `yaml:"want_eof"`
+
+	// enum_string tests
+	Enum []interface{} `yaml:"enum"` // [Type, Value] where Type is string and Value is int or string
+
+	// api_method, api_panic, api_delete tests, and reader tests
+	Bytes  bool          `yaml:"byte"`
+	Method []interface{} `yaml:"call"`
+	Setup  interface{}   `yaml:"init"` // Can be []interface{} (api tests) or map[string]interface{} (reader tests)
+}
+
+// IntOrStr can be converted from either an int or a string constant name
+// constantMap maps constant names to their integer values
+var constantMap = map[string]int{
+	// ScalarStyle (bit-shifted starting at iota=1)
+	"ANY_SCALAR_STYLE":           0,
+	"PLAIN_SCALAR_STYLE":         2,
+	"SINGLE_QUOTED_SCALAR_STYLE": 4,
+	"DOUBLE_QUOTED_SCALAR_STYLE": 8,
+	"LITERAL_SCALAR_STYLE":       16,
+	"FOLDED_SCALAR_STYLE":        32,
+
+	// TokenType
+	"NO_TOKEN":                   0,
+	"STREAM_START_TOKEN":         1,
+	"STREAM_END_TOKEN":           2,
+	"VERSION_DIRECTIVE_TOKEN":    3,
+	"TAG_DIRECTIVE_TOKEN":        4,
+	"DOCUMENT_START_TOKEN":       5,
+	"DOCUMENT_END_TOKEN":         6,
+	"BLOCK_SEQUENCE_START_TOKEN": 7,
+	"BLOCK_MAPPING_START_TOKEN":  8,
+	"BLOCK_END_TOKEN":            9,
+	"FLOW_SEQUENCE_START_TOKEN":  10,
+	"FLOW_SEQUENCE_END_TOKEN":    11,
+	"FLOW_MAPPING_START_TOKEN":   12,
+	"FLOW_MAPPING_END_TOKEN":     13,
+	"BLOCK_ENTRY_TOKEN":          14,
+	"FLOW_ENTRY_TOKEN":           15,
+	"KEY_TOKEN":                  16,
+	"VALUE_TOKEN":                17,
+	"ALIAS_TOKEN":                18,
+	"ANCHOR_TOKEN":               19,
+	"TAG_TOKEN":                  20,
+	"SCALAR_TOKEN":               21,
+
+	// EventType
+	"NO_EVENT":             0,
+	"STREAM_START_EVENT":   1,
+	"STREAM_END_EVENT":     2,
+	"DOCUMENT_START_EVENT": 3,
+	"DOCUMENT_END_EVENT":   4,
+	"ALIAS_EVENT":          5,
+	"SCALAR_EVENT":         6,
+	"SEQUENCE_START_EVENT": 7,
+	"SEQUENCE_END_EVENT":   8,
+	"MAPPING_START_EVENT":  9,
+	"MAPPING_END_EVENT":    10,
+	"TAIL_COMMENT_EVENT":   11,
+
+	// ParserState
+	"PARSE_STREAM_START_STATE":                      0,
+	"PARSE_IMPLICIT_DOCUMENT_START_STATE":           1,
+	"PARSE_DOCUMENT_START_STATE":                    2,
+	"PARSE_DOCUMENT_CONTENT_STATE":                  3,
+	"PARSE_DOCUMENT_END_STATE":                      4,
+	"PARSE_BLOCK_NODE_STATE":                        5,
+	"PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE":        6,
+	"PARSE_BLOCK_SEQUENCE_ENTRY_STATE":              7,
+	"PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE":         8,
+	"PARSE_BLOCK_MAPPING_FIRST_KEY_STATE":           9,
+	"PARSE_BLOCK_MAPPING_KEY_STATE":                 10,
+	"PARSE_BLOCK_MAPPING_VALUE_STATE":               11,
+	"PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE":         12,
+	"PARSE_FLOW_SEQUENCE_ENTRY_STATE":               13,
+	"PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE":   14,
+	"PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE": 15,
+	"PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE":   16,
+	"PARSE_FLOW_MAPPING_FIRST_KEY_STATE":            17,
+	"PARSE_FLOW_MAPPING_KEY_STATE":                  18,
+	"PARSE_FLOW_MAPPING_VALUE_STATE":                19,
+	"PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE":          20,
+	"PARSE_END_STATE":                               21,
+
+	// SequenceStyle / MappingStyle
+	"ANY_SEQUENCE_STYLE":   0,
+	"BLOCK_SEQUENCE_STYLE": 1,
+	"FLOW_SEQUENCE_STYLE":  2,
+	"ANY_MAPPING_STYLE":    0,
+	"BLOCK_MAPPING_STYLE":  1,
+	"FLOW_MAPPING_STYLE":   2,
+
+	// Encoding
+	"ANY_ENCODING":     0,
+	"UTF8_ENCODING":    1,
+	"UTF16LE_ENCODING": 2,
+	"UTF16BE_ENCODING": 3,
+
+	// LineBreak
+	"ANY_BREAK":  0,
+	"CR_BREAK":   1,
+	"LN_BREAK":   2,
+	"CRLN_BREAK": 3,
+
+	// ErrorType
+	"NO_ERROR":       0,
+	"MEMORY_ERROR":   1,
+	"READER_ERROR":   2,
+	"SCANNER_ERROR":  3,
+	"PARSER_ERROR":   4,
+	"COMPOSER_ERROR": 5,
+	"WRITER_ERROR":   6,
+	"EMITTER_ERROR":  7,
+}
+
+// resolveConstant converts a constant name string to its integer value
+func resolveConstant(t *testing.T, name string) int {
+	t.Helper()
+	val, ok := constantMap[name]
+	if !ok {
+		t.Fatalf("unknown constant name: %s", name)
+	}
+	return val
+}
+
+// IntOrStr can be converted from either an int or a string constant name
+type IntOrStr struct {
+	Value int
+}
+
+func (ios *IntOrStr) FromValue(v interface{}) error {
+	// Try int first
+	if intVal, ok := v.(int); ok {
+		ios.Value = intVal
+		return nil
+	}
+
+	// Otherwise, it should be a string constant name
+	strVal, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("IntOrStr value must be int or string, got %T", v)
+	}
+
+	val, ok := constantMap[strVal]
+	if !ok {
+		return fmt.Errorf("unknown constant name: %s", strVal)
+	}
+	ios.Value = val
+	return nil
+}
+
+// ByteInput can be converted from either a string or a sequence of hex bytes
+type ByteInput []byte
+
+func (bi *ByteInput) FromValue(v interface{}) error {
+	// Try string first
+	if strVal, ok := v.(string); ok {
+		*bi = []byte(strVal)
+		return nil
+	}
+
+	// Try single int (convert to single-byte array)
+	if intVal, ok := v.(int); ok {
+		if intVal < 0 || intVal > 255 {
+			return fmt.Errorf("byte value out of range [0-255]: %d", intVal)
+		}
+		*bi = []byte{byte(intVal)}
+		return nil
+	}
+
+	// Otherwise, it should be a sequence of integer bytes
+	intSlice, ok := v.([]interface{})
+	if !ok {
+		return fmt.Errorf("input must be a string, int, or sequence of integers, got %T", v)
+	}
+
+	// Convert integers to bytes
+	bytes := make([]byte, len(intSlice))
+	for i, val := range intSlice {
+		intVal, ok := val.(int)
+		if !ok {
+			return fmt.Errorf("byte array element must be int, got %T", val)
+		}
+		if intVal < 0 || intVal > 255 {
+			return fmt.Errorf("byte value out of range [0-255]: %d", intVal)
+		}
+		bytes[i] = byte(intVal)
+	}
+	*bi = bytes
+	return nil
+}
+
+// Args can be converted from either a single value or an array of values
+type Args []interface{}
+
+func (a *Args) FromValue(v interface{}) error {
+	// Try array first
+	if arrVal, ok := v.([]interface{}); ok {
+		*a = arrVal
+		return nil
+	}
+
+	// Otherwise, it's a single scalar value - wrap it in a slice
+	*a = []interface{}{v}
+	return nil
+}
+
+// EventSpec specifies an event in YAML format
+type EventSpec struct {
+	Type             string                `yaml:"type"`
+	Encoding         string                `yaml:"encoding"`
+	Implicit         bool                  `yaml:"implicit"`
+	QuotedImplicit   bool                  `yaml:"quoted_implicit"`
+	Anchor           string                `yaml:"anchor"`
+	Tag              string                `yaml:"tag"`
+	Value            string                `yaml:"value"`
+	Style            string                `yaml:"style"`
+	VersionDirective *VersionDirectiveSpec `yaml:"version-directive"`
+	TagDirectives    []TagDirectiveSpec    `yaml:"tag-directives"`
+}
+
+// VersionDirectiveSpec specifies a version directive
+type VersionDirectiveSpec struct {
+	Major int `yaml:"major"`
+	Minor int `yaml:"minor"`
+}
+
+// TagDirectiveSpec specifies a tag directive
+type TagDirectiveSpec struct {
+	Handle string `yaml:"handle"`
+	Prefix string `yaml:"prefix"`
+}
+
+// TokenSpec specifies a token in YAML format
+type TokenSpec struct {
+	Type  string `yaml:"type"`
+	Value string `yaml:"value"`
+	Style string `yaml:"style"`
+}
+
+// EmitterConfig specifies emitter configuration
+type EmitterConfig struct {
+	Canonical bool   `yaml:"canonical"`
+	Indent    int    `yaml:"indent"`
+	Width     int    `yaml:"width"`
+	Unicode   bool   `yaml:"unicode"`
+	LineBreak string `yaml:"line_break"`
+}
+
+// SetupSpec specifies test setup
+type SetupSpec struct {
+	Constructor string     `yaml:"constructor"`
+	Calls       []CallSpec `yaml:"calls"`
+}
+
+// CallSpec specifies a method call
+type CallSpec struct {
+	Method string    `yaml:"method"`
+	Args   []ArgSpec `yaml:"args"`
+}
+
+// ArgSpec specifies a method argument
+type ArgSpec struct {
+	Bytes  string `yaml:"bytes"`
+	String string `yaml:"string"`
+	Int    int    `yaml:"int"`
+	Bool   bool   `yaml:"bool"`
+	Hex    string `yaml:"hex"`
+	Reader bool   `yaml:"reader"` // Creates a strings.Reader from String field
+	Writer bool   `yaml:"writer"` // Creates a bytes.Buffer
+}
+
+// FieldCheck specifies a field check
+type FieldCheck struct {
+	Nil   []interface{} `yaml:"nil"`
+	Cap   []interface{} `yaml:"cap"`
+	Len   []interface{} `yaml:"len"`
+	LenGt []interface{} `yaml:"len-gt"` // Length greater than
+	Eq    []interface{} `yaml:"eq"`
+	Gte   []interface{} `yaml:"gte"` // Greater than or equal
+}
+
+// CharTestCase represents a character classification test case
+type CharTestCase struct {
+	InputHex string      `yaml:"input_hex"`
+	Pos      int         `yaml:"pos"`
+	Want     interface{} `yaml:"want"` // Can be bool or int
+}
+
+// unmarshalTestCases converts raw YAML data to TestCase structs using yamltest
+func unmarshalTestCases(data interface{}) ([]TestCase, error) {
+	casesSlice, ok := data.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected []interface{}, got %T", data)
+	}
+
+	var testCases []TestCase
+	for i, item := range casesSlice {
+		caseMap, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("test case %d: expected map[string]interface{}, got %T", i, item)
+		}
+
+		// Normalize type-as-key format for top-level test cases
+		caseMap = normalizeTypeAsKey(caseMap)
+
+		var tc TestCase
+		if err := UnmarshalStruct(&tc, caseMap); err != nil {
+			return nil, fmt.Errorf("test case %d: %w", i, err)
+		}
+		testCases = append(testCases, tc)
+	}
+
+	return testCases, nil
+}
+
+func LoadTestCases(filename string) ([]TestCase, error) {
+	// Get the path relative to this file
+	_, thisFile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(thisFile)
+	path := filepath.Join(dir, "testdata", filename)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", filename, err)
+	}
+
+	// Load YAML using LoadYAML from testloader.go
+	rawData, err := LoadYAML(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", filename, err)
+	}
+
+	// Convert to TestCase structs
+	cases, err := unmarshalTestCases(rawData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal test cases from %s: %w", filename, err)
+	}
+
+	// Post-process: convert Want to WantSpecs/WantTokens for detailed tests
+	for i := range cases {
+		// Determine which field to populate based on test type
+		switch cases[i].Type {
+		case "parse-events-detailed":
+			if cases[i].Want != nil {
+				// Want should be []interface{} of maps, convert to []EventSpec
+				wantSlice, ok := cases[i].Want.([]interface{})
+				if !ok {
+					return nil, fmt.Errorf("test %s: want should be a sequence, got %T", cases[i].Name, cases[i].Want)
+				}
+				cases[i].WantSpecs = make([]EventSpec, len(wantSlice))
+				for j, item := range wantSlice {
+					var itemMap map[string]interface{}
+					// Check if item is a scalar string (simplified format)
+					if strVal, ok := item.(string); ok {
+						// Convert scalar to map with type field
+						itemMap = map[string]interface{}{"type": strVal}
+					} else {
+						itemMap, ok = item.(map[string]interface{})
+						if !ok {
+							return nil, fmt.Errorf("test %s: want[%d] should be a map or string, got %T", cases[i].Name, j, item)
+						}
+						// Normalize type-as-key format
+						itemMap = normalizeTypeAsKey(itemMap)
+					}
+					if err := UnmarshalStruct(&cases[i].WantSpecs[j], itemMap); err != nil {
+						return nil, fmt.Errorf("test %s: want[%d]: %w", cases[i].Name, j, err)
+					}
+				}
+			}
+		case "scan-tokens-detailed":
+			if cases[i].Want != nil {
+				// Want should be []interface{} of maps, convert to []TokenSpec
+				wantSlice, ok := cases[i].Want.([]interface{})
+				if !ok {
+					return nil, fmt.Errorf("test %s: want should be a sequence, got %T", cases[i].Name, cases[i].Want)
+				}
+				cases[i].WantTokens = make([]TokenSpec, len(wantSlice))
+				for j, item := range wantSlice {
+					var itemMap map[string]interface{}
+					// Check if item is a scalar string (simplified format)
+					if strVal, ok := item.(string); ok {
+						// Convert scalar to map with type field
+						itemMap = map[string]interface{}{"type": strVal}
+					} else {
+						itemMap, ok = item.(map[string]interface{})
+						if !ok {
+							return nil, fmt.Errorf("test %s: want[%d] should be a map or string, got %T", cases[i].Name, j, item)
+						}
+						// Normalize type-as-key format
+						itemMap = normalizeTypeAsKey(itemMap)
+					}
+					if err := UnmarshalStruct(&cases[i].WantTokens[j], itemMap); err != nil {
+						return nil, fmt.Errorf("test %s: want[%d]: %w", cases[i].Name, j, err)
+					}
+				}
+			}
+		}
+
+		// Post-process: convert Want to WantContains for emit tests
+		switch cases[i].Type {
+		case "emit", "emit-config", "roundtrip", "emit-writer":
+			if cases[i].Want != nil {
+				switch v := cases[i].Want.(type) {
+				case string:
+					// Scalar want value
+					cases[i].WantContains = []string{v}
+				case []interface{}:
+					// Sequence want values
+					for _, item := range v {
+						if str, ok := item.(string); ok {
+							cases[i].WantContains = append(cases[i].WantContains, str)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return cases, nil
+}
+
+// ParseEventType converts a string to EventType
+func ParseEventType(t *testing.T, s string) EventType {
+	t.Helper()
+	switch s {
+	case "NO_EVENT":
+		return NO_EVENT
+	case "STREAM_START_EVENT":
+		return STREAM_START_EVENT
+	case "STREAM_END_EVENT":
+		return STREAM_END_EVENT
+	case "DOCUMENT_START_EVENT":
+		return DOCUMENT_START_EVENT
+	case "DOCUMENT_END_EVENT":
+		return DOCUMENT_END_EVENT
+	case "ALIAS_EVENT":
+		return ALIAS_EVENT
+	case "SCALAR_EVENT":
+		return SCALAR_EVENT
+	case "SEQUENCE_START_EVENT":
+		return SEQUENCE_START_EVENT
+	case "SEQUENCE_END_EVENT":
+		return SEQUENCE_END_EVENT
+	case "MAPPING_START_EVENT":
+		return MAPPING_START_EVENT
+	case "MAPPING_END_EVENT":
+		return MAPPING_END_EVENT
+	default:
+		t.Fatalf("unknown event type: %s", s)
+		return NO_EVENT
+	}
+}
+
+// ParseTokenType converts a string to TokenType
+func ParseTokenType(t *testing.T, s string) TokenType {
+	t.Helper()
+	switch s {
+	case "NO_TOKEN":
+		return NO_TOKEN
+	case "STREAM_START_TOKEN":
+		return STREAM_START_TOKEN
+	case "STREAM_END_TOKEN":
+		return STREAM_END_TOKEN
+	case "VERSION_DIRECTIVE_TOKEN":
+		return VERSION_DIRECTIVE_TOKEN
+	case "TAG_DIRECTIVE_TOKEN":
+		return TAG_DIRECTIVE_TOKEN
+	case "DOCUMENT_START_TOKEN":
+		return DOCUMENT_START_TOKEN
+	case "DOCUMENT_END_TOKEN":
+		return DOCUMENT_END_TOKEN
+	case "BLOCK_SEQUENCE_START_TOKEN":
+		return BLOCK_SEQUENCE_START_TOKEN
+	case "BLOCK_MAPPING_START_TOKEN":
+		return BLOCK_MAPPING_START_TOKEN
+	case "BLOCK_END_TOKEN":
+		return BLOCK_END_TOKEN
+	case "FLOW_SEQUENCE_START_TOKEN":
+		return FLOW_SEQUENCE_START_TOKEN
+	case "FLOW_SEQUENCE_END_TOKEN":
+		return FLOW_SEQUENCE_END_TOKEN
+	case "FLOW_MAPPING_START_TOKEN":
+		return FLOW_MAPPING_START_TOKEN
+	case "FLOW_MAPPING_END_TOKEN":
+		return FLOW_MAPPING_END_TOKEN
+	case "BLOCK_ENTRY_TOKEN":
+		return BLOCK_ENTRY_TOKEN
+	case "FLOW_ENTRY_TOKEN":
+		return FLOW_ENTRY_TOKEN
+	case "KEY_TOKEN":
+		return KEY_TOKEN
+	case "VALUE_TOKEN":
+		return VALUE_TOKEN
+	case "ALIAS_TOKEN":
+		return ALIAS_TOKEN
+	case "ANCHOR_TOKEN":
+		return ANCHOR_TOKEN
+	case "TAG_TOKEN":
+		return TAG_TOKEN
+	case "SCALAR_TOKEN":
+		return SCALAR_TOKEN
+	default:
+		t.Fatalf("unknown token type: %s", s)
+		return NO_TOKEN
+	}
+}
+
+// ParseEncoding converts a string to Encoding
+func ParseEncoding(t *testing.T, s string) Encoding {
+	t.Helper()
+	switch s {
+	case "ANY_ENCODING":
+		return ANY_ENCODING
+	case "UTF8_ENCODING":
+		return UTF8_ENCODING
+	case "UTF16LE_ENCODING":
+		return UTF16LE_ENCODING
+	case "UTF16BE_ENCODING":
+		return UTF16BE_ENCODING
+	default:
+		t.Fatalf("unknown encoding: %s", s)
+		return ANY_ENCODING
+	}
+}
+
+// ParseScalarStyle converts a string to ScalarStyle
+func ParseScalarStyle(t *testing.T, s string) ScalarStyle {
+	t.Helper()
+	switch s {
+	case "ANY_SCALAR_STYLE":
+		return ANY_SCALAR_STYLE
+	case "PLAIN_SCALAR_STYLE":
+		return PLAIN_SCALAR_STYLE
+	case "SINGLE_QUOTED_SCALAR_STYLE":
+		return SINGLE_QUOTED_SCALAR_STYLE
+	case "DOUBLE_QUOTED_SCALAR_STYLE":
+		return DOUBLE_QUOTED_SCALAR_STYLE
+	case "LITERAL_SCALAR_STYLE":
+		return LITERAL_SCALAR_STYLE
+	case "FOLDED_SCALAR_STYLE":
+		return FOLDED_SCALAR_STYLE
+	default:
+		t.Fatalf("unknown scalar style: %s", s)
+		return ANY_SCALAR_STYLE
+	}
+}
+
+// ParseSequenceStyle converts a string to SequenceStyle
+func ParseSequenceStyle(t *testing.T, s string) SequenceStyle {
+	t.Helper()
+	switch s {
+	case "ANY_SEQUENCE_STYLE":
+		return ANY_SEQUENCE_STYLE
+	case "BLOCK_SEQUENCE_STYLE":
+		return BLOCK_SEQUENCE_STYLE
+	case "FLOW_SEQUENCE_STYLE":
+		return FLOW_SEQUENCE_STYLE
+	default:
+		t.Fatalf("unknown sequence style: %s", s)
+		return ANY_SEQUENCE_STYLE
+	}
+}
+
+// ParseMappingStyle converts a string to MappingStyle
+func ParseMappingStyle(t *testing.T, s string) MappingStyle {
+	t.Helper()
+	switch s {
+	case "ANY_MAPPING_STYLE":
+		return ANY_MAPPING_STYLE
+	case "BLOCK_MAPPING_STYLE":
+		return BLOCK_MAPPING_STYLE
+	case "FLOW_MAPPING_STYLE":
+		return FLOW_MAPPING_STYLE
+	default:
+		t.Fatalf("unknown mapping style: %s", s)
+		return ANY_MAPPING_STYLE
+	}
+}
+
+// CreateEventFromSpec creates an Event from an EventSpec
+func CreateEventFromSpec(t *testing.T, spec EventSpec) Event {
+	t.Helper()
+	eventType := ParseEventType(t, spec.Type)
+
+	switch eventType {
+	case STREAM_START_EVENT:
+		encoding := UTF8_ENCODING
+		if spec.Encoding != "" {
+			encoding = ParseEncoding(t, spec.Encoding)
+		}
+		return NewStreamStartEvent(encoding)
+
+	case STREAM_END_EVENT:
+		return NewStreamEndEvent()
+
+	case DOCUMENT_START_EVENT:
+		var vd *VersionDirective
+		if spec.VersionDirective != nil {
+			vd = &VersionDirective{
+				major: int8(spec.VersionDirective.Major),
+				minor: int8(spec.VersionDirective.Minor),
+			}
+		}
+		var td []TagDirective
+		for _, tagSpec := range spec.TagDirectives {
+			td = append(td, TagDirective{
+				handle: []byte(tagSpec.Handle),
+				prefix: []byte(tagSpec.Prefix),
+			})
+		}
+		return NewDocumentStartEvent(vd, td, spec.Implicit)
+
+	case DOCUMENT_END_EVENT:
+		return NewDocumentEndEvent(spec.Implicit)
+
+	case ALIAS_EVENT:
+		return NewAliasEvent([]byte(spec.Anchor))
+
+	case SCALAR_EVENT:
+		style := PLAIN_SCALAR_STYLE
+		if spec.Style != "" {
+			style = ParseScalarStyle(t, spec.Style)
+		}
+		return NewScalarEvent(
+			[]byte(spec.Anchor),
+			[]byte(spec.Tag),
+			[]byte(spec.Value),
+			spec.Implicit,
+			spec.QuotedImplicit,
+			style,
+		)
+
+	case SEQUENCE_START_EVENT:
+		style := BLOCK_SEQUENCE_STYLE
+		if spec.Style != "" {
+			style = ParseSequenceStyle(t, spec.Style)
+		}
+		return NewSequenceStartEvent(
+			[]byte(spec.Anchor),
+			[]byte(spec.Tag),
+			spec.Implicit,
+			style,
+		)
+
+	case SEQUENCE_END_EVENT:
+		return NewSequenceEndEvent()
+
+	case MAPPING_START_EVENT:
+		style := BLOCK_MAPPING_STYLE
+		if spec.Style != "" {
+			style = ParseMappingStyle(t, spec.Style)
+		}
+		return NewMappingStartEvent(
+			[]byte(spec.Anchor),
+			[]byte(spec.Tag),
+			spec.Implicit,
+			style,
+		)
+
+	case MAPPING_END_EVENT:
+		return NewMappingEndEvent()
+
+	default:
+		t.Fatalf("unsupported event type: %v", eventType)
+		return Event{}
+	}
+}
+
+// HexToBytes converts a hex string to bytes
+func HexToBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("invalid hex string: %s: %v", s, err)
+	}
+	return b
+}
+
+// GetField uses reflection to get a field value from a struct
+func GetField(t *testing.T, obj interface{}, fieldName string) interface{} {
+	t.Helper()
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	field := v.FieldByName(fieldName)
+	if !field.IsValid() {
+		t.Fatalf("field %s not found", fieldName)
+	}
+	return field.Interface()
+}
+
+// CreateArgValue creates a value from an ArgSpec
+func CreateArgValue(t *testing.T, spec ArgSpec) interface{} {
+	t.Helper()
+	if spec.Bytes != "" {
+		return []byte(spec.Bytes)
+	}
+	if spec.String != "" {
+		if spec.Reader {
+			return bytes.NewReader([]byte(spec.String))
+		}
+		return spec.String
+	}
+	if spec.Hex != "" {
+		return HexToBytes(t, spec.Hex)
+	}
+	if spec.Writer {
+		return new(bytes.Buffer)
+	}
+	// Default to the first non-zero value
+	if spec.Int != 0 {
+		return spec.Int
+	}
+	if spec.Bool {
+		return spec.Bool
+	}
+	return nil
+}
+
+// CallMethod calls a method on an object using reflection
+func CallMethod(t *testing.T, obj interface{}, methodName string, args []interface{}) []reflect.Value {
+	t.Helper()
+	v := reflect.ValueOf(obj)
+	method := v.MethodByName(methodName)
+	if !method.IsValid() {
+		t.Fatalf("method %s not found on %T", methodName, obj)
+	}
+
+	var argValues []reflect.Value
+	for _, arg := range args {
+		argValues = append(argValues, reflect.ValueOf(arg))
+	}
+
+	return method.Call(argValues)
+}
+
+// CreateObject creates an object using a constructor function
+func CreateObject(t *testing.T, constructorName string) interface{} {
+	t.Helper()
+	switch constructorName {
+	case "NewParser":
+		return NewParser()
+	case "NewEmitter":
+		return NewEmitter()
+	default:
+		t.Fatalf("unknown constructor: %s", constructorName)
+		return nil
+	}
+}
+
+// emitEvents is a helper to emit events and return the output
+func emitEvents(events []Event) (string, error) {
+	emitter := NewEmitter()
+	var output []byte
+	emitter.SetOutputString(&output)
+
+	for i := range events {
+		if err := emitter.Emit(&events[i]); err != nil {
+			return "", err
+		}
+	}
+
+	return string(output), nil
+}
+
+// parseEvents is a helper to parse input and return event types
+func parseEvents(input string) ([]EventType, bool) {
+	parser := NewParser()
+	parser.SetInputString([]byte(input))
+
+	var types []EventType
+	for {
+		var event Event
+		if !parser.Parse(&event) {
+			if parser.ErrorType != NO_ERROR {
+				return nil, false
+			}
+			return types, true
+		}
+		types = append(types, event.Type)
+		if event.Type == STREAM_END_EVENT {
+			break
+		}
+	}
+	return types, true
+}
+
+// parseEventsDetailed is a helper to parse input and return full events
+func parseEventsDetailed(input string) ([]Event, bool) {
+	parser := NewParser()
+	parser.SetInputString([]byte(input))
+
+	var events []Event
+	for {
+		var event Event
+		if !parser.Parse(&event) {
+			if parser.ErrorType != NO_ERROR {
+				return nil, false
+			}
+			return events, true
+		}
+		events = append(events, event)
+		if event.Type == STREAM_END_EVENT {
+			break
+		}
+	}
+	return events, true
+}
+
+// scanTokens is a helper to scan input and return token types
+func scanTokens(input string) ([]TokenType, bool) {
+	parser := NewParser()
+	parser.SetInputString([]byte(input))
+
+	var types []TokenType
+	for {
+		var token Token
+		if !parser.Scan(&token) {
+			if parser.ErrorType != NO_ERROR {
+				return nil, false
+			}
+			return types, true
+		}
+		types = append(types, token.Type)
+		if token.Type == STREAM_END_TOKEN {
+			break
+		}
+	}
+	return types, true
+}
+
+// scanTokensDetailed is a helper to scan input and return full tokens
+func scanTokensDetailed(input string) ([]Token, bool) {
+	parser := NewParser()
+	parser.SetInputString([]byte(input))
+
+	var tokens []Token
+	for {
+		var token Token
+		if !parser.Scan(&token) {
+			if parser.ErrorType != NO_ERROR {
+				return nil, false
+			}
+			return tokens, true
+		}
+		tokens = append(tokens, token)
+		if token.Type == STREAM_END_TOKEN {
+			break
+		}
+	}
+	return tokens, true
+}
+
+// ConfigureEmitter configures an emitter from an EmitterConfig
+func ConfigureEmitter(emitter *Emitter, config EmitterConfig) {
+	if config.Canonical {
+		emitter.SetCanonical(true)
+	}
+	if config.Indent > 0 {
+		emitter.SetIndent(config.Indent)
+	}
+	if config.Width != 0 {
+		emitter.SetWidth(config.Width)
+	}
+	if config.Unicode {
+		emitter.SetUnicode(true)
+	}
+	if config.LineBreak != "" {
+		// Parse line break style if needed
+		switch config.LineBreak {
+		case "LN":
+			emitter.SetLineBreak(LN_BREAK)
+		case "CR":
+			emitter.SetLineBreak(CR_BREAK)
+		case "CRLF":
+			emitter.SetLineBreak(CRLN_BREAK)
+		}
+	}
+}
+
+// RunEmitTest runs an emit test case
+func RunEmitTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	var events []Event
+	for _, eventSpec := range tc.Events {
+		events = append(events, CreateEventFromSpec(t, eventSpec))
+	}
+
+	var output []byte
+	var emitter *Emitter
+
+	if tc.Type == "emit-config" {
+		e := NewEmitter()
+		emitter = &e
+		emitter.SetOutputString(&output)
+		ConfigureEmitter(emitter, tc.Config)
+
+		for i := range events {
+			err := emitter.Emit(&events[i])
+			assert.NoErrorf(t, err, "Emit() error: %v", err)
+		}
+	} else {
+		result, err := emitEvents(events)
+		assert.NoErrorf(t, err, "emitEvents() error: %v", err)
+		output = []byte(result)
+	}
+
+	for _, expected := range tc.WantContains {
+		assert.Truef(t, bytes.Contains(output, []byte(expected)),
+			"output should contain %q, got %q", expected, string(output))
+	}
+}
+
+// RunRoundTripTest runs a roundtrip test case
+func RunRoundTripTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	parser := NewParser()
+	parser.SetInputString([]byte(tc.Yaml))
+
+	var events []Event
+	for {
+		var event Event
+		if !parser.Parse(&event) {
+			break
+		}
+		events = append(events, event)
+		if event.Type == STREAM_END_EVENT {
+			break
+		}
+	}
+
+	emitter := NewEmitter()
+	var output []byte
+	emitter.SetOutputString(&output)
+
+	for i := range events {
+		err := emitter.Emit(&events[i])
+		assert.NoErrorf(t, err, "Emit() error: %v", err)
+	}
+
+	result := string(output)
+	for _, expected := range tc.WantContains {
+		assert.Truef(t, bytes.Contains(output, []byte(expected)),
+			"output should contain %q, got %q", expected, result)
+	}
+}
+
+// GetWriter extracts an io.Writer from an interface value
+func GetWriter(t *testing.T, v interface{}) io.Writer {
+	t.Helper()
+	if w, ok := v.(io.Writer); ok {
+		return w
+	}
+	t.Fatalf("value is not an io.Writer: %T", v)
+	return nil
+}
+
+// GetReader extracts an io.Reader from an interface value
+func GetReader(t *testing.T, v interface{}) io.Reader {
+	t.Helper()
+	if r, ok := v.(io.Reader); ok {
+		return r
+	}
+	t.Fatalf("value is not an io.Reader: %T", v)
+	return nil
+}
+
+// TestHandler is a function that runs a specific test type
+type TestHandler func(*testing.T, TestCase)
+
+// RunTestCases loads test cases from a YAML file and runs them using the provided handlers
+func RunTestCases(t *testing.T, filename string, handlers map[string]TestHandler) {
+	t.Helper()
+	cases, err := LoadTestCases(filename)
+	assert.NoErrorf(t, err, "Failed to load test cases: %v", err)
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			handler, ok := handlers[tc.Type]
+			if !ok {
+				t.Fatalf("unknown test type: %s", tc.Type)
+			}
+			handler(t, tc)
+		})
+	}
+}
+
+// WantBool extracts a bool from tc.Want, returning defaultVal if Want is nil
+func WantBool(t *testing.T, want interface{}, defaultVal bool) bool {
+	t.Helper()
+	if want == nil {
+		return defaultVal
+	}
+	boolVal, ok := want.(bool)
+	if !ok {
+		t.Fatalf("Want should be bool, got %T", want)
+	}
+	return boolVal
+}

--- a/internal/libyaml/yamlprivate_test.go
+++ b/internal/libyaml/yamlprivate_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package libyaml
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v4/internal/testutil/assert"
+)
+
+func TestYAMLPrivate(t *testing.T) {
+	RunTestCases(t, "yamlprivate.yaml", map[string]TestHandler{
+		"char-predicate": runCharPredicateTest,
+		"char-convert":   runCharConvertTest,
+	})
+}
+
+func runCharPredicateTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	input := tc.Input
+	index := tc.Index
+
+	// Default want to true if not specified
+	want := WantBool(t, tc.Want, true)
+
+	var got bool
+	switch tc.Function {
+	case "isAlpha":
+		got = isAlpha(input, index)
+	case "isFlowIndicator":
+		got = isFlowIndicator(input, index)
+	case "isAnchorChar":
+		got = isAnchorChar(input, index)
+	case "isColon":
+		got = isColon(input, index)
+	case "isDigit":
+		got = isDigit(input, index)
+	case "isHex":
+		got = isHex(input, index)
+	case "isASCII":
+		got = isASCII(input, index)
+	case "isPrintable":
+		got = isPrintable(input, index)
+	case "isZeroChar":
+		got = isZeroChar(input, index)
+	case "isBOM":
+		got = isBOM(input, index)
+	case "isSpace":
+		got = isSpace(input, index)
+	case "isTab":
+		got = isTab(input, index)
+	case "isBlank":
+		got = isBlank(input, index)
+	case "isLineBreak":
+		got = isLineBreak(input, index)
+	case "isCRLF":
+		got = isCRLF(input, index)
+	case "isBreakOrZero":
+		got = isBreakOrZero(input, index)
+	case "isSpaceOrZero":
+		got = isSpaceOrZero(input, index)
+	case "isBlankOrZero":
+		got = isBlankOrZero(input, index)
+	default:
+		t.Fatalf("unknown function: %s", tc.Function)
+	}
+
+	assert.Equalf(t, want, got, "%s(%q, %d) = %v, want %v", tc.Function, input, index, got, want)
+}
+
+func runCharConvertTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	input := tc.Input
+	index := tc.Index
+	want, ok := tc.Want.(int)
+	assert.Truef(t, ok, "Want should be int, got %T", tc.Want)
+
+	var got int
+	switch tc.Function {
+	case "asDigit":
+		got = asDigit(input, index)
+	case "asHex":
+		got = asHex(input, index)
+	case "width":
+		// width takes a single byte, not a byte array and index
+		got = width(input[index])
+	default:
+		t.Fatalf("unknown function: %s", tc.Function)
+	}
+
+	assert.Equalf(t, want, got, "%s(%q, %d) = %d, want %d", tc.Function, input, index, got, want)
+}


### PR DESCRIPTION
Refactored from and replaces @colinjlacy's https://github.com/yaml/go-yaml/pull/184

Uses super clean, simple, consistent and documented foo_test.yaml files for test data, and minimal foo_test.go files for the code running the tests.

Added internal/libyaml/README.md that explains both the code and the test layout.