### PR TITLE
Fix incorrect event formatting

### DIFF
--- a/testdata/parser_events.yaml
+++ b/testdata/parser_events.yaml
@@ -61,3 +61,45 @@
       -MAP
       -DOC
       -STR
+
+- parser-events:
+    name: FlowAnchorTagOrdering
+    yaml: |
+      a: &aaa !aaa []
+      b: &aab !aaa {}
+      c: !aaa &aac "test"
+
+    want: |
+      +STR
+      +DOC
+      +MAP
+      =VAL :a
+      +SEQ [] &aaa <!aaa>
+      -SEQ
+      =VAL :b
+      +MAP {} &aab <!aaa>
+      -MAP
+      =VAL :c
+      =VAL &aac <!aaa> "test
+      -MAP
+      -DOC
+      -STR
+
+- parser-events:
+    name: ScalarEscaping
+    yaml: |
+      ["\\", "\0", "\b", "\n", "\r", "\t"]
+
+    want: |
+      +STR
+      +DOC
+      +SEQ []
+      =VAL "\\
+      =VAL "\0
+      =VAL "\b
+      =VAL "\n
+      =VAL "\r
+      =VAL "\t
+      -SEQ
+      -DOC
+      -STR

--- a/yts/known-failing-tests
+++ b/yts/known-failing-tests
@@ -35,7 +35,6 @@ TestYAMLSuite/5TYM/JSONComparisonTest
 TestYAMLSuite/652Z/JSONComparisonTest
 TestYAMLSuite/6BCT/EventComparisonTest
 TestYAMLSuite/6BCT/LoadTest
-TestYAMLSuite/6BFJ/EventComparisonTest
 TestYAMLSuite/6BFJ/LoadTest
 TestYAMLSuite/6CA3/EventComparisonTest
 TestYAMLSuite/6CA3/LoadTest
@@ -82,11 +81,9 @@ TestYAMLSuite/AZ63/JSONComparisonTest
 TestYAMLSuite/BEC7/EventComparisonTest
 TestYAMLSuite/BEC7/LoadTest
 TestYAMLSuite/BS4K/LoadTest
-TestYAMLSuite/C4HZ/EventComparisonTest
 TestYAMLSuite/C4HZ/JSONComparisonTest
 TestYAMLSuite/CFD4/EventComparisonTest
 TestYAMLSuite/CFD4/LoadTest
-TestYAMLSuite/CN3R/EventComparisonTest
 TestYAMLSuite/CVW2/EventComparisonTest
 TestYAMLSuite/CVW2/LoadTest
 TestYAMLSuite/DBG4/JSONComparisonTest
@@ -109,14 +106,12 @@ TestYAMLSuite/DK95-06/JSONComparisonTest
 TestYAMLSuite/DK95-07/EventComparisonTest
 TestYAMLSuite/DK95-07/LoadTest
 TestYAMLSuite/EB22/LoadTest
-TestYAMLSuite/EHF6/EventComparisonTest
 TestYAMLSuite/F2C7/JSONComparisonTest
 TestYAMLSuite/FP8R/EventComparisonTest
 TestYAMLSuite/FP8R/JSONComparisonTest
 TestYAMLSuite/FP8R/MarshalTest
 TestYAMLSuite/FRK4/EventComparisonTest
 TestYAMLSuite/FRK4/LoadTest
-TestYAMLSuite/G4RS/EventComparisonTest
 TestYAMLSuite/G5U8/EventComparisonTest
 TestYAMLSuite/G5U8/LoadTest
 TestYAMLSuite/H2RW/JSONComparisonTest
@@ -208,7 +203,6 @@ TestYAMLSuite/W5VH/EventComparisonTest
 TestYAMLSuite/W5VH/LoadTest
 TestYAMLSuite/WZ62/EventComparisonTest
 TestYAMLSuite/WZ62/LoadTest
-TestYAMLSuite/X38W/EventComparisonTest
 TestYAMLSuite/X38W/LoadTest
 TestYAMLSuite/X4QW/EventComparisonTest
 TestYAMLSuite/X4QW/LoadTest


### PR DESCRIPTION
Some YTS EventComparisonTest tests were failing because the event formatting did not match.

Fixes:
- TestYAMLSuite/6BFJ/EventComparisonTest
- TestYAMLSuite/C4HZ/EventComparisonTest
- TestYAMLSuite/CN3R/EventComparisonTest
- TestYAMLSuite/EHF6/EventComparisonTest
- TestYAMLSuite/G4RS/EventComparisonTest
- TestYAMLSuite/X38W/EventComparisonTest