### PR TITLE
use explicit legacy options

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -317,21 +317,13 @@ var (
 )
 
 func newDecoder(opts *options) *decoder {
-	d := &decoder{
+	return &decoder{
 		stringMapType:  stringMapType,
 		generalMapType: generalMapType,
-		uniqueKeys:     true, // default for legacy Decoder API (when opts == nil)
+		knownFields:    opts.knownFields,
+		uniqueKeys:     opts.uniqueKeys,
+		aliases:        make(map[*Node]bool),
 	}
-	d.aliases = make(map[*Node]bool)
-
-	if opts != nil {
-		// For Loader API, opts comes from applyOptions() which initializes
-		// uniqueKeys to true by default, so this preserves the same behavior
-		d.knownFields = opts.knownFields
-		d.uniqueKeys = opts.uniqueKeys
-	}
-
-	return d
 }
 
 func (d *decoder) terror(n *Node, tag string, out reflect.Value) {

--- a/options.go
+++ b/options.go
@@ -440,3 +440,12 @@ func applyOptions(opts ...Option) (*options, error) {
 	}
 	return o, nil
 }
+
+// legacyOptions holds the default options for legacy APIs like
+// Marshal/Unmarshal.
+var legacyOptions = &options{
+	indent:     4,
+	lineWidth:  -1,
+	unicode:    true,
+	uniqueKeys: true,
+}

--- a/yaml.go
+++ b/yaml.go
@@ -199,7 +199,7 @@ func (dec *Decoder) KnownFields(enable bool) {
 //
 // Deprecated: Use Loader.Load instead. Will be removed in v5.
 func (dec *Decoder) Decode(v any) (err error) {
-	d := newDecoder(nil)
+	d := newDecoder(legacyOptions)
 	d.knownFields = dec.knownFields
 	defer handleErr(&err)
 	node := dec.parser.parse()
@@ -224,7 +224,7 @@ func (dec *Decoder) Decode(v any) (err error) {
 //
 // Deprecated: Use Node.Load instead. Will be removed in v5.
 func (n *Node) Decode(v any) (err error) {
-	d := newDecoder(nil)
+	d := newDecoder(legacyOptions)
 	defer handleErr(&err)
 	out := reflect.ValueOf(v)
 	if out.Kind() == reflect.Pointer && !out.IsNil() {
@@ -338,7 +338,7 @@ func unmarshal(in []byte, out any, opts ...Option) (err error) {
 // Deprecated: Use Dump instead. Will be removed in v5.
 func Marshal(in any) (out []byte, err error) {
 	defer handleErr(&err)
-	e := newEncoder(noWriter, noOptions)
+	e := newEncoder(noWriter, legacyOptions)
 	defer e.destroy()
 	e.marshalDoc("", reflect.ValueOf(in))
 	e.finish()
@@ -502,7 +502,7 @@ type Encoder struct {
 // Deprecated: Use NewDumper instead. Will be removed in v5.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
-		encoder: newEncoder(w, noOptions),
+		encoder: newEncoder(w, legacyOptions),
 	}
 }
 
@@ -529,7 +529,7 @@ func (e *Encoder) Encode(v any) (err error) {
 // Deprecated: Use Node.Dump instead. Will be removed in v5.
 func (n *Node) Encode(v any) (err error) {
 	defer handleErr(&err)
-	e := newEncoder(noWriter, noOptions)
+	e := newEncoder(noWriter, legacyOptions)
 	defer e.destroy()
 	e.marshalDoc("", reflect.ValueOf(v))
 	e.finish()


### PR DESCRIPTION
The legacy code paths pass nil options to encoder/decoder, which
handle `nil` options by setting specific settings. This change
simplifies this code by using explicit `legacyOptions` instead of
`nil`.