### PR TITLE
Fix godoc for re-exported blocks of comments

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -264,6 +264,7 @@ type Unmarshaler interface {
 }
 
 // Re-export stream-related types
+
 type (
 	VersionDirective = libyaml.StreamVersionDirective
 	TagDirective     = libyaml.StreamTagDirective
@@ -271,6 +272,7 @@ type (
 )
 
 // Re-export encoding constants
+
 const (
 	EncodingAny     = libyaml.ANY_ENCODING
 	EncodingUTF8    = libyaml.UTF8_ENCODING
@@ -279,6 +281,7 @@ const (
 )
 
 // Re-export error types
+
 type (
 
 	// LoadError represents an error encountered while decoding a YAML document.
@@ -301,6 +304,7 @@ type (
 )
 
 // Re-export Kind constants
+
 const (
 	DocumentNode = libyaml.DocumentNode
 	SequenceNode = libyaml.SequenceNode
@@ -311,6 +315,7 @@ const (
 )
 
 // Re-export Style constants
+
 const (
 	TaggedStyle       = libyaml.TaggedStyle
 	DoubleQuotedStyle = libyaml.DoubleQuotedStyle
@@ -324,6 +329,7 @@ const (
 type LineBreak = libyaml.LineBreak
 
 // Line break constants for different platforms.
+
 const (
 	LineBreakLN   = libyaml.LN_BREAK   // Unix-style \n (default)
 	LineBreakCR   = libyaml.CR_BREAK   // Old Mac-style \r


### PR DESCRIPTION
When re-exporting a block of comments, we added a comment just before the block to indicate that the block is re-exported.

But the godoc will be rendered as being the comment for the next declaration, so the godoc of the first declaration.

This leads to confusion when reading the documentation of the package. The "re-exported comment" shouldn't be visible in the publicly.