### PR TITLE
GNUmakefile refactor and doc updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,7 @@ updates:
   directory: /  # Location of package manifests
   schedule:
     interval: weekly
+
 - package-ecosystem: github-actions
   directory: /
   groups:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -9,50 +9,35 @@ on:
 permissions: read-all
 
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
+    needs: go-versions
+    continue-on-error: true  # make sure to run all versions, even if one fails
+
+    strategy:
+      matrix:
+        go-version: ${{ fromJSON(needs.go-versions.outputs.versions) }}
+
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       with:
         persist-credentials: false
-    - name: Set up Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
-      with:
-        go-version: stable
-    - name: Install golangci-lint
-      run: |
-        make golangci-lint-install
-        echo "${{ github.workspace }}/.cache/local/bin" >> "$GITHUB_PATH"
-    # yamllint disable-line rule:line-length
-    - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
-      with:
-        install-mode: none
+
+    - name: Run all unit tests w/ -cover, all YTS tests and go lint
+      run: make test lint v=1 GO-VERSION=${{ matrix.go-version }}
+
   go-versions:
     name: Lookup Go versions
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.versions.outputs.matrix }}
+      versions: ${{ steps.latest-patch-versions.outputs.matrix }}
+
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-    # yamllint disable-line rule:line-length
-    - uses: arnested/go-version-action@978371bd4d8cad0f54106c8be4273e2fcdd74f57  # v1.1.23
-      id: versions
-  build:
-    runs-on: ubuntu-latest
-    needs: go-versions
-    continue-on-error: true  # make sure to run all versions, even if one fails
-    strategy:
-      matrix:
-        go-versions: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
-    steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+    - name: Get latest patch for each minor version
+      # yamllint disable-line rule:line-length
+      uses: arnested/go-version-action@90b2bf6e8cbbba34a5e514cfe9d3f7541d91ffa7  # v1.2.0
+      id: latest-patch-versions
       with:
-        persist-credentials: false
-    - name: Set up Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
-      with:
-        go-version: ${{ matrix.go-versions }}
-    - name: Run yaml-test-suit tests
-      run: make test-yts
-    - name: Run go test
-      run: go test -vet=off -v -race ./...
+        latest-patches-only: true
+        patch-level: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ project.
 By participating in this project, you agree to follow our Code of Conduct.
 
 We expect all contributors to:
+
 - Be respectful and inclusive
 - Use welcoming and inclusive language
 - Be collaborative and constructive
@@ -24,6 +25,7 @@ We expect all contributors to:
 ### Reporting Issues
 
 Before submitting an issue, please:
+
 - Check if the issue already exists in our issue tracker
 - Use a clear and descriptive title
 - Provide detailed steps to reproduce the issue
@@ -101,34 +103,79 @@ foo: &a1 bar
 
 ## Development Process
 
-- Installing Go is not necessary. See "The Makefile" below.
+- This project makes use of a GNU makefile (`GNUmakefile`) for many dev tasks
+- The makefile doesn't use your locally installed Go commands; it auto-installs
+  them, so that all results are deterministic
 - Fork and clone the repository
 - Make your changes
 - Run tests, linters and formatters
