### PR TITLE
Refactor TypeError to LoadErrors and restore v3 TypeError for compatibility

### DIFF
--- a/dumper.go
+++ b/dumper.go
@@ -52,7 +52,7 @@ func Dump(in any, opts ...Option) (out []byte, err error) {
 		// Multi-document mode: in must be a slice
 		inVal := reflect.ValueOf(in)
 		if inVal.Kind() != reflect.Slice {
-			return nil, &TypeError{Errors: []*libyaml.ConstructError{{
+			return nil, &LoadErrors{Errors: []*libyaml.ConstructError{{
 				Err: errors.New("yaml: WithAllDocuments requires a slice input"),
 			}}}
 		}

--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -340,7 +340,7 @@ func NewConstructor(opts *Options) *Constructor {
 
 // Construct decodes YAML input into the provided output value.
 // The out parameter must be a pointer to the value to decode into.
-// Returns a TypeError if type mismatches occur during decoding.
+// Returns a [LoadErrors] if type mismatches occur during decoding.
 func Construct(in []byte, out any, opts *Options) error {
 	d := NewConstructor(opts)
 	p := NewComposer(in)
@@ -354,7 +354,7 @@ func Construct(in []byte, out any, opts *Options) error {
 		d.Construct(node, v)
 	}
 	if len(d.TypeErrors) > 0 {
-		return &TypeError{Errors: d.TypeErrors}
+		return &LoadErrors{Errors: d.TypeErrors}
 	}
 	return nil
 }
@@ -383,7 +383,7 @@ func (c *Constructor) callConstructor(n *Node, u constructor) (good bool) {
 	switch e := err.(type) {
 	case nil:
 		return true
-	case *TypeError:
+	case *LoadErrors:
 		c.TypeErrors = append(c.TypeErrors, e.Errors...)
 		return false
 	default:
@@ -404,14 +404,14 @@ func (c *Constructor) callObsoleteConstructor(n *Node, u obsoleteConstructor) (g
 		if len(c.TypeErrors) > terrlen {
 			issues := c.TypeErrors[terrlen:]
 			c.TypeErrors = c.TypeErrors[:terrlen]
-			return &TypeError{issues}
+			return &LoadErrors{issues}
 		}
 		return nil
 	})
 	switch e := err.(type) {
 	case nil:
 		return true
-	case *TypeError:
+	case *LoadErrors:
 		c.TypeErrors = append(c.TypeErrors, e.Errors...)
 		return false
 	default:
@@ -590,7 +590,7 @@ func (c *Constructor) tryCallYAMLConstructor(n *Node, out reflect.Value) (called
 	}
 
 	switch e := err.(type) {
-	case *TypeError:
+	case *LoadErrors:
 		c.TypeErrors = append(c.TypeErrors, e.Errors...)
 		return true, false
 	default:

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -282,7 +282,7 @@ func (n *Node) Decode(v any) (err error) {
 	}
 	d.Construct(n, out)
 	if len(d.TypeErrors) > 0 {
-		return &TypeError{Errors: d.TypeErrors}
+		return &LoadErrors{Errors: d.TypeErrors}
 	}
 	return nil
 }
@@ -313,7 +313,7 @@ func (n *Node) Load(v any, opts ...Option) (err error) {
 	}
 	d.Construct(n, out)
 	if len(d.TypeErrors) > 0 {
-		return &TypeError{Errors: d.TypeErrors}
+		return &LoadErrors{Errors: d.TypeErrors}
 	}
 	return nil
 }

--- a/loader.go
+++ b/loader.go
@@ -41,7 +41,7 @@ import (
 // The type of the decoded values should be compatible with the respective
 // values in out. If one or more values cannot be decoded due to type
 // mismatches, decoding continues partially until the end of the YAML
-// content, and a *yaml.TypeError is returned with details for all
+// content, and a *yaml.LoadErrors is returned with details for all
 // missed values.
 //
 // Struct fields are only loaded if they are exported (have an upper case
@@ -80,14 +80,14 @@ func Load(in []byte, out any, opts ...Option) error {
 func loadAll(in []byte, out any, opts *libyaml.Options) error {
 	outVal := reflect.ValueOf(out)
 	if outVal.Kind() != reflect.Pointer || outVal.IsNil() {
-		return &TypeError{Errors: []*libyaml.ConstructError{{
+		return &LoadErrors{Errors: []*libyaml.ConstructError{{
 			Err: errors.New("yaml: WithAllDocuments requires a non-nil pointer to a slice"),
 		}}}
 	}
 
 	sliceVal := outVal.Elem()
 	if sliceVal.Kind() != reflect.Slice {
-		return &TypeError{Errors: []*libyaml.ConstructError{{
+		return &LoadErrors{Errors: []*libyaml.ConstructError{{
 			Err: errors.New("yaml: WithAllDocuments requires a pointer to a slice"),
 		}}}
 	}
@@ -134,7 +134,7 @@ func loadSingle(in []byte, out any, opts *libyaml.Options) error {
 	// Load first document
 	err = l.Load(out)
 	if err == io.EOF {
-		return &TypeError{Errors: []*libyaml.ConstructError{{
+		return &LoadErrors{Errors: []*libyaml.ConstructError{{
 			Err: errors.New("yaml: no documents in stream"),
 		}}}
 	}
@@ -151,7 +151,7 @@ func loadSingle(in []byte, out any, opts *libyaml.Options) error {
 			return err
 		}
 		// Successfully loaded a second document - this is an error in strict mode
-		return &TypeError{Errors: []*libyaml.ConstructError{{
+		return &LoadErrors{Errors: []*libyaml.ConstructError{{
 			Err: errors.New("yaml: expected single document, found multiple"),
 		}}}
 	}
@@ -225,7 +225,7 @@ func (l *Loader) Load(v any) (err error) {
 	if len(l.decoder.TypeErrors) > 0 {
 		typeErrors := l.decoder.TypeErrors
 		l.decoder.TypeErrors = nil
-		return &TypeError{Errors: typeErrors}
+		return &LoadErrors{Errors: typeErrors}
 	}
 	return nil
 }

--- a/yaml.go
+++ b/yaml.go
@@ -274,7 +274,23 @@ const (
 
 // Re-export error types
 type (
+
+	// LoadError represents an error encountered while decoding a YAML document.
+	//
+	// It contains details about the location in the document where the error
+	// occurred, as well as a descriptive message.
 	LoadError = libyaml.ConstructError
+
+	// LoadErrors is returned when one or more fields cannot be properly decoded.
+	//
+	// It contains multiple *[LoadError] instances with details about each error.
+	LoadErrors = libyaml.LoadErrors
+
+	// TypeError is an obsolete error type retained for compatibility.
+	//
+	// Deprecated: Use [LoadErrors] instead.
+	//
+	//nolint:staticcheck // we are using deprecated TypeError for compatibility
 	TypeError = libyaml.TypeError
 )
 
@@ -530,7 +546,7 @@ func (dec *Decoder) Decode(v any) (err error) {
 	}
 	d.Construct(node, out)
 	if len(d.TypeErrors) > 0 {
-		return &TypeError{Errors: d.TypeErrors}
+		return &LoadErrors{Errors: d.TypeErrors}
 	}
 	return nil
 }
@@ -599,7 +615,7 @@ func (e *Encoder) Close() (err error) {
 // The type of the decoded values should be compatible with the respective
 // values in out. If one or more values cannot be decoded due to a type
 // mismatches, decoding continues partially until the end of the YAML
-// content, and a *yaml.TypeError is returned with details for all
+// content, and a *yaml.LoadErrors is returned with details for all
 // missed values.
 //
 // Struct fields are only unmarshalled if they are exported (have an


### PR DESCRIPTION
This PR refactors the error handling for constructor conflicts, improving code clarity and maintaining compatibility with yaml/v3.

Summary of Changes

   This PR contains 4 commits that clean up and improve the TypeError implementation:

   - Remove TypeError.Unwrap method - Eliminates the Unwrap() method that was added in commit 08d6997 (PR #240). This method couldn't work for old Go 
   versions (<1.20) because Unwrap() []error is not supported there. Since TypeError.Is() and TypeError.As() methods were added in commit 6fae831 (PR #240) to provide compatibility for both old and new Go versions, the Unwrap() method became redundant.

   - Removes the Strings() method that was intended as a migration helper with #236 from []string to []error, which is no longer needed.

   - Rename TypeError to LoadErrors - Renames TypeError to LoadErrors to better reflect its actual purpose (multiple constructor 
   matches) rather than implying a type-related issue. This also prepares for better compatibility with yaml/v3.
   - Restore yaml/v3 TypeError - Restores the TypeError functionality with the signature from yaml/v3.
  https://github.com/yaml/go-yaml/pull/19 changed the signature of the TypeError causing breaking changes. We are now restoring the TypeError signature. LoadErrors struct should be used now, this explains why TypeError is now marked as deprecated.

