### PR TITLE
Add TypeError.Strings() for v3 to v4 migration

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1782,3 +1782,19 @@ func TestParserErrorUnknownAnchorPosition(t *testing.T) {
 		assert.DeepEqual(t, expected, asErr)
 	}
 }
+
+func TestTypeError_Strings(t *testing.T) {
+	// Create a TypeError with multiple errors
+	typeErr := &yaml.TypeError{
+		Errors: []*yaml.UnmarshalError{
+			{Err: errors.New("cannot unmarshal string into int"), Line: 5, Column: 3},
+			{Err: errors.New("cannot unmarshal bool into string"), Line: 10, Column: 7},
+		},
+	}
+
+	strings := typeErr.Strings()
+
+	assert.Equal(t, 2, len(strings))
+	assert.Equal(t, "line 5: cannot unmarshal string into int", strings[0])
+	assert.Equal(t, "line 10: cannot unmarshal bool into string", strings[1])
+}

--- a/yaml.go
+++ b/yaml.go
@@ -677,6 +677,20 @@ func (e *TypeError) As(target any) bool {
 	return false
 }
 
+// Strings returns the error messages as a string slice.
+//
+// This method is provided for compatibility with code migrating from v3,
+// where TypeError.Errors was []string. New code should access the Errors
+// field directly to get structured error information including line and
+// column numbers.
+func (e *TypeError) Strings() []string {
+	result := make([]string, len(e.Errors))
+	for i, err := range e.Errors {
+		result[i] = err.Error()
+	}
+	return result
+}
+
 type Kind uint32
 
 const (


### PR DESCRIPTION
In v3, TypeError.Errors was []string. In v4, it changed to []*UnmarshalError to provide structured error information with line and column numbers. This is a breaking change for code that directly accesses the Errors field.

The new Strings() method eases migration by providing a simple way to get the v3-style string slice without changing existing logic:

  // v3 code
  for _, msg := range typeErr.Errors { ... }

  // v4 migration (minimal change)
  for _, msg := range typeErr.Strings() { ... }

This allows users to migrate with a one-line change, deferring the adoption of structured errors until they're ready. New code should still access the Errors field directly to take advantage of the richer error information.

This was added because Claude saw this as the only breaking issue from V3 to V4. 

See https://gist.github.com/ingydotnet/8a2becd45d032655a327fe361b3fe234 for more info.