-  - `make test-all`
+  - `make test`
   - `make lint`
   - `make fmt`
   - `make tidy`
 - Submit a [Pull Request](https://github.com/yaml/go-yaml/pulls)
 
 
-## The Makefile
+### Using Your Own Go with the Makefile
 
-The repository contains a Makefile (`GNUmakefile`) that provides a number of
-useful targets:
+We ask that you always test with the makefile installed Go before committing,
+since it is deterministic and uses the exact same flow as the go-yaml CI.
 
-- `make test` runs the tests
+We also realize that many Go devs need to run their locally installed Go
+commands for their development environment, and might want to use them with
+the go-yaml makefile.
+
+If you need to use your own Go utils with the makefile, set `GO_YAML_PATH` to
+the directory(s) containing them (either by exporting it or passing it to
+`make`).
+
+Something like this:
+
+```bash
+export GO_YAML_PATH=$(dirname "$(command -v go)")
+make test
+# or
+make test GO_YAML_PATH=$(dirname "$(command -v go)")
+```
+
+**Note:** `GO-VERSION` and `GO_YAML_PATH` are mutually exclusive.
+When `GO_YAML_PATH` is set, the makefile uses your own Go environment and
+ignores any `GO-VERSION` setting.
+
+
+### Using the Makefile Environment as a Shell
+
+Sometimes you might want to run your own shell commands using the same binaries
+that the makefile installs.
+
+To get a subshell with this environment, run one of:
+
+```bash
+make shell
+make bash
+make zsh
+make shell GO-VERSION=1.23.4
+```
+
+
+
+## Makefile Targets
+
+The repository's makefile (`GNUmakefile`) provides a number of useful targets:
+
+- `make test` runs all tests including yaml-test-suite tests
+- `make test-unit` runs just the unit tests
+- `make test-internal` runs just the internal tests
+- `make test-yts` runs just the yaml-test-suite tests
 - `make test v=1 count=3` runs the tests with options
 - `make test GO-VERSION=1.23.4` runs the tests with a specific Go version
+- `make test GO_YAML_PATH=/path/to/go/bin` uses your own Go installation
 - `make shell` opens a shell with the project's dependencies set up
 - `make shell GO-VERSION=1.23.4` opens a shell with a specific Go version
 - `make fmt` runs `golangci-lint fmt ./...`
 - `make lint` runs `golangci-lint run`
 - `make tidy` runs `go mod tidy`
-- `make install` runs `go install`
 - `make distclean` cleans the project completely
-
-The Makefile will install all requirements for any target, including Go itself.
 
 
 ## Getting Help

--- a/README.md
+++ b/README.md
@@ -177,26 +177,62 @@ b:
 ```
 
 
-## Testing with `make`
+## Development and Testing with `make`
 
-Running `make test` in this directory should just work.
-You don't need to have `go` installed and even if you do the `GNUmakefile` will
-ignore it and setup / cache its own version under `.cache/`.
-
-The only things you need are:
-* Linux or macOS
-* `git`
-* `bash`
-* `curl`
-* `make`
+This project's makefile (`GNUmakefile`) is set up to support all of the
+project's testing, automation and development tasks in a completely
+deterministic way.
 
 Some `make` commands are:
 
 * `make test`
+* `make lint tidy`
+* `make test-shell`
+* `make test v=1`
+* `make test o='-foo --bar=baz'`  # Add extra CLI options
 * `make test GO-VERSION=1.2.34`
-* `make shell` Start a shell with the local `go` environment
+* `make test GO_YAML_PATH=/usr/local/go/bin`
+* `make shell`  # Start a shell with the local `go` environment
 * `make shell GO-VERSION=1.2.34`
-* `make distclean` - Removes `.cache/`
+* `make distclean`  # Remove all generated files including `.cache/`
+
+
+### Dependency Auto-install
+
+By default, this makefile will not use your system's Go installation, or any
+other system tools that it needs.
+
+The only things from your system that it relies on are:
+* Linux or macOS
+* GNU `make` (3.81+)
+* `git`
+* `bash`
+* `curl`
+
+Everything else, including Go and Go utils, are installed and cached as they
+are needed by the makefile (under `.cache/`).
+
+> **Note**: Use `make shell` to get a subshell with the same environment that
+> the makefile set up for its commands.
+
+
+### Using your own Go
+
+If you want to use your own Go installation and utils, export `GO_YAML_PATH` to
+the directory containing the `go` binary.
+
+Use something like this:
+
+```
+export GO_YAML_PATH=$(dirname "$(command -v go)")
+make <rule>
+# or:
+make <rule> GO_YAML_PATH=$(dirname "$(command -v go)")
+```
+
+> **Note:** `GO-VERSION` and `GO_YAML_PATH` are mutually exclusive.
+> When `GO_YAML_PATH` is set, the Makefile uses your own Go installation and
+> ignores any `GO-VERSION` setting.
 
 
 ## The `go-yaml` CLI Tool
@@ -205,13 +241,16 @@ This repository includes a `go-yaml` CLI tool which can be used to understand
 the internal stages and final results of YAML processing with the go-yaml
 library.
 
+We strongly encourage you to show pertinent output from this command when
+reporting and discussing issues.
+
 ```bash
 make go-yaml
 ./go-yaml --help
-./go-yaml -t <<< '
+./go-yaml <<< '
 foo: &a1 bar
 *a1: baz
-'
+' -n        # Show value on decoded Node structs (formatted in YAML)
 ```
 
 You can also install it with:

--- a/util/yaml-test-suite
+++ b/util/yaml-test-suite
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() (
+  type=$1
+
+  if [[ $type == all ]]; then
+    export RUNALL=1
+  elif [[ $type == fail ]]; then
+    export RUNFAILING=1
+  else
+    exit 1
+  fi
+
+  results=$(
+    go test ./yts -count=1 -v |
+      awk '/     --- (PASS|FAIL): / {print $2, $3}'
+  ) || true
+
+  known_count=$(grep -c '' yts/known-failing-tests)
+  pass_count=$(grep -c '^PASS:' <<<"$results")
+  fail_count=$(grep -c '^FAIL:' <<<"$results")
+
+  echo "PASS: $pass_count"
+  echo "FAIL: $fail_count (known: $known_count)"
+
+  if [[ $type == fail ]] && [[ $pass_count -gt 0 ]]; then
+    echo "ERROR: Found passing tests among expected failures:"
+    grep '^PASS:' "$results"
+    exit 1
+  fi
+
+  if [[ $fail_count != "$known_count" ]]; then
+    echo "ERROR: FAIL count ($fail_count) differs from expected $known_count"
+    exit 1
+  fi
+)
+
+main "$@"

--- a/yts/test_suite_test.go
+++ b/yts/test_suite_test.go
@@ -52,7 +52,7 @@ func TestYAMLSuite(t *testing.T) {
 	if _, err := os.Stat(testDir + "/229Q"); os.IsNotExist(err) {
 		t.Fatalf(`YTS tests require data files to be present at '%s'.
 Run 'make test-data' to download them first,
-or just run the tests with 'make test-all'.`, testDir)
+or just run the tests with 'make test'.`, testDir)
 	}
 	runTestsInDir(t, testDir)
 }


### PR DESCRIPTION
Refactor GNUmakefile and update docs

Require GO_YAML_PATH to use user's go binary

go-yaml's Makefile should be determistic by default.

Update CI matrix to rely on Makefile to auto-install, so the CI tests
run the same and deterministically matching the user's testing.

Support shellcheck testing.
