### PR TITLE
Support escaped slash in strings

### DIFF
--- a/internal/libyaml/scanner.go
+++ b/internal/libyaml/scanner.go
@@ -2231,6 +2231,10 @@ func (parser *Parser) scanFlowScalar(token *Token, single bool) error {
 					code_length = 4
 				case 'U':
 					code_length = 8
+				case '/':
+					// Support escaped slash ("\/"), as required by YAML 1.2.0+
+					// for strict JSON compatibility
+					s = append(s, '/')
 				default:
 					return formatScannerErrorContext("while scanning a quoted scalar", start_mark,
 						"found unknown escape character", parser.mark)

--- a/internal/libyaml/testdata/constructor.yaml
+++ b/internal/libyaml/testdata/constructor.yaml
@@ -79,6 +79,12 @@
     yaml: '"42"'
     want: '42'
 
+# https://github.com/yaml/go-yaml/issues/245
+- scalar-resolution:
+    name: Escaped slash in double-quoted string
+    yaml: '"\/"'
+    want: '/'
+
 - scalar-resolution:
     name: Mapping with numeric values
     yaml: |


### PR DESCRIPTION
Fixes #245 by porting forward https://github.com/go-yaml/yaml/pull/862

Original text:

---

The JSON spec lists the `/` character as optionally-escapable, and so YAML v1.2.0 added support for the sequence `\/` to be unescaped to `/`.

This PR adds the minimum necessary support for this, and should solve the issues that a few people have already hit, as documented in https://github.com/go-yaml/yaml/issues/797.

Thanks!