### PR TITLE
Support decoding !!binary into []byte

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -615,6 +615,14 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 		}
 		out.SetString(n.Value)
 		return true
+	case reflect.Slice:
+		// allow decoding !!binary-tagged value into []byte specifically
+		if out.Type().Elem().Kind() == reflect.Uint8 {
+			if tag == binaryTag {
+				out.SetBytes([]byte(resolved.(string)))
+				return true
+			}
+		}
 	case reflect.Interface:
 		out.Set(reflect.ValueOf(resolved))
 		return true

--- a/decode_test.go
+++ b/decode_test.go
@@ -121,6 +121,9 @@ func init() {
 	decodeTypes.RegisterFactory("map[string]float64", func() any {
 		return make(map[string]float64)
 	})
+	decodeTypes.RegisterFactory("map[string][]byte", func() any {
+		return make(map[string][]byte)
+	})
 	decodeTypes.RegisterFactory("map[any]any", func() any {
 		return make(map[any]any)
 	})

--- a/testdata/decode.yaml
+++ b/testdata/decode.yaml
@@ -790,6 +790,28 @@
     want:
       v: test
 
+# !!binary tags
+- decode:
+    name: decoding !!binary into any
+    yaml: 'v: !!binary MTIzCg=='
+    type: map[string]any
+    want:
+      v: "123\n"
+
+- decode:
+    name: decoding !!binary into string
+    yaml: 'v: !!binary MTIzCg=='
+    type: map[string]string
+    want:
+      v: "123\n"
+
+- decode:
+    name: decoding !!binary into []byte
+    yaml: 'v: !!binary MTIzCg=='
+    type: map[string][]byte
+    want:
+      v: [0x31, 0x32, 0x33, 0x0A]
+
 # Anchors and aliases
 - decode:
     name: anchor as key with alias


### PR DESCRIPTION
Although Go doesn't restrict strings to contain valid UTF-8, `[]byte` is still commonly used to represent non-text buffers.

PyYAML generates !!binary values for Python's bytes type, so these values are not rare.

This doesn't affect the marshal direction: `[]byte` is still dumped as a list of integers.

Closes #226