### PR TITLE
Fix Unmarshaler DocumentNode regression

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -585,6 +585,10 @@ func Unmarshal(in []byte, out any) (err error) {
 				Err: errors.New("yaml: no documents in stream"),
 			}}}
 		}
+		// Unwrap DocumentNode to get the actual content
+		if node.Kind == libyaml.DocumentNode && len(node.Content) == 1 {
+			node = node.Content[0]
+		}
 		return u.UnmarshalYAML(node)
 	}
 	// Normal path


### PR DESCRIPTION
Custom Unmarshalers were receiving DocumentNode instead of the actual content node (SequenceNode, ScalarNode, MappingNode) when Unmarshaling whole documents. This fixes the regression by unwrapping DocumentNode to pass the actual content to custom Unmarshalers.

Adds TestUnmarshalerNodeKind regression test to verify correct node kinds are passed to custom Unmarshalers.

Fixes #274