### PR TITLE
Remove deprecation markers and rename Legacy verbiage

### DIFF
--- a/docs/dump-load-api.md
+++ b/docs/dump-load-api.md
@@ -8,9 +8,9 @@ from simple one-liners to advanced streaming with full configuration control.
 **For new code in v4+, prefer `Dump`/`Load` over `Marshal`/`Unmarshal` and
 `Encode`/`Decode`.**
 
-**IMPORTANT**: `Marshal`, `Unmarshal`, `Encoder`, and `Decoder` are deprecated
-as of v4 and will be removed in v5.
-Use `Dump`/`Load` and `Dumper`/`Loader` instead.
+The classic API (`Marshal`, `Unmarshal`, `Encoder`, `Decoder`) remains supported
+for compatibility, but `Dump`/`Load` and `Dumper`/`Loader` offer more flexibility
+with options support.
 
 ### Why Dump and Load?
 
@@ -36,16 +36,16 @@ provide a full Dump and Load stack.
 Those involve the Represent (for Dump) and Construct (for Load) YAML stack
 stages and v4 will offer those (optionally) for Dump and Load.
 
-### Transition Path
+### Classic API
 
-`Marshal`/`Unmarshal` and `Encode`/`Decode` are retained in v4 to smooth the
-transition from v3:
+`Marshal`/`Unmarshal` and `Encode`/`Decode` provide a simple, options-free
+interface:
 
