### PR TITLE
Add .agents.md files for guiding agentic AI tools

### DIFF
--- a/.ai-agents/template.md
+++ b/.ai-agents/template.md
@@ -1,0 +1,307 @@
+# AI Assistant Guidelines for go-yaml
+
+## Project Context
+
+This is the **go-yaml** library (`go.yaml.in/yaml/v4`), a critical Go YAML
+implementation used in **Kubernetes** and many other production systems.
+
+**Critical Context:**
+- Maintainer: Ingy döt Net (YAML spec lead maintainer)
+- Code is scrutinized by experienced Go developers
+- AI-generated code must meet professional Go standards
+- Repeated mistakes will annoy the review team
+
+**Package-specific guidelines:**
+- See `internal/libyaml/.agents.md` for that package's patterns
+
+## Go Coding Standards for This Project
+
+### Code Formatting
+
+```bash
+# Always format code with gofumpt (configured in .golangci.yaml)
+make fmt
+
+# Run linters before committing
+make lint
+
+# Run tests
+make test
+```
+
+**Formatting rules:**
+- Use `gofumpt` formatter (stricter than `gofmt`)
+- Try hard to keep lines to **80 characters maximum**
+- Start doc comments and multi-line comments on new lines
+
+### Linter Configuration
+
+From `.golangci.yaml`:
+- **Enabled**: `dupword`, `govet`, `misspell`, `nolintlint`, `staticcheck`
+- **Disabled**: `errcheck`, `ineffassign`, `unused` (for now)
+- **Note**: ST1003 (underscores in identifiers) is disabled because the
+  codebase currently has many underscores
+
+### Testing Patterns
+
+#### Use testdata/ for Test Fixtures
+
+```go
+// CORRECT: Use testdata/ directory (Go build tool ignores this)
+testFile := "testdata/scanner.yaml"
+
+// WRONG: Don't scatter test data in arbitrary locations
+testFile := "test_files/scanner.yaml"  // ❌
+```
+
+#### Use Assertion Helpers
+
+```go
+import "go.yaml.in/yaml/v4/internal/testutil/assert"
+
+// CORRECT: Use assertion helpers for clear error messages
+assert.Truef(t, ok, "scanTokens() failed")
+assert.Equalf(t, expected, actual, "token[%d] mismatch", i)
+
+// WRONG: Don't use raw if statements
+if !ok {  // ❌
+    t.Errorf("scanTokens() failed")
+}
+```
+
+#### Use t.Helper() in Test Helpers
+
+```go
+// CORRECT: Mark test helper functions with t.Helper()
+func runScanTokensTest(t *testing.T, tc TestCase) {
+    t.Helper()  // This makes error messages point to the caller
+    // ... test logic
+}
+
+// WRONG: Forgetting t.Helper() makes debugging harder
+func runScanTokensTest(t *testing.T, tc TestCase) {  // ❌
+    // ... test logic (errors will point here, not to caller)
+}
+```
+
+### Type Assertions and Error Handling
+
+```go
+// CORRECT: Always check type assertions
+wantSlice, ok := tc.Want.([]interface{})
+assert.Truef(t, ok, "Want should be []interface{}, got %T", tc.Want)
+
+// WRONG: Unchecked type assertion can panic
+wantSlice := tc.Want.([]interface{})  // ❌ Can panic
+```
+
+### Documentation Standards
+
+**Critical Rules from PR #194:**
+
+1. **Never reference fields that don't exist**
+   ```markdown
+   ❌ WRONG: "The Find field contains expected results"
+   ✅ RIGHT: "The Want field contains expected results"
+   ```
+
+2. **Verify examples match actual structs**
+   ```yaml
+   # ❌ WRONG: Including fields that don't exist
+   - test-type:
+       name: Example
+       detailed: true  # This field doesn't exist!
+
+   # ✅ RIGHT: Only use actual fields
+   - test-type:
+       name: Example
+       yaml: "test"
+   ```
+
+3. **Check field names against code before writing docs**
+   - Read the actual struct definition
+   - Don't invent fields or guess names
+   - If unsure, check the code first
+
+### Naming Conventions
+
+#### File Naming
+
+```
+scanner_test.go       ✅ Test files use _test.go suffix
+yamldatatest_test.go  ✅ Underscores in multi-word names
+testdata/             ✅ Go convention for test fixtures
+```
+
+#### Variable and Function Naming
+
+```go
+// Use camelCase for unexported names
+func parseTokenType(t *testing.T, s string) TokenType
+
+// Use PascalCase for exported names
+func NewParser() Parser
+func (p *Parser) SetInputString(input []byte)
+```
+
+### String Comparison Against External Data
+
+**Critical Rule from PR #194:**
+
+When comparing strings against values from YAML files or other external data,
+**the Go code must use the EXACT format from the data file**.
+
+```go
+// Example: Test types in YAML files use hyphens
+// testdata/emitter.yaml contains:
+//   - emit-config:
+//       name: Test
+
+// ❌ WRONG: Using underscores when data uses hyphens
+if tc.Type == "emit_config" {
+    // This will never match!
+}
+
+// ✅ RIGHT: Match the exact format from YAML
+if tc.Type == "emit-config" {
+    // Matches the YAML data
+}
+```
+
+**Common pitfall areas:**
+- Test type names: `emit-config`, `scan-tokens-detailed` (use hyphens)
+- Style constants: Check the actual constant name in code
+- Error messages: Match exact text from implementation
+
+### Error Handling
+
+```go
+// Return errors, don't panic in library code
+func LoadYAML(data []byte) (interface{}, error) {
+    if err := validate(data); err != nil {
+        return nil, fmt.Errorf("validation failed: %w", err)
+    }
+    // ...
+}
+
+// Tests can use assertions
+func TestSomething(t *testing.T) {
+    result, err := LoadYAML(data)
+    assert.NoErrorf(t, err, "LoadYAML failed")
+}
+
+// Panic only for programmer errors (like bad constructor calls)
+func createObject(t *testing.T, constructor string) interface{} {
+    switch constructor {
+    case "NewParser":
+        return &Parser{}
+    default:
+        t.Fatalf("unknown constructor: %s", constructor)  // Test code can fail
+    }
+    return nil
+}
+```
+
+## Commit Conventions
+
+From `CONTRIBUTING.md`:
+
+**Commit message format:**
+- Start with capital letter
+- Do NOT end with period
+- Maximum 50 characters for subject
+- No merge commits
+
+```
+✅ Add support for c1 control characters
+✅ Fix block scalar hint handling
+❌ add support for c1 control characters  (no capital)
+❌ Fix block scalar hint handling.        (has period)
+```
+
+## Common AI Mistakes to Avoid
+
+These issues were caught in PR #194 review:
+
+### 1. Naming Mismatches
+
+```yaml
+# YAML data file uses hyphens
+- emit-config:
+    name: Test
+```
+
+```go
+// ❌ WRONG: Go code uses underscores
+if tc.Type == "emit_config" {
+```
+
+```go
+// ✅ RIGHT: Go code matches YAML exactly
+if tc.Type == "emit-config" {
+```
+
+### 2. Documentation Field Name Errors
+
+```go
+// Actual struct
+type TestCase struct {
+    Want interface{} `yaml:"want"`
+}
+```
+
+```markdown
+❌ WRONG in README:
+The `Find` field contains the expected result.
+
+✅ RIGHT in README:
+The `Want` field contains the expected result.
+```
+
+### 3. Invalid Example Fields
+
+```markdown
+❌ WRONG in README:
+- scan-tokens-detailed:
+    name: Example
+    detailed: true  # This field doesn't exist!
+
+✅ RIGHT in README:
+- scan-tokens-detailed:
+    name: Example
+    yaml: "test"
+```
+
+### 4. Inconsistent Naming Within Domain
+
+```markdown
+❌ WRONG: Mixing hyphens and underscores
+scan-tokens-detailed  ✅
+scan-tokens_detailed  ❌
+
+✅ RIGHT: Consistent hyphens
+scan-tokens
+scan-tokens-detailed
+parse-events
+parse-events-detailed
+```
+
+## Before Submitting Code
+
+**Checklist:**
+1. ✅ Run `make fmt` (gofumpt formatting)
+2. ✅ Run `make lint` (golangci-lint)
+3. ✅ Run `make test` (all tests pass)
+4. ✅ Verify string comparisons match data file formats exactly
+5. ✅ Check documentation references actual field names
+6. ✅ Confirm examples use only valid fields
+7. ✅ Use `testdata/` for test fixtures
+8. ✅ Use assertion helpers (`assert.Truef`, etc.)
+9. ✅ Add `t.Helper()` to test helper functions
+
+## Getting Help
+
+- Read package-specific `.agents.md` files
+- Check `CONTRIBUTING.md` for workflow
+- Review existing code for patterns
+- When uncertain, ask the user

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.claude/
 /yts/testdata/
 /go-yaml
