### PR TITLE
Accept int(0) as time.Duration

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -619,6 +619,9 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 			if !isDuration && !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
 				return true
+			} else if isDuration && resolved == 0 {
+				out.SetInt(0)
+				return true
 			}
 		case int64:
 			if !isDuration && !out.OverflowInt(resolved) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -309,6 +309,16 @@ var unmarshalTests = []struct {
 		"a: 3s",
 		map[string]time.Duration{"a": 3 * time.Second},
 	},
+	// Zero duration as a string.
+	{
+		"a: '0'",
+		map[string]time.Duration{"a": 0},
+	},
+	// Zero duration as an int.
+	{
+		"a: 0",
+		map[string]time.Duration{"a": 0},
+	},
 
 	// Binary data.
 	{


### PR DESCRIPTION
Copy of: https://github.com/go-yaml/yaml/pull/876

Integer zero or string "0" are valid according to time.ParseDuration. See the original PR for a lengthier description.
