### PR TITLE
node: add NewDecoder function that allows customizing decode behaviour in Unmarshalers

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1709,6 +1709,25 @@ func TestObsoleteUnmarshalerRetry(t *testing.T) {
 	assert.DeepEqual(t, obsoleteSliceUnmarshaler([]int{1}), su)
 }
 
+type knownFieldsUnmarshaler[T any] struct {
+	dest T
+}
+
+func (u *knownFieldsUnmarshaler[T]) UnmarshalYAML(node *yaml.Node) error {
+	d := node.NewDecoder()
+	d.KnownFields(true)
+	return d.Decode(&u.dest)
+}
+
+func TestKnownFieldsUnmarshaler(t *testing.T) {
+	type testData struct {
+		A int `yaml:"a"`
+	}
+	var kfu knownFieldsUnmarshaler[testData]
+	err := yaml.Unmarshal([]byte("{'a':1,'b':2}"), &kfu)
+	assert.NotNil(t, err)
+}
+
 // From http://yaml.org/type/merge.html
 var mergeTests = `
 anchors:


### PR DESCRIPTION
This PR adds `*Node.NewDecoder` function that allows setting options on the decoder, namely `KnownFields`, in `Unmarshaler` implementations. This is achieved by augmenting the `Decoder` type with a `node *Node` field. 

Things I considered:
- Make `Decoder` an interface. This would be a breaking change.
- Add a `DecodeWithOptions`, but we already have a decoder so why not reuse it? All development going into `Decoder` will automatically be available here too.
- Replace `Decoder.parser` with some interface or `func() *Node` instead of two fields. I'm open for this. E.g.:
 
```go
type Decoder struct {
  getNode func() *Node
  knownFields bool
}
func NewDecoder() *Decoder {
  p := newParserFromReader(r)
  return &Decoder{getNode: p.parse}
}
func (n *Node) NewDecoder() *Decoder {
  return &Decoder{
    getNode:     func()*Node { return n },
    knownFields: false,
  }
}
```