### PR TITLE
Add go modernize linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
   - misspell
   - nolintlint
   - staticcheck
+  - modernize
   disable:
   - errcheck
   - ineffassign

--- a/cmd/go-yaml/event.go
+++ b/cmd/go-yaml/event.go
@@ -200,7 +200,7 @@ func processEventsUnmarshal(profuse, compact bool) error {
 		firstDoc = false
 
 		// For unmarshal mode, use interface{} first to avoid preserving comments
-		var data interface{}
+		var data any
 		if err := yaml.Unmarshal(doc, &data); err != nil {
 			return fmt.Errorf("failed to unmarshal YAML: %w", err)
 		}

--- a/cmd/go-yaml/json.go
+++ b/cmd/go-yaml/json.go
@@ -26,7 +26,7 @@ func processJSONDecode(pretty bool) error {
 
 	for {
 		// Read each document
-		var data interface{}
+		var data any
 		err := decoder.Decode(&data)
 		if err != nil {
 			if err.Error() == "EOF" {
@@ -66,7 +66,7 @@ func processJSONUnmarshal(pretty bool) error {
 		}
 
 		// For unmarshal mode, always use interface{} to avoid preserving comments
-		var data interface{}
+		var data any
 		err := yaml.Unmarshal(doc, &data)
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal YAML: %w", err)

--- a/cmd/go-yaml/main.go
+++ b/cmd/go-yaml/main.go
@@ -221,7 +221,7 @@ func ProcessNodeUnmarshal() error {
 		firstDoc = false
 
 		// For unmarshal mode, use interface{} first to avoid preserving comments
-		var data interface{}
+		var data any
 		if err := yaml.Unmarshal(doc, &data); err != nil {
 			return fmt.Errorf("failed to unmarshal YAML: %w", err)
 		}

--- a/cmd/go-yaml/token.go
+++ b/cmd/go-yaml/token.go
@@ -261,7 +261,7 @@ func processTokensUnmarshal(profuse, compact bool) error {
 		firstDoc = false
 
 		// For unmarshal mode, use interface{} first to avoid preserving comments
-		var data interface{}
+		var data any
 		if err := yaml.Unmarshal(doc, &data); err != nil {
 			return fmt.Errorf("failed to unmarshal YAML: %w", err)
 		}

--- a/cmd/go-yaml/yaml.go
+++ b/cmd/go-yaml/yaml.go
@@ -77,7 +77,7 @@ func processYAMLDecode(preserve, marshal bool) error {
 		firstDoc := true
 
 		for {
-			var data interface{}
+			var data any
 			err := decoder.Decode(&data)
 			if err != nil {
 				if err == io.EOF || err.Error() == "EOF" {
@@ -176,7 +176,7 @@ func processYAMLUnmarshal(preserve, marshal bool) error {
 			}
 		} else {
 			// For unmarshal mode with -y (not -Y), always use interface{} to avoid preserving comments
-			var data interface{}
+			var data any
 			if err := yaml.Unmarshal(doc, &data); err != nil {
 				return fmt.Errorf("failed to unmarshal YAML: %w", err)
 			}

--- a/decode_test.go
+++ b/decode_test.go
@@ -701,14 +701,14 @@ func TestUnmarshalDurationInt(t *testing.T) {
 }
 
 func TestUnmarshalErrorsFromYAML(t *testing.T) {
-	datatest.RunTestCases(t, func() ([]map[string]interface{}, error) {
+	datatest.RunTestCases(t, func() ([]map[string]any, error) {
 		return datatest.LoadTestCasesFromFile("testdata/unmarshal_errors.yaml", libyaml.LoadYAML)
 	}, map[string]datatest.TestHandler{
 		"unmarshal-error": runUnmarshalErrorTest,
 	})
 }
 
-func runUnmarshalErrorTest(t *testing.T, tc map[string]interface{}) {
+func runUnmarshalErrorTest(t *testing.T, tc map[string]any) {
 	t.Helper()
 
 	yamlInput := datatest.RequireString(t, tc, "yaml")
@@ -723,10 +723,10 @@ func runUnmarshalErrorTest(t *testing.T, tc map[string]interface{}) {
 }
 
 func TestDecoderErrors(t *testing.T) {
-	datatest.RunTestCases(t, func() ([]map[string]interface{}, error) {
+	datatest.RunTestCases(t, func() ([]map[string]any, error) {
 		return datatest.LoadTestCasesFromFile("testdata/unmarshal_errors.yaml", libyaml.LoadYAML)
 	}, map[string]datatest.TestHandler{
-		"unmarshal-error": func(t *testing.T, tc map[string]interface{}) {
+		"unmarshal-error": func(t *testing.T, tc map[string]any) {
 			t.Helper()
 			yamlInput := datatest.RequireString(t, tc, "yaml")
 			expectedError := datatest.RequireString(t, tc, "want")
@@ -1659,14 +1659,14 @@ func (t *textUnmarshaler) UnmarshalText(s []byte) error {
 }
 
 func TestFuzzCrashersFromYAML(t *testing.T) {
-	datatest.RunTestCases(t, func() ([]map[string]interface{}, error) {
+	datatest.RunTestCases(t, func() ([]map[string]any, error) {
 		return datatest.LoadTestCasesFromFile("testdata/fuzz_crashers.yaml", libyaml.LoadYAML)
 	}, map[string]datatest.TestHandler{
 		"fuzz-crasher": runFuzzCrasherTest,
 	})
 }
 
-func runFuzzCrasherTest(t *testing.T, tc map[string]interface{}) {
+func runFuzzCrasherTest(t *testing.T, tc map[string]any) {
 	t.Helper()
 
 	yamlInput := datatest.RequireString(t, tc, "yaml")

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -28,7 +28,7 @@ func FuzzEncodeFromJSON(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, s string) {
-		var v interface{}
+		var v any
 		if err := json.Unmarshal([]byte(s), &v); err != nil {
 			t.Skipf("not valid JSON %q", s)
 		}
@@ -44,7 +44,7 @@ func FuzzEncodeFromJSON(f *testing.F) {
 		t.Logf("YAML %q <%[1]x>", b)
 
 		// Decode as YAML
-		var v2 interface{}
+		var v2 any
 		if err := yaml.Unmarshal(b, &v2); err != nil {
 			t.Error(err)
 		}

--- a/internal/libyaml/api_test.go
+++ b/internal/libyaml/api_test.go
@@ -36,7 +36,7 @@ func runAPIMethodTest(t *testing.T, tc TestCase) {
 
 	// Run setup if any
 	if tc.Setup != nil {
-		if setupList, ok := tc.Setup.([]interface{}); ok && len(setupList) > 0 {
+		if setupList, ok := tc.Setup.([]any); ok && len(setupList) > 0 {
 			callMethodFromList(t, obj, setupList, tc.Bytes)
 		}
 	}
@@ -55,7 +55,7 @@ func runAPIPanicTest(t *testing.T, tc TestCase) {
 
 	// Run setup if any
 	if tc.Setup != nil {
-		if setupList, ok := tc.Setup.([]interface{}); ok && len(setupList) > 0 {
+		if setupList, ok := tc.Setup.([]any); ok && len(setupList) > 0 {
 			callMethodFromList(t, obj, setupList, tc.Bytes)
 		}
 	}
@@ -66,7 +66,7 @@ func runAPIPanicTest(t *testing.T, tc TestCase) {
 	switch v := tc.Want.(type) {
 	case string:
 		wantMsg = v
-	case []interface{}:
+	case []any:
 		if len(v) > 0 {
 			msg, ok := v[0].(string)
 			assert.Truef(t, ok, "Want[0] should be string, got %T", v[0])
@@ -89,13 +89,13 @@ func runAPIDeleteTest(t *testing.T, tc TestCase) {
 
 	// Run setup if any
 	if tc.Setup != nil {
-		if setupList, ok := tc.Setup.([]interface{}); ok && len(setupList) > 0 {
+		if setupList, ok := tc.Setup.([]any); ok && len(setupList) > 0 {
 			callMethodFromList(t, obj, setupList, tc.Bytes)
 		}
 	}
 
 	// Call Delete method
-	callMethodFromList(t, obj, []interface{}{"Delete"}, false)
+	callMethodFromList(t, obj, []any{"Delete"}, false)
 
 	// Run checks after delete
 	runFieldChecks(t, obj, tc.Checks)
@@ -109,7 +109,7 @@ func runAPINewEventTest(t *testing.T, tc TestCase) {
 }
 
 // createObject creates a Parser or Emitter based on constructor name
-func createObject(t *testing.T, constructor string) interface{} {
+func createObject(t *testing.T, constructor string) any {
 	t.Helper()
 	switch constructor {
 	case "NewParser":
@@ -125,7 +125,7 @@ func createObject(t *testing.T, constructor string) interface{} {
 }
 
 // createEventFromList creates an Event from a method list [constructor, args...]
-func createEventFromList(t *testing.T, methodList []interface{}, useBytes bool) Event {
+func createEventFromList(t *testing.T, methodList []any, useBytes bool) Event {
 	t.Helper()
 	if len(methodList) == 0 {
 		t.Fatalf("empty method list")
@@ -178,7 +178,7 @@ func createEventFromList(t *testing.T, methodList []interface{}, useBytes bool) 
 }
 
 // callMethodFromList calls a method from a list [methodName, args...]
-func callMethodFromList(t *testing.T, obj interface{}, methodList []interface{}, useBytes bool) {
+func callMethodFromList(t *testing.T, obj any, methodList []any, useBytes bool) {
 	t.Helper()
 	if len(methodList) == 0 {
 		t.Fatalf("empty method list")
@@ -234,7 +234,7 @@ func callMethodFromList(t *testing.T, obj interface{}, methodList []interface{},
 }
 
 // parseArg parses an argument which could be int, bool, or string constant
-func parseArg(t *testing.T, arg interface{}) int {
+func parseArg(t *testing.T, arg any) int {
 	t.Helper()
 	switch v := arg.(type) {
 	case int:
@@ -255,7 +255,7 @@ func parseArg(t *testing.T, arg interface{}) int {
 }
 
 // parseBoolArg parses a boolean argument
-func parseBoolArg(t *testing.T, arg interface{}) bool {
+func parseBoolArg(t *testing.T, arg any) bool {
 	t.Helper()
 	switch v := arg.(type) {
 	case bool:
@@ -276,7 +276,7 @@ func parseBoolArg(t *testing.T, arg interface{}) bool {
 }
 
 // parseStringArg parses a string argument
-func parseStringArg(t *testing.T, arg interface{}, useBytes bool) string {
+func parseStringArg(t *testing.T, arg any, useBytes bool) string {
 	t.Helper()
 	switch v := arg.(type) {
 	case string:
@@ -328,7 +328,7 @@ func parseConstant(t *testing.T, name string) int {
 
 // hasLength checks if a slice has exactly the expected length
 // Returns true if length matches, false if empty, and fails fatally otherwise
-func hasLength(t *testing.T, slice []interface{}, expected int) bool {
+func hasLength(t *testing.T, slice []any, expected int) bool {
 	t.Helper()
 	if len(slice) == 0 {
 		return false
@@ -340,7 +340,7 @@ func hasLength(t *testing.T, slice []interface{}, expected int) bool {
 }
 
 // runFieldChecks runs field checks on an object
-func runFieldChecks(t *testing.T, obj interface{}, checks []FieldCheck) {
+func runFieldChecks(t *testing.T, obj any, checks []FieldCheck) {
 	t.Helper()
 
 	v := reflect.ValueOf(obj)
@@ -501,7 +501,7 @@ func getIntValue(t *testing.T, field reflect.Value, fieldName string) int {
 }
 
 // checkEqual performs an equality check on a field
-func checkEqual(t *testing.T, v reflect.Value, fieldName string, expectedValue interface{}) {
+func checkEqual(t *testing.T, v reflect.Value, fieldName string, expectedValue any) {
 	t.Helper()
 
 	// Handle buffer-N special case
@@ -565,7 +565,7 @@ func checkEqual(t *testing.T, v reflect.Value, fieldName string, expectedValue i
 	}
 
 	// Get value based on type (handle unexported fields)
-	var got interface{}
+	var got any
 
 	if field.CanInterface() {
 		// For exported fields, convert expected to field's type

--- a/internal/libyaml/parser_test.go
+++ b/internal/libyaml/parser_test.go
@@ -22,7 +22,7 @@ func runParseEventsTest(t *testing.T, tc TestCase) {
 	assert.Truef(t, ok, "parseEvents() = %v, want true", ok)
 
 	// Convert Want from interface{} to []string
-	wantSlice, ok := tc.Want.([]interface{})
+	wantSlice, ok := tc.Want.([]any)
 	assert.Truef(t, ok, "Want should be []interface{}")
 
 	var expected []EventType
@@ -103,7 +103,7 @@ func runParseErrorTest(t *testing.T, tc TestCase) {
 		switch v := tc.Want.(type) {
 		case bool:
 			wantError = v
-		case []interface{}:
+		case []any:
 			if len(v) > 0 {
 				if boolVal, ok := v[0].(bool); ok {
 					wantError = boolVal

--- a/internal/libyaml/reader_test.go
+++ b/internal/libyaml/reader_test.go
@@ -127,14 +127,14 @@ func runReaderPanicTest(t *testing.T, tc TestCase) {
 	}, "Expected panic: %s", wantMsg)
 }
 
-func applySetup(t *testing.T, parser *Parser, setup interface{}) {
+func applySetup(t *testing.T, parser *Parser, setup any) {
 	t.Helper()
 
 	if setup == nil {
 		return
 	}
 
-	setupMap, ok := setup.(map[string]interface{})
+	setupMap, ok := setup.(map[string]any)
 	if !ok {
 		t.Fatalf("setup must be a map, got %T", setup)
 	}

--- a/internal/libyaml/scanner_test.go
+++ b/internal/libyaml/scanner_test.go
@@ -22,7 +22,7 @@ func runScanTokensTest(t *testing.T, tc TestCase) {
 	assert.Truef(t, ok, "scanTokens() failed")
 
 	// Convert Want from interface{} to []string
-	wantSlice, ok := tc.Want.([]interface{})
+	wantSlice, ok := tc.Want.([]any)
 	assert.Truef(t, ok, "Want should be []interface{}")
 
 	var expected []TokenType
@@ -79,7 +79,7 @@ func runScanErrorTest(t *testing.T, tc TestCase) {
 		switch v := tc.Want.(type) {
 		case bool:
 			wantError = v
-		case []interface{}:
+		case []any:
 			if len(v) > 0 {
 				if boolVal, ok := v[0].(bool); ok {
 					wantError = boolVal

--- a/internal/libyaml/yaml_test.go
+++ b/internal/libyaml/yaml_test.go
@@ -56,7 +56,7 @@ func runEnumStringTest(t *testing.T, tc TestCase) {
 	switch v := tc.Want.(type) {
 	case string:
 		want = v
-	case []interface{}:
+	case []any:
 		if len(v) > 0 {
 			var ok bool
 			want, ok = v[0].(string)

--- a/internal/testutil/assert/assert.go
+++ b/internal/testutil/assert/assert.go
@@ -98,7 +98,7 @@ func ErrorIs(tb miniTB, got, want error) {
 }
 
 // errorAsNoPanic calls [errors.As], but catch possible panic and returns it as an error
-func errorAsNoPanic(tb miniTB, err error, target interface{}) (ok bool, panic error) {
+func errorAsNoPanic(tb miniTB, err error, target any) (ok bool, panic error) {
 	defer func() {
 		if r := recover(); r != nil {
 			ok = false
@@ -111,7 +111,7 @@ func errorAsNoPanic(tb miniTB, err error, target interface{}) (ok bool, panic er
 }
 
 // ErrorAs asserts that an error can be assigned to a target variable by using [errors.As].
-func ErrorAs(tb miniTB, err error, target interface{}) {
+func ErrorAs(tb miniTB, err error, target any) {
 	tb.Helper()
 
 	ok, panicErr := errorAsNoPanic(tb, err, target)

--- a/internal/testutil/datatest/constants.go
+++ b/internal/testutil/datatest/constants.go
@@ -71,7 +71,7 @@ func (r *ConstantRegistry) ListConstants() []string {
 // 1. An integer constant name (returns the resolved value)
 // 2. A direct integer value
 // Returns an error if neither works.
-func (r *ConstantRegistry) ResolveIntOrString(value interface{}) (int, error) {
+func (r *ConstantRegistry) ResolveIntOrString(value any) (int, error) {
 	switch v := value.(type) {
 	case int:
 		return v, nil

--- a/internal/testutil/datatest/converters.go
+++ b/internal/testutil/datatest/converters.go
@@ -12,7 +12,7 @@ type IntOrStr struct {
 }
 
 // FromValue implements the custom converter interface used by UnmarshalStruct.
-func (ios *IntOrStr) FromValue(v interface{}) error {
+func (ios *IntOrStr) FromValue(v any) error {
 	switch val := v.(type) {
 	case int:
 		ios.Value = val
@@ -37,7 +37,7 @@ func (ios *IntOrStr) FromValue(v interface{}) error {
 type ByteInput []byte
 
 // FromValue implements the custom converter interface used by UnmarshalStruct.
-func (bi *ByteInput) FromValue(v interface{}) error {
+func (bi *ByteInput) FromValue(v any) error {
 	// Try string first
 	if strVal, ok := v.(string); ok {
 		*bi = []byte(strVal)
@@ -54,7 +54,7 @@ func (bi *ByteInput) FromValue(v interface{}) error {
 	}
 
 	// Otherwise, it should be a sequence of integer bytes
-	intSlice, ok := v.([]interface{})
+	intSlice, ok := v.([]any)
 	if !ok {
 		return fmt.Errorf("input must be a string, int, or sequence of integers, got %T", v)
 	}
@@ -77,18 +77,18 @@ func (bi *ByteInput) FromValue(v interface{}) error {
 
 // Args can be converted from either a single value or an array of values.
 // This is useful for method arguments that can be either scalar or array.
-type Args []interface{}
+type Args []any
 
 // FromValue implements the custom converter interface used by UnmarshalStruct.
-func (a *Args) FromValue(v interface{}) error {
+func (a *Args) FromValue(v any) error {
 	// Try array first
-	if arrVal, ok := v.([]interface{}); ok {
+	if arrVal, ok := v.([]any); ok {
 		*a = arrVal
 		return nil
 	}
 
 	// Otherwise, it's a single scalar value - wrap it in a slice
-	*a = []interface{}{v}
+	*a = []any{v}
 	return nil
 }
 
@@ -96,7 +96,7 @@ func (a *Args) FromValue(v interface{}) error {
 type StringSlice []string
 
 // FromValue implements the custom converter interface used by UnmarshalStruct.
-func (ss *StringSlice) FromValue(v interface{}) error {
+func (ss *StringSlice) FromValue(v any) error {
 	// Try string first
 	if strVal, ok := v.(string); ok {
 		*ss = []string{strVal}
@@ -104,7 +104,7 @@ func (ss *StringSlice) FromValue(v interface{}) error {
 	}
 
 	// Try slice of interface{}
-	if slice, ok := v.([]interface{}); ok {
+	if slice, ok := v.([]any); ok {
 		strs := make([]string, len(slice))
 		for i, item := range slice {
 			str, ok := item.(string)
@@ -124,7 +124,7 @@ func (ss *StringSlice) FromValue(v interface{}) error {
 type IntSlice []int
 
 // FromValue implements the custom converter interface used by UnmarshalStruct.
-func (is *IntSlice) FromValue(v interface{}) error {
+func (is *IntSlice) FromValue(v any) error {
 	// Try int first
 	if intVal, ok := v.(int); ok {
 		*is = []int{intVal}
@@ -132,7 +132,7 @@ func (is *IntSlice) FromValue(v interface{}) error {
 	}
 
 	// Try slice of interface{}
-	if slice, ok := v.([]interface{}); ok {
+	if slice, ok := v.([]any); ok {
 		ints := make([]int, len(slice))
 		for i, item := range slice {
 			intVal, ok := item.(int)

--- a/internal/testutil/datatest/helpers.go
+++ b/internal/testutil/datatest/helpers.go
@@ -23,7 +23,7 @@ func HexToBytes(t *testing.T, s string) []byte {
 
 // GetField uses reflection to get a field value from a struct or pointer to struct.
 // This is useful for test assertions that need to check internal field values.
-func GetField(t *testing.T, obj interface{}, fieldName string) interface{} {
+func GetField(t *testing.T, obj any, fieldName string) any {
 	t.Helper()
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Ptr {
@@ -40,7 +40,7 @@ func GetField(t *testing.T, obj interface{}, fieldName string) interface{} {
 // This is useful for test cases that need to call methods dynamically.
 // Returns the slice of return values from the method call as reflect.Value wrappers.
 // Callers must extract the actual values using methods like .Interface(), .Int(), .String(), etc.
-func CallMethod(t *testing.T, obj interface{}, methodName string, args []interface{}) []reflect.Value {
+func CallMethod(t *testing.T, obj any, methodName string, args []any) []reflect.Value {
 	t.Helper()
 	v := reflect.ValueOf(obj)
 	method := v.MethodByName(methodName)
@@ -59,7 +59,7 @@ func CallMethod(t *testing.T, obj interface{}, methodName string, args []interfa
 // WantBool extracts a bool value from a test case's Want field.
 // If Want is nil, returns the defaultVal.
 // This is useful for test cases where the expected result is a boolean.
-func WantBool(t *testing.T, want interface{}, defaultVal bool) bool {
+func WantBool(t *testing.T, want any, defaultVal bool) bool {
 	t.Helper()
 	if want == nil {
 		return defaultVal
@@ -73,7 +73,7 @@ func WantBool(t *testing.T, want interface{}, defaultVal bool) bool {
 
 // WantString extracts a string value from a test case's Want field.
 // If Want is nil, returns the defaultVal.
-func WantString(t *testing.T, want interface{}, defaultVal string) string {
+func WantString(t *testing.T, want any, defaultVal string) string {
 	t.Helper()
 	if want == nil {
 		return defaultVal
@@ -87,7 +87,7 @@ func WantString(t *testing.T, want interface{}, defaultVal string) string {
 
 // WantInt extracts an int value from a test case's Want field.
 // If Want is nil, returns the defaultVal.
-func WantInt(t *testing.T, want interface{}, defaultVal int) int {
+func WantInt(t *testing.T, want any, defaultVal int) int {
 	t.Helper()
 	if want == nil {
 		return defaultVal
@@ -101,12 +101,12 @@ func WantInt(t *testing.T, want interface{}, defaultVal int) int {
 
 // WantSlice extracts a slice value from a test case's Want field.
 // If Want is nil, returns nil.
-func WantSlice(t *testing.T, want interface{}) []interface{} {
+func WantSlice(t *testing.T, want any) []any {
 	t.Helper()
 	if want == nil {
 		return nil
 	}
-	sliceVal, ok := want.([]interface{})
+	sliceVal, ok := want.([]any)
 	if !ok {
 		t.Fatalf("Want should be []interface{}, got %T", want)
 	}
@@ -115,7 +115,7 @@ func WantSlice(t *testing.T, want interface{}) []interface{} {
 
 // SetFieldValue sets a field value on a struct using reflection.
 // This is useful for test setup that needs to configure objects dynamically.
-func SetFieldValue(t *testing.T, obj interface{}, fieldName string, value interface{}) {
+func SetFieldValue(t *testing.T, obj any, fieldName string, value any) {
 	t.Helper()
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Ptr {
@@ -148,8 +148,8 @@ func TrimTrailingNewline(s string) string {
 //	Simple loop: {loop: ["value", count]}
 //	Join parts: {join: [{text: "..."}, {loop: ["...", count]}]}
 //	Nested: {join: [...], loop: count}
-func GenerateData(spec interface{}) ([]byte, error) {
-	specMap, ok := spec.(map[string]interface{})
+func GenerateData(spec any) ([]byte, error) {
+	specMap, ok := spec.(map[string]any)
 	if !ok {
 		// If it's just a string, return it as-is
 		if str, ok := spec.(string); ok {
@@ -187,8 +187,8 @@ func GenerateData(spec interface{}) ([]byte, error) {
 	return nil, fmt.Errorf("data spec must have 'loop' or 'join' field")
 }
 
-func generateSimpleLoop(loopVal interface{}) ([]byte, error) {
-	loopArr, ok := loopVal.([]interface{})
+func generateSimpleLoop(loopVal any) ([]byte, error) {
+	loopArr, ok := loopVal.([]any)
 	if !ok {
 		return nil, fmt.Errorf("loop must be array [value, count], got %T", loopVal)
 	}
@@ -210,15 +210,15 @@ func generateSimpleLoop(loopVal interface{}) ([]byte, error) {
 	return []byte(strings.Repeat(value, count)), nil
 }
 
-func generateJoin(joinVal interface{}) ([]byte, error) {
-	joinList, ok := joinVal.([]interface{})
+func generateJoin(joinVal any) ([]byte, error) {
+	joinList, ok := joinVal.([]any)
 	if !ok {
 		return nil, fmt.Errorf("join must be array, got %T", joinVal)
 	}
 
 	var result strings.Builder
 	for i, item := range joinList {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("join item %d must be map, got %T", i, item)
 		}

--- a/internal/testutil/datatest/registry.go
+++ b/internal/testutil/datatest/registry.go
@@ -11,14 +11,14 @@ import (
 // This allows test data in YAML to reference types by name.
 type TypeRegistry struct {
 	types     map[string]reflect.Type
-	factories map[string]func() interface{}
+	factories map[string]func() any
 }
 
 // NewTypeRegistry creates a new type registry.
 func NewTypeRegistry() *TypeRegistry {
 	return &TypeRegistry{
 		types:     make(map[string]reflect.Type),
-		factories: make(map[string]func() interface{}),
+		factories: make(map[string]func() any),
 	}
 }
 
@@ -30,7 +30,7 @@ func NewTypeRegistry() *TypeRegistry {
 //	registry.Register("string", "")
 //	registry.Register("int", 0)
 //	registry.Register("yaml.Node", yaml.Node{})
-func (r *TypeRegistry) Register(name string, exemplar interface{}) {
+func (r *TypeRegistry) Register(name string, exemplar any) {
 	r.types[name] = reflect.TypeOf(exemplar)
 }
 
@@ -42,7 +42,7 @@ func (r *TypeRegistry) Register(name string, exemplar interface{}) {
 //	registry.RegisterFactory("map[string]any", func() interface{} {
 //	    return make(map[string]interface{})
 //	})
-func (r *TypeRegistry) RegisterFactory(name string, factory func() interface{}) {
+func (r *TypeRegistry) RegisterFactory(name string, factory func() any) {
 	r.factories[name] = factory
 	// Also register the type by calling the factory once
 	if instance := factory(); instance != nil {
@@ -52,7 +52,7 @@ func (r *TypeRegistry) RegisterFactory(name string, factory func() interface{}) 
 
 // NewInstance creates a new zero-value instance of the registered type.
 // Returns an error if the type is not registered.
-func (r *TypeRegistry) NewInstance(name string) (interface{}, error) {
+func (r *TypeRegistry) NewInstance(name string) (any, error) {
 	// Check if there's a factory first
 	if factory, ok := r.factories[name]; ok {
 		return factory(), nil
@@ -70,7 +70,7 @@ func (r *TypeRegistry) NewInstance(name string) (interface{}, error) {
 
 // NewPointerInstance creates a new pointer to a zero-value instance of the registered type.
 // This is useful for unmarshaling into struct pointers.
-func (r *TypeRegistry) NewPointerInstance(name string) (interface{}, error) {
+func (r *TypeRegistry) NewPointerInstance(name string) (any, error) {
 	// Check if there's a factory first
 	if factory, ok := r.factories[name]; ok {
 		instance := factory()

--- a/internal/testutil/datatest/runner.go
+++ b/internal/testutil/datatest/runner.go
@@ -9,7 +9,7 @@ import (
 
 // TestHandler is a function that runs a single test case.
 // The test case is passed as a map[string]interface{}.
-type TestHandler func(t *testing.T, tc map[string]interface{})
+type TestHandler func(t *testing.T, tc map[string]any)
 
 // TestRunner manages test execution with handlers for different test types.
 type TestRunner struct {
@@ -29,7 +29,7 @@ func (r *TestRunner) RegisterHandler(testType string, handler TestHandler) {
 }
 
 // RunWithCases executes test cases loaded from a slice of maps.
-func (r *TestRunner) RunWithCases(t *testing.T, cases []map[string]interface{}) {
+func (r *TestRunner) RunWithCases(t *testing.T, cases []map[string]any) {
 	t.Helper()
 
 	for _, tc := range cases {
@@ -58,7 +58,7 @@ func (r *TestRunner) RunWithCases(t *testing.T, cases []map[string]interface{}) 
 
 // RunTestCases is a convenience function that creates a runner and executes test cases.
 // The loadFunc should be provided by the calling package to load test data using its preferred YAML parser.
-func RunTestCases(t *testing.T, loadFunc func() ([]map[string]interface{}, error), handlers map[string]TestHandler) {
+func RunTestCases(t *testing.T, loadFunc func() ([]map[string]any, error), handlers map[string]TestHandler) {
 	t.Helper()
 
 	cases, err := loadFunc()
@@ -74,7 +74,7 @@ func RunTestCases(t *testing.T, loadFunc func() ([]map[string]interface{}, error
 }
 
 // GetString extracts a string field from a test case map.
-func GetString(tc map[string]interface{}, key string) (string, bool) {
+func GetString(tc map[string]any, key string) (string, bool) {
 	val, ok := tc[key]
 	if !ok {
 		return "", false
@@ -84,7 +84,7 @@ func GetString(tc map[string]interface{}, key string) (string, bool) {
 }
 
 // GetInt extracts an int field from a test case map.
-func GetInt(tc map[string]interface{}, key string) (int, bool) {
+func GetInt(tc map[string]any, key string) (int, bool) {
 	val, ok := tc[key]
 	if !ok {
 		return 0, false
@@ -94,7 +94,7 @@ func GetInt(tc map[string]interface{}, key string) (int, bool) {
 }
 
 // GetBool extracts a bool field from a test case map.
-func GetBool(tc map[string]interface{}, key string) (bool, bool) {
+func GetBool(tc map[string]any, key string) (bool, bool) {
 	val, ok := tc[key]
 	if !ok {
 		return false, false
@@ -104,27 +104,27 @@ func GetBool(tc map[string]interface{}, key string) (bool, bool) {
 }
 
 // GetSlice extracts a slice field from a test case map.
-func GetSlice(tc map[string]interface{}, key string) ([]interface{}, bool) {
+func GetSlice(tc map[string]any, key string) ([]any, bool) {
 	val, ok := tc[key]
 	if !ok {
 		return nil, false
 	}
-	slice, ok := val.([]interface{})
+	slice, ok := val.([]any)
 	return slice, ok
 }
 
 // GetMap extracts a map field from a test case map.
-func GetMap(tc map[string]interface{}, key string) (map[string]interface{}, bool) {
+func GetMap(tc map[string]any, key string) (map[string]any, bool) {
 	val, ok := tc[key]
 	if !ok {
 		return nil, false
 	}
-	m, ok := val.(map[string]interface{})
+	m, ok := val.(map[string]any)
 	return m, ok
 }
 
 // RequireString extracts a string field, failing the test if not present.
-func RequireString(t *testing.T, tc map[string]interface{}, key string) string {
+func RequireString(t *testing.T, tc map[string]any, key string) string {
 	t.Helper()
 	val, ok := GetString(tc, key)
 	if !ok {
@@ -134,7 +134,7 @@ func RequireString(t *testing.T, tc map[string]interface{}, key string) string {
 }
 
 // RequireInt extracts an int field, failing the test if not present.
-func RequireInt(t *testing.T, tc map[string]interface{}, key string) int {
+func RequireInt(t *testing.T, tc map[string]any, key string) int {
 	t.Helper()
 	val, ok := GetInt(tc, key)
 	if !ok {
@@ -144,7 +144,7 @@ func RequireInt(t *testing.T, tc map[string]interface{}, key string) int {
 }
 
 // RequireSlice extracts a slice field, failing the test if not present.
-func RequireSlice(t *testing.T, tc map[string]interface{}, key string) []interface{} {
+func RequireSlice(t *testing.T, tc map[string]any, key string) []any {
 	t.Helper()
 	val, ok := GetSlice(tc, key)
 	if !ok {
@@ -154,12 +154,12 @@ func RequireSlice(t *testing.T, tc map[string]interface{}, key string) []interfa
 }
 
 // UnmarshalTestCase unmarshals a test case map into a struct.
-func UnmarshalTestCase(tc map[string]interface{}, target interface{}) error {
+func UnmarshalTestCase(tc map[string]any, target any) error {
 	return UnmarshalStruct(target, tc)
 }
 
 // AssertEqual is a helper for comparing expected and actual values in test handlers.
-func AssertEqual(t *testing.T, expected, actual interface{}) {
+func AssertEqual(t *testing.T, expected, actual any) {
 	t.Helper()
 	if fmt.Sprintf("%v", expected) != fmt.Sprintf("%v", actual) {
 		t.Errorf("Expected:\n%v\nGot:\n%v", expected, actual)

--- a/limit_test.go
+++ b/limit_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLimits(t *testing.T) {
-	datatest.RunTestCases(t, func() ([]map[string]interface{}, error) {
+	datatest.RunTestCases(t, func() ([]map[string]any, error) {
 		return datatest.LoadTestCasesFromFile("testdata/limit.yaml", libyaml.LoadYAML)
 	}, map[string]datatest.TestHandler{
 		"limit":       runLimitTest,
@@ -20,7 +20,7 @@ func TestLimits(t *testing.T) {
 	})
 }
 
-func runLimitTest(t *testing.T, tc map[string]interface{}) {
+func runLimitTest(t *testing.T, tc map[string]any) {
 	t.Helper()
 
 	// Generate data from spec
@@ -37,7 +37,7 @@ func runLimitTest(t *testing.T, tc map[string]interface{}) {
 		switch v := wantVal.(type) {
 		case string:
 			expectedError = v
-		case map[string]interface{}:
+		case map[string]any:
 			// Future: could validate structure here
 			// For now, just ignore (treated as success case)
 		default:

--- a/parser_events_test.go
+++ b/parser_events_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestParserGetEvents(t *testing.T) {
-	datatest.RunTestCases(t, func() ([]map[string]interface{}, error) {
+	datatest.RunTestCases(t, func() ([]map[string]any, error) {
 		return datatest.LoadTestCasesFromFile("testdata/parser_events.yaml", libyaml.LoadYAML)
 	}, map[string]datatest.TestHandler{
 		"parser-events": runParserEventsTest,
 	})
 }
 
-func runParserEventsTest(t *testing.T, tc map[string]interface{}) {
+func runParserEventsTest(t *testing.T, tc map[string]any) {
 	t.Helper()
 
 	// Extract test data


### PR DESCRIPTION
Add linter to check usage of modern Go idioms.

Ref: https://github.com/yaml/go-yaml/issues/4

https://golangci-lint.run/docs/linters/configuration/#modernize https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize

The PR might look large, but the material changes are
- Adding linter to `.golangci.yaml`
- `interface{} -> any` conversion