+/CLAUDE.md
+/COPILOT.md
+/CURSOR.md

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 # Auto-install https://github.com/makeplus/makes at specific commit:
 MAKES := .cache/makes
 MAKES-LOCAL := .cache/local
-MAKES-COMMIT ?= 654f7c57ca30a2b08cb4aab8bb0c0d509510ad81
+MAKES-COMMIT ?= 40dee58a023162aa71ed9dc8c93973c7d73d32d5
 $(shell [ -d $(MAKES) ] || ( \
   git clone -q https://github.com/makeplus/makes $(MAKES) && \
   git -C $(MAKES) reset -q --hard $(MAKES-COMMIT)))
@@ -11,6 +11,8 @@ $(error $(MAKES) is not at the correct commit: $(MAKES-COMMIT))
 endif
 include $(MAKES)/init.mk
 include $(MAKES)/clean.mk
+AGENTS-NAMES := claude
+include $(MAKES)/agents.mk
 
 # Only auto-install go if no go exists or GO-VERSION specified:
 ifeq (,$(shell command -v go))
@@ -26,8 +28,8 @@ YTS-DIR := yts/testdata/$(YTS-TAG)
 CLI-BINARY := go-yaml
 
 MAKES-NO-CLEAN := true
-MAKES-CLEAN := $(CLI-BINARY)
-MAKES-REALCLEAN := $(dir $(YTS-DIR))
+MAKES-CLEAN += $(CLI-BINARY)
+MAKES-REALCLEAN += $(dir $(YTS-DIR))
 
 # Setup and include go.mk and shell.mk:
 GO-FILES := $(shell find -not \( -path ./.cache -prune \) -name '*.go' | sort)

--- a/internal/libyaml/.agents.md
+++ b/internal/libyaml/.agents.md
@@ -1,0 +1,378 @@
+# AI Assistant Guidelines for internal/libyaml Package
+
+## Package Overview
+
+This package provides low-level YAML processing through a 3-stage pipeline:
+**Scanner → Parser → Emitter**
+
+It implements libyaml C library functionality in Go.
+
+**Read first**: `../../.agents.md` for project-wide Go guidelines
+
+## Data-Driven Test Framework
+
+### Architecture
+
+This package uses a **data-driven testing approach**:
+- Test data: YAML files in `testdata/` directory
+- Test logic: Go files (`*_test.go`)
+- **One-to-one pairing**: Each `testdata/foo.yaml` has a `foo_test.go`
+
+### Critical Rules for Test Types
+
+**Test type names in YAML files use HYPHENS, not underscores.**
+
+```yaml
+# ✅ CORRECT format in testdata/*.yaml files
+- scan-tokens:
+    name: Simple scalar
+
+- scan-tokens-detailed:
+    name: Quoted scalar
+
+- emit-config:
+    name: Custom indent
+
+- parse-events-detailed:
+    name: Anchor test
+```
+
+**Go code MUST use the EXACT same format:**
+
+```go
+// ✅ CORRECT: Matches YAML format exactly
+switch tc.Type {
+case "scan-tokens":
+    runScanTokensTest(t, tc)
+case "scan-tokens-detailed":
+    runScanTokensDetailedTest(t, tc)
+case "emit-config":
+    runEmitConfigTest(t, tc)
+}
+
+// ❌ WRONG: Using underscores when YAML uses hyphens
+switch tc.Type {
+case "emit_config":  // Will never match!
+    runEmitConfigTest(t, tc)
+}
+```
+
+### Test Type Reference
+
+**Scanner tests:**
+- `scan-tokens` - Token sequence verification
+- `scan-tokens-detailed` - Token properties (value, style)
+- `scan-error` - Error detection
+
+**Parser tests:**
+- `parse-events` - Event sequence verification
+- `parse-events-detailed` - Event properties (anchor, tag, value)
+- `parse-error` - Error detection
+
+**Emitter tests:**
+- `emit` - Event-to-YAML conversion
+- `emit-config` - Emit with configuration options
+- `roundtrip` - Parse → emit verification
+- `emit-writer` - Emit to io.Writer
+
+**API tests:**
+- `api-new` - Constructor tests
+- `api-method` - Method and field state tests
+- `api-panic` - Methods that should panic
+- `api-delete` - Cleanup tests
+- `api-new-event` - Event constructor tests
+
+**Utility tests:**
+- `enum-string` - String() method tests for enums
+- `style-accessor` - Style accessor method tests
+
+**Other tests:**
+- `scalar-resolution` - Scalar type resolution tests
+- `char-predicate` - Character classification predicates
+- `char-convert` - Character conversion functions
+
+### TestCase Struct Fields
+
+**ACTUAL field names** (verified against `yamldatatest_test.go`):
+
+```go
+type TestCase struct {
+    Name         string        // Test case name
+    Type         string        // Test type (e.g., "scan-tokens")
+
+    // Input
+    Yaml         string        // Input YAML string
+    InputHex     string        // Hex-encoded input
+    InputBytes   string        // Byte string input
+
+    // Expected results
+    Want         interface{}   // Generic expected result
+    WantSpecs    []EventSpec   // For detailed event tests
+    WantTokens   []TokenSpec   // For detailed token tests
+    WantContains []string      // For emit tests
+    WantEncoding string        // For encoding tests
+    WantData     string        // For reader tests
+    WantEOF      bool          // For reader tests
+
+    // Test data
+    Events       []EventSpec   // Events to emit (emit tests)
+    Config       EmitterConfig // Emitter configuration
+    Cases        []CharTestCase// Character test cases
+
+    // API tests
+    Constructor  string        // Constructor name (e.g., "NewParser")
+    Method       []interface{} // Method call [name, args...]
+    Setup        interface{}   // Setup method call
+    Checks       []FieldCheck  // Field validations
+    Bytes        bool          // Convert string args to []byte
+
+    // Other
+    Function     string        // Function to call
+    Input        ByteInput     // Byte input data
+    Index        int           // Index parameter
+    Args         Args          // Method arguments
+    Output       string        // Output handler type
+    Handler      string        // Handler type
+    Enum         []interface{} // [Type, Value] for enum tests
+    StyleTest    []interface{} // [Method, STYLE] for style tests
+}
+```
+
+**❌ WRONG field names to avoid:**
+- `Find` (doesn't exist, use `Want`)
+- `detailed` (doesn't exist, test type name indicates detailed mode)
+
+### Adding New Tests
+
+#### Step 1: Add test case to YAML file
+
+```yaml
+# testdata/scanner.yaml
+
+- scan-tokens:
+    name: Your test name here
+    yaml: |-
+      your: yaml
+      here: test
+    want:
+    - STREAM_START_TOKEN
+    - BLOCK_MAPPING_START_TOKEN
+    - SCALAR_TOKEN
+    - SCALAR_TOKEN
+    - SCALAR_TOKEN
+    - SCALAR_TOKEN
+    - BLOCK_END_TOKEN
+    - STREAM_END_TOKEN
+```
+
+**Rules:**
+- Use test type as key: `scan-tokens:`, `emit-config:`, etc.
+- Use **hyphens** not underscores in type names
+- `name` should use title case: "Simple mapping", "Block scalar"
+- `yaml` field uses `|-` for literal block scalars
+- `want` field format depends on test type (see examples in testdata files)
+
+#### Step 2: Verify test handler exists
+
+```go
+// scanner_test.go
+
+func TestScanner(t *testing.T) {
+    RunTestCases(t, "scanner.yaml", map[string]TestHandler{
+        "scan-tokens":          runScanTokensTest,
+        "scan-tokens-detailed": runScanTokensDetailedTest,
+        "scan-error":           runScanErrorTest,
+        // Add new handler here if needed
+    })
+}
+```
+
+**The map keys MUST match the YAML type names exactly** (with hyphens).
+
+#### Step 3: Run the test
+
+```bash
+go test ./internal/libyaml -run TestScanner -v
+```
+
+### Test Handler Pattern
+
+```go
+func runScanTokensTest(t *testing.T, tc TestCase) {
+    t.Helper()  // Always include this in test helpers!
+
+    // 1. Type assert Want field to expected type
+    wantSlice, ok := tc.Want.([]interface{})
+    assert.Truef(t, ok, "Want should be []interface{}, got %T", tc.Want)
+
+    // 2. Perform test operation
+    types, ok := scanTokens(tc.Yaml)
+    assert.Truef(t, ok, "scanTokens() failed")
+
+    // 3. Validate results with assertions
+    assert.Equalf(t, len(wantSlice), len(types),
+        "got %d tokens, want %d", len(types), len(wantSlice))
+
+    for i, expected := range wantSlice {
+        assert.Equalf(t, expected, types[i],
+            "token[%d] = %v, want %v", i, types[i], expected)
+    }
+}
+```
+
+**Pattern rules:**
+- Always use `t.Helper()` as first line
+- Use type assertions with explicit `ok` check
+- Use `assert.Truef`, `assert.Equalf` for better error messages
+- Include context in assertion messages (indices, field names, etc.)
+
+### Constant Names and Values
+
+When referencing YAML constants in test data, use the exact names:
+
+**Scalar Styles (use these names in YAML):**
+```
+PLAIN_SCALAR_STYLE
+SINGLE_QUOTED_SCALAR_STYLE
+DOUBLE_QUOTED_SCALAR_STYLE
+LITERAL_SCALAR_STYLE
+FOLDED_SCALAR_STYLE
+```
+
+**Token Types:**
+```
+STREAM_START_TOKEN
+STREAM_END_TOKEN
+SCALAR_TOKEN
+KEY_TOKEN
+VALUE_TOKEN
+ALIAS_TOKEN
+ANCHOR_TOKEN
+TAG_TOKEN
+BLOCK_MAPPING_START_TOKEN
+FLOW_MAPPING_START_TOKEN
+BLOCK_SEQUENCE_START_TOKEN
+FLOW_SEQUENCE_START_TOKEN
+BLOCK_END_TOKEN
+```
+
+**Event Types:**
+```
+STREAM_START_EVENT
+STREAM_END_EVENT
+DOCUMENT_START_EVENT
+DOCUMENT_END_EVENT
+SCALAR_EVENT
+MAPPING_START_EVENT
+MAPPING_END_EVENT
+SEQUENCE_START_EVENT
+SEQUENCE_END_EVENT
+ALIAS_EVENT
+```
+
+**Encoding:**
+```
+UTF8_ENCODING
+UTF16LE_ENCODING
+UTF16BE_ENCODING
+```
+
+**Styles:**
+```
+PLAIN_SCALAR_STYLE
+SINGLE_QUOTED_SCALAR_STYLE
+DOUBLE_QUOTED_SCALAR_STYLE
+BLOCK_MAPPING_STYLE
+FLOW_MAPPING_STYLE
+BLOCK_SEQUENCE_STYLE
+FLOW_SEQUENCE_STYLE
+```
+
+These are defined in `yamldatatest_test.go:constantMap`.
+
+### Common Patterns
+
+#### Parsing Enums from Strings
+
+```go
+func ParseTokenType(t *testing.T, s string) TokenType {
+    t.Helper()
+    val := resolveConstant(t, s)
+    return TokenType(val)
+}
+
+func ParseScalarStyle(t *testing.T, s string) ScalarStyle {
+    t.Helper()
+    val := resolveConstant(t, s)
+    return ScalarStyle(val)
+}
+```
+
+#### Using Reflection for Field Access
+
+```go
+func getFieldValue(t *testing.T, obj interface{}, fieldName string) interface{} {
+    t.Helper()
+
+    v := reflect.ValueOf(obj)
+    if v.Kind() == reflect.Ptr {
+        v = v.Elem()
+    }
+
+    field := v.FieldByName(fieldName)
+    if !field.IsValid() {
+        t.Fatalf("field %s not found in %T", fieldName, obj)
+    }
+
+    return field.Interface()
+}
+```
+
+## Documentation Standards
+
+See `README.md` for the authoritative test framework documentation.
+
+**When updating README.md:**
+1. Read the actual Go struct definitions first
+2. Verify field names exist before documenting them
+3. Test examples are valid (don't include non-existent fields)
+4. Test type names use hyphens consistently
+5. Double-check against actual testdata YAML files
+
+**From PR #194 review - mistakes to avoid:**
+- ❌ Don't reference `Find` field (doesn't exist, it's `Want`)
+- ❌ Don't show `detailed: true` in examples (doesn't exist)
+- ❌ Don't mix underscores and hyphens in test type names
+
+## File Organization
+
+```
+internal/libyaml/
+├── scanner.go              # Scanner implementation
+├── parser.go               # Parser implementation
+├── emitter.go              # Emitter implementation
+├── scanner_test.go         # Scanner tests (pairs with testdata/scanner.yaml)
+├── parser_test.go          # Parser tests
+├── emitter_test.go         # Emitter tests
+├── yamldatatest_test.go    # Test framework implementation
+├── yamldatatest_loader.go  # YAML test data loader
+├── README.md               # Complete test framework documentation
+└── testdata/               # Test data (Go build tool ignores this)
+    ├── scanner.yaml        # Scanner test cases
+    ├── parser.yaml         # Parser test cases
+    ├── emitter.yaml        # Emitter test cases
+    └── ...                 # Other test data files
+```
+
+## Before Submitting Code
+
+**Package-specific checklist:**
+1. ✅ Test type names in YAML use hyphens: `emit-config`, not `emit_config`
+2. ✅ Go switch/if statements use exact YAML format
+3. ✅ Documentation references actual struct fields (not `Find` or invented fields)
+4. ✅ Examples in docs use only valid fields
+5. ✅ New test cases added to appropriate `testdata/*.yaml` file
+6. ✅ Test handler registered in `map[string]TestHandler`
+7. ✅ All tests pass: `go test ./internal/libyaml -v`
+
+**Then follow project-wide checklist in `../../.agents.md`**


### PR DESCRIPTION
The go-yaml project has some very ambitious goals, and we are going to use agentic AI to help us accomplish them.

Many of our pull requests (including many of mine) have used these agents like claude code, cursor and copilot to accomplish much if not all of the work.

Using this new technology requires us to carefully review everything. Fortunately we have extremely good reviewers!

A recent example is pull request #194. I used claude to generate all of the code and all of the tests, and relied on heavily on @ccoVeille (and others including copilot) to review the code and he found dozens of mistakes. In turn i used claude almost entirely to address these mistakes faster than they were reported.

But this brings us to the situation where next time claude will make the same mistakes, and I imagine @ccoVeille will be very disappointed and/or annoyed to see that.

For that reason i ask claude to generate the new standard `.agents.md` files in this PR, by carefully looking at the #194 reviews, in an attempt to prevent it from making the same mistakes on future endeavors.

While this feels like a responsible thing to do i have no doubt the agents will make many mistakes again. But hopefully this starts an ongoing process where after not too long we'll have the full wind in our sails.

Feel free to add to these files as we review this pr. Feel free even to have agents help you with that!

I do suspect opinions are going to be all over the place for this.
Personally I see a lot of potential to do things for YAML in short order that I've only dreamt of in the past.
Like anything new there will be some rough seas ahead, but I've never been more excited to steer this ship!
I hope that feeling is shared by many and accepted by others.
