### PR TITLE
Bugfix: allocate 4 bytes instead of 32 bytes

### DIFF
--- a/internal/libyaml/scanner.go
+++ b/internal/libyaml/scanner.go
@@ -548,7 +548,7 @@ func (parser *Parser) read(s []byte) []byte {
 		panic("invalid character sequence")
 	}
 	if len(s) == 0 {
-		s = make([]byte, 0, 32)
+		s = make([]byte, 0, 4)
 	}
 	if w == 1 && len(s)+w <= cap(s) {
 		s = s[:len(s)+1]


### PR DESCRIPTION
This looks like a typo in the `read` function.

The maximum `width` is 4 (see https://github.com/yaml/go-yaml/blob/1c3a4ee7046215c76a8fcdca6bd6210894186394/internal/libyaml/yamlprivate.go#L238).
To me, it looks like we incorrectly allocated 32 bytes when we read a character that can be max 4 bytes long.
Often `read` will be called just once, for 1 character and will unnecessarily allocate space for at least 8 characters.