### PR TITLE
Use YAML syntax to avoid using yamllint directives

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,7 @@ updates:
   directory: /  # Location of package manifests
   schedule:
     interval: weekly
+
 - package-ecosystem: github-actions
   directory: /
   groups:

--- a/.github/workflows/check-commit-message.yaml
+++ b/.github/workflows/check-commit-message.yaml
@@ -11,12 +11,15 @@ jobs:
     name: Check Commit Message
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login != 'dependabot[bot]'
+
     steps:
     - name: Checkout code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
       with:
         fetch-depth: 0  # Fetch all history to ensure all SHAs are available
         persist-credentials: false
+
     - name: Check PR Commits
       run:
         util/check-commit-messages.sh

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -28,20 +28,21 @@ jobs:
           build-mode: autobuild
     steps:
     - name: Checkout repository
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
       with:
         persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      # yamllint disable-line rule:line-length
-      uses: github/codeql-action/init@cf1bb45a277cb3c205638b2cd5c984db1c46a412  # v4.31.7
+      uses: "github/codeql-action/init\
+             @cf1bb45a277cb3c205638b2cd5c984db1c46a412"  # v4.31.7
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      # yamllint disable-line rule:line-length
-      uses: github/codeql-action/analyze@cf1bb45a277cb3c205638b2cd5c984db1c46a412  # v4.31.7
+      uses: "github/codeql-action/analyze\
+             @cf1bb45a277cb3c205638b2cd5c984db1c46a412"  # v4.31.7
       with:
         category: /language:${{matrix.language}}

--- a/.github/workflows/files.yaml
+++ b/.github/workflows/files.yaml
@@ -1,4 +1,5 @@
 name: Files Lint
+
 on:
   push:
     branches: [ main ]
@@ -10,48 +11,58 @@ permissions: read-all
 jobs:
   action-lint:
     runs-on: ubuntu-latest
+
     steps:
     - name: checkout-action
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
       with:
         persist-credentials: false
 
     - name: actionlint
-      # yamllint disable-line rule:line-length
-      uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc  # v2.0.1
+      uses: "raven-actions/actionlint\
+             @3a24062651993d40fed1019b58ac6fbdfbf276cc"  # v2.0.1
 
   yamllint:
     runs-on: ubuntu-latest
+
     steps:
     - name: checkout-action
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
       with:
         persist-credentials: false
 
     - name: yamllint
-      # yamllint disable-line rule:line-length
-      uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
+      uses: "ibiqlik/action-yamllint\
+             @2576378a8e339169678f9939646ee3ee325e845c"  # v3.1.1
 
   ls-lint:
     runs-on: ubuntu-latest
+
     steps:
     - name: checkout-action
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
       with:
         persist-credentials: false
 
     - name: ls-lint
-      uses: ls-lint/action@02e380fe8733d499cbfc9e22276de5085508a5bd  # v2.3.1
+      uses: "ls-lint/action\
+             @02e380fe8733d499cbfc9e22276de5085508a5bd"  # v2.3.1
       with:
         config: .ls-lint.yaml
 
   typos:
     runs-on: ubuntu-latest
+
     steps:
     - name: checkout-action
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
       with:
         persist-credentials: false
 
     - name: typos-action
-      uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06  # v1.40.0
+      uses: "crate-ci/typos\
+             @2d0ce569feab1f8752f1dde43cc2f2aa53236e06"  # v1.40.0

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -12,19 +12,21 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+    - uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
       with:
         persist-credentials: false
     - name: Set up Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      uses: "actions/setup-go\
+             @4dc6199c7b1a012772edbd06daecab0f50c9053c"  # v6.1.0
       with:
         go-version: stable
     - name: Install golangci-lint
       run: |
         make golangci-lint-install
         echo "${{ github.workspace }}/.cache/local/bin" >> "$GITHUB_PATH"
-    # yamllint disable-line rule:line-length
-    - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
+    - uses: "golangci/golangci-lint-action\
+             @1e7e51e771db61008b38414a730f564565cf7c20"  # v9.2.0
       with:
         install-mode: none
   go-versions:
@@ -33,9 +35,10 @@ jobs:
     outputs:
       matrix: ${{ steps.versions.outputs.matrix }}
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-    # yamllint disable-line rule:line-length
-    - uses: arnested/go-version-action@978371bd4d8cad0f54106c8be4273e2fcdd74f57  # v1.1.23
+    - uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
+    - uses: "arnested/go-version-action\
+             @978371bd4d8cad0f54106c8be4273e2fcdd74f57"  # v1.1.23
       id: versions
   build:
     runs-on: ubuntu-latest
@@ -45,11 +48,13 @@ jobs:
       matrix:
         go-versions: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+    - uses: "actions/checkout\
+             @8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
       with:
         persist-credentials: false
     - name: Set up Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      uses: "actions/setup-go\
+             @4dc6199c7b1a012772edbd06daecab0f50c9053c"  # v6.1.0
       with:
         go-version: ${{ matrix.go-versions }}
     - name: Run yaml-test-suit tests

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -14,6 +14,13 @@ rules:
   truthy:
     check-keys: false  # there is a problem with the "on" key in GitHub Actions
   quoted-strings:
-    check-keys: true  # by default, only values are checked
-    quote-type: single
     required: only-when-needed
+    check-keys: true  # by default, only values are checked
+    # We prefer single quotes over double quotes but double quotes are needed
+    # for certain strings.
+    # `any` allows double-quotes or single-quotes but still prevents unnecessary
+    # quotes.
+    # For now, this is as good as we can get with yamllint.
+    # Watch https://github.com/adrienverge/yamllint/pull/777
+    # for a possibly better option.
+    quote-type: any  # was `single` before


### PR DESCRIPTION
The syntax in this PR emerged from [this thread](https://github.com/yaml/go-yaml/pull/198#discussion_r2616493215) while reviewing

- https://github.com/yaml/go-yaml/pull/198

I moved out the changes that weren't related to Makefile from #198 to this PR

I prefer to see them in a PR that doesn't bring other changes.

Also, some files such as codeql.yaml were left behind.