-- They work **without options** and continue using **v3 semantics** (4-space
+- They work **without options** and use **v3 semantics** (4-space
   indent, non-compact sequences)
-- They're perfect for upgrading existing v3 code with minimal changes
-- For new code, use `Dump`/`Load` instead—they can replicate the old behavior
-  and much more
+- They're perfect for simple use cases and upgrading existing v3 code
+- For new code, use `Dump`/`Load` instead—they can replicate the same behavior
+  with added flexibility
 
 ### Flexibility
 
@@ -67,12 +67,12 @@ when you need it.
 
 go-yaml provides five main API functions for dumping and loading YAML:
 
-| Reader | Writer | Configurable | Use Case | Deprecated |
-|--------|--------|--------------|----------|------------|
-| `Load` | `Dump` | Yes | Single or multi-doc with options | No |
-| `NewLoader` | `NewDumper` | Yes | Large files, continuous streams | No |
-| `Unmarshal` | `Marshal` | No | Quick conversions, preset behavior | Yes |
-| `Decode` | `Encode` | No | Multi-doc streams, preset behavior | Yes |
+| Reader | Writer | Configurable | Use Case |
+|--------|--------|--------------|----------|
+| `Load` | `Dump` | Yes | Single or multi-doc with options |
+| `NewLoader` | `NewDumper` | Yes | Large files, continuous streams |
+| `Unmarshal` | `Marshal` | No | Quick conversions, preset behavior |
+| `NewDecoder` | `NewEncoder` | No | Multi-doc streams, preset behavior |
 
 ## Configurable API: Dump and Load
 
@@ -242,12 +242,9 @@ for {
 **When to use:** Large files, network streams, processing documents
 incrementally, or when you need maximum control.
 
-## DEPRECATED: Static Behavior API (Marshal and Unmarshal)
+## Classic API: Marshal and Unmarshal
 
-**DEPRECATED**: This API is deprecated in v4 and will be removed in v5.
-Use `Dump` and `Load` instead.
-
-No options, no streaming—just convert.
+Simple conversion with no options or streaming.
 
 **Note:** These functions use **v3 semantics** (4-space indent, non-compact
 sequences) and **do not accept options**.
@@ -306,10 +303,7 @@ fmt.Println(config.Name)  // "myapp"
 **When to use:** Quick scripts, tests, simple config files where default
 formatting is fine.
 
-## DEPRECATED: Static Behavior Streaming API (Encoder and Decoder)
-
-**DEPRECATED**: This API is deprecated in v4 and will be removed in v5.
-Use `Dumper` and `Loader` instead.
+## Classic Streaming API: Encoder and Decoder
 
 For multi-document streams without needing options.
 Simple functions for encoding/decoding streams.

--- a/docs/v3-to-v4-migration.md
+++ b/docs/v3-to-v4-migration.md
@@ -6,7 +6,7 @@ This guide will help you migrate your code from `go.yaml.in/yaml/v3`
 ## Quick Migration Checklist
 
 - [ ] Update import path
-- [ ] Replace deprecated API calls
+- [ ] Optionally migrate to new API (Load/Dump, Loader/Dumper)
 - [ ] Handle TypeError.Errors type change (if you use it directly)
 - [ ] Adjust formatting expectations or use yaml.V3 preset
 - [ ] Update tests
@@ -248,20 +248,18 @@ data, err := yaml.Dump(&config,
 
 ## Backward Compatibility
 
-All v3 APIs continue to work in v4 but are **deprecated** for removal
-in v5:
+All v3 APIs continue to work in v4. The classic API remains supported
+for simple use cases:
 
-- `Unmarshal()` → Use `Load()`
-- `Marshal()` → Use `Dump()`
-- `NewDecoder()` → Use `NewLoader()`
-- `NewEncoder()` → Use `NewDumper()`
-- `Decoder.Decode()` → Use `Loader.Load()`
-- `Encoder.Encode()` → Use `Dumper.Dump()`
+- `Unmarshal()` - Classic API (or use `Load()` for more flexibility)
+- `Marshal()` - Classic API (or use `Dump()` for more flexibility)
+- `NewDecoder()` - Classic API (or use `NewLoader()` for more flexibility)
+- `NewEncoder()` - Classic API (or use `NewDumper()` for more flexibility)
 
 You can migrate incrementally:
 1. Update import path to v4
 2. Verify tests pass
-3. Gradually replace deprecated APIs
+3. Optionally migrate to new API for additional features
 4. Update TypeError.Errors handling if applicable
 
 ## Migration Strategies
@@ -299,9 +297,6 @@ data, err := yaml.Dump(&config, yaml.V3)
 # Run your existing tests
 go test ./...
 
-# Check for deprecation warnings (Go 1.18+)
-go test -v ./... 2>&1 | grep -i 'deprecat.*'
-
 # Verify YAML output formatting
 # Use the go-yaml CLI tool to compare
 go install go.yaml.in/yaml/v4/cmd/go-yaml@latest
@@ -326,9 +321,9 @@ for _, e := range typeErr.Errors {
 }
 ```
 
-### Issue: Deprecation warnings
+### Issue: Want more flexibility from classic API
 
-**Solution:** Replace deprecated APIs:
+**Solution:** Migrate to the new API for options support:
 - `Unmarshal` → `Load`
 - `Marshal` → `Dump`
 - `NewDecoder` → `NewLoader`

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -273,10 +273,8 @@ func (n *Node) SetString(s string) {
 //
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
-//
-// Deprecated: Use Node.Load instead. Will be removed in v5.
 func (n *Node) Decode(v any) (err error) {
-	d := NewConstructor(LegacyOptions)
+	d := NewConstructor(DefaultOptions)
 	defer handleErr(&err)
 	out := reflect.ValueOf(v)
 	if out.Kind() == reflect.Pointer && !out.IsNil() {
@@ -324,11 +322,9 @@ func (n *Node) Load(v any, opts ...Option) (err error) {
 //
 // See the documentation for Marshal for details about the
 // conversion of Go values into YAML.
-//
-// Deprecated: Use Node.Dump instead. Will be removed in v5.
 func (n *Node) Encode(v any) (err error) {
 	defer handleErr(&err)
-	e := NewRepresenter(noWriter, LegacyOptions)
+	e := NewRepresenter(noWriter, DefaultOptions)
 	defer e.Destroy()
 	e.MarshalDoc("", reflect.ValueOf(v))
 	e.Finish()

--- a/internal/libyaml/options.go
+++ b/internal/libyaml/options.go
@@ -351,9 +351,8 @@ func ApplyOptions(opts ...Option) (*Options, error) {
 	return o, nil
 }
 
-// LegacyOptions holds the default options for legacy APIs like
-// Marshal/Unmarshal.
-var LegacyOptions = &Options{
+// DefaultOptions holds the default options for APIs that don't accept options.
+var DefaultOptions = &Options{
 	Indent:     4,
 	LineWidth:  -1,
 	Unicode:    true,

--- a/yaml.go
+++ b/yaml.go
@@ -13,7 +13,7 @@
 // - Options API (WithIndent, WithKnownFields, etc.)
 // - Type and constant re-exports from internal/libyaml
 // - Helper functions for struct field handling
-// - Deprecated APIs (Decoder, Encoder, Unmarshal, Marshal)
+// - Classic APIs (Decoder, Encoder, Unmarshal, Marshal)
 //
 // For the main API, see:
 // - loader.go: Load, Loader
@@ -486,12 +486,10 @@ func handleErr(err *error) {
 }
 
 //-----------------------------------------------------------------------------
-// Deprecated APIs
+// Classic APIs
 //-----------------------------------------------------------------------------
 
 // A Decoder reads and decodes YAML values from an input stream.
-//
-// Deprecated: Use Loader instead. Will be removed in v5.
 type Decoder struct {
 	composer    *libyaml.Composer
 	knownFields bool
@@ -501,8 +499,6 @@ type Decoder struct {
 //
 // The decoder introduces its own buffering and may read
 // data from r beyond the YAML values requested.
-//
-// Deprecated: Use NewLoader instead. Will be removed in v5.
 func NewDecoder(r io.Reader) *Decoder {
 	return &Decoder{
 		composer: libyaml.NewComposerFromReader(r),
@@ -511,9 +507,6 @@ func NewDecoder(r io.Reader) *Decoder {
 
 // KnownFields ensures that the keys in decoded mappings to
 // exist as fields in the struct being decoded into.
-//
-// Deprecated: Use NewLoader with WithKnownFields option instead.
-// Will be removed in v5.
 func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
 }
@@ -523,10 +516,8 @@ func (dec *Decoder) KnownFields(enable bool) {
 //
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
-//
-// Deprecated: Use Loader.Load instead. Will be removed in v5.
 func (dec *Decoder) Decode(v any) (err error) {
-	d := libyaml.NewConstructor(libyaml.LegacyOptions)
+	d := libyaml.NewConstructor(libyaml.DefaultOptions)
 	d.KnownFields = dec.knownFields
 	defer handleErr(&err)
 	node := dec.composer.Parse()
@@ -545,8 +536,6 @@ func (dec *Decoder) Decode(v any) (err error) {
 }
 
 // An Encoder writes YAML values to an output stream.
-//
-// Deprecated: Use Dumper instead. Will be removed in v5.
 type Encoder struct {
 	encoder *libyaml.Representer
 }
@@ -554,11 +543,9 @@ type Encoder struct {
 // NewEncoder returns a new encoder that writes to w.
 // The Encoder should be closed after use to flush all data
 // to w.
-//
-// Deprecated: Use NewDumper instead. Will be removed in v5.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
-		encoder: libyaml.NewRepresenter(w, libyaml.LegacyOptions),
+		encoder: libyaml.NewRepresenter(w, libyaml.DefaultOptions),
 	}
 }
 
@@ -569,8 +556,6 @@ func NewEncoder(w io.Writer) *Encoder {
 //
 // See the documentation for Marshal for details about the conversion of Go
 // values to YAML.
-//
-// Deprecated: Use Dumper.Dump instead. Will be removed in v5.
 func (e *Encoder) Encode(v any) (err error) {
 	defer handleErr(&err)
 	e.encoder.MarshalDoc("", reflect.ValueOf(v))
@@ -578,8 +563,6 @@ func (e *Encoder) Encode(v any) (err error) {
 }
 
 // SetIndent changes the used indentation used when encoding.
-//
-// Deprecated: Use NewDumper with WithIndent option instead. Will be removed in v5.
 func (e *Encoder) SetIndent(spaces int) {
 	if spaces < 0 {
 		panic("yaml: cannot indent to a negative number of spaces")
@@ -588,23 +571,17 @@ func (e *Encoder) SetIndent(spaces int) {
 }
 
 // CompactSeqIndent makes it so that '- ' is considered part of the indentation.
-//
-// Deprecated: Use NewDumper with WithCompactSeqIndent option instead. Will be removed in v5.
 func (e *Encoder) CompactSeqIndent() {
 	e.encoder.Emitter.CompactSequenceIndent = true
 }
 
 // DefaultSeqIndent makes it so that '- ' is not considered part of the indentation.
-//
-// Deprecated: This is the default behavior for Dumper. Will be removed in v5.
 func (e *Encoder) DefaultSeqIndent() {
 	e.encoder.Emitter.CompactSequenceIndent = false
 }
 
 // Close closes the encoder by writing any remaining data.
 // It does not write a stream terminating string "...".
-//
-// Deprecated: Use Dumper.Close instead. Will be removed in v5.
 func (e *Encoder) Close() (err error) {
 	defer handleErr(&err)
 	e.encoder.Finish()
@@ -644,8 +621,6 @@ func (e *Encoder) Close() (err error) {
 //
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
-//
-// Deprecated: Use Load instead. Will be removed in v5.
 func Unmarshal(in []byte, out any) (err error) {
 	return unmarshal(in, out, V3)
 }
@@ -714,11 +689,9 @@ func unmarshal(in []byte, out any, opts ...Option) (err error) {
 //	}
 //	yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
 //	yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
-//
-// Deprecated: Use Dump instead. Will be removed in v5.
 func Marshal(in any) (out []byte, err error) {
 	defer handleErr(&err)
-	e := libyaml.NewRepresenter(noWriter, libyaml.LegacyOptions)
+	e := libyaml.NewRepresenter(noWriter, libyaml.DefaultOptions)
 	defer e.Destroy()
 	e.MarshalDoc("", reflect.ValueOf(in))
 	e.Finish()


### PR DESCRIPTION
This change removes all deprecation warnings from the classic API (Decoder, Encoder, Unmarshal, Marshal) and renames the internal LegacyOptions to DefaultOptions to better reflect its purpose.

I think it's too early to start deprecating things until we know how the community wants to use the APIs. 
I realize the new APIs fully cover the old ones, but it might be an easier transition to leave those as supported for now. 

Changes:
- Removed "Deprecated:" markers from Decoder, Encoder, and related methods in yaml.go
- Removed "Deprecated:" markers from Node.Decode and Node.Encode in internal/libyaml/node.go
- Renamed section header from "Deprecated APIs" to "Classic APIs" in yaml.go
- Renamed LegacyOptions to DefaultOptions in internal/libyaml/options.go
- Updated all references to use DefaultOptions consistently
- Updated documentation in docs/dump-load-api.md and docs/v3-to-v4-migration.md to remove deprecation language

The classic API is no longer marked as deprecated and will remain supported as a stable, simple interface alongside the newer Loader and Dumper APIs. The DefaultOptions variable now clearly indicates it provides default settings for APIs that don't accept explicit options.

All existing tests pass with no regressions.