### PR TITLE
Convert version presets to functions

### DIFF
--- a/cmd/go-yaml/main.go
+++ b/cmd/go-yaml/main.go
@@ -59,13 +59,13 @@ func initOptionRegistry() {
 	optionRegistry = map[string]optionSpec{
 		// Version presets
 		"v2": {typ: "preset", handler: func(string) ([]yaml.Option, error) {
-			return []yaml.Option{yaml.V2}, nil
+			return []yaml.Option{yaml.WithV2Defaults()}, nil
 		}},
 		"v3": {typ: "preset", handler: func(string) ([]yaml.Option, error) {
-			return []yaml.Option{yaml.V3}, nil
+			return []yaml.Option{yaml.WithV3Defaults()}, nil
 		}},
 		"v4": {typ: "preset", handler: func(string) ([]yaml.Option, error) {
-			return []yaml.Option{yaml.V4}, nil
+			return []yaml.Option{yaml.WithV4Defaults()}, nil
 		}},
 
 		// Formatting options
@@ -295,7 +295,7 @@ func buildOptions(configFile string, optionFlags []string) ([]yaml.Option, error
 	var opts []yaml.Option
 
 	// Default to V4 preset
-	opts = append(opts, yaml.V4)
+	opts = append(opts, yaml.WithV4Defaults())
 
 	// Load config file if specified
 	if configFile != "" {

--- a/doc.go
+++ b/doc.go
@@ -81,14 +81,14 @@
 //
 // Or use version-specific option presets for consistent formatting:
 //
-//	yaml.NewDumper(w, yaml.V3)
+//	yaml.NewDumper(w, yaml.WithV3Defaults())
 //
 // Options can be combined and later options override earlier ones:
 //
 //	// Start with v3 defaults, then override indent
 //	yaml.NewDumper(w,
-//	    yaml.V3,
-//	    yaml.WithIndent(4),
+//	    yaml.WithV3Defaults(),
+//	    yaml.WithIndent(2),
 //	)
 //
 // Load options from YAML configuration files:

--- a/docs/dev/dump-load-api.md
+++ b/docs/dev/dump-load-api.md
@@ -53,9 +53,9 @@ With `Dump` and `Load`, you can choose your starting point:
 
 - **v4 semantics**: `yaml.Dump(&data)` (default: 2-space indent, compact
   sequences)
-- **v3 semantics**: `yaml.Dump(&data, yaml.V3)` (matches Marshal: 4-space
-  indent, non-compact)
-- **v2 semantics**: `yaml.Dump(&data, yaml.V2)` (2-space indent, non-compact)
+- **v3 semantics**: `yaml.Dump(&data, yaml.WithV3Defaults())` (same
+  indentation and sequence style as Marshal: 4-space indent, non-compact)
+- **v2 semantics**: `yaml.Dump(&data, yaml.WithV2Defaults())` (2-space indent, non-compact)
 - **Custom options**: `yaml.Dump(&data, yaml.WithIndent(4),
   yaml.WithExplicitStart())`
 
@@ -275,7 +275,7 @@ data, err := yaml.Marshal(&config)
 
 ```go
 config := Config{Name: "myapp", Port: 8080, Enabled: true}
-data, err := yaml.Dump(&config, yaml.V3)
+data, err := yaml.Dump(&config, yaml.WithV3Defaults())
 // Same output as Marshal (4-space indent, non-compact)
 ```
 
@@ -297,7 +297,7 @@ fmt.Println(config.Name)  // "myapp"
 
 ```go
 var config Config
-err := yaml.Load(yamlData, &config, yaml.V3)
+err := yaml.Load(yamlData, &config, yaml.WithV3Defaults())
 fmt.Println(config.Name)  // "myapp"
 ```
 
@@ -340,7 +340,7 @@ name: third
 file, _ := os.Create("output.yaml")
 defer file.Close()
 
-dumper, _ := yaml.NewDumper(file, yaml.V3)
+dumper, _ := yaml.NewDumper(file, yaml.WithV3Defaults())
 dumper.Dump(&doc1)
 dumper.Dump(&doc2)
 dumper.Dump(&doc3)
@@ -377,7 +377,7 @@ for {
 file, _ := os.Open("config.yaml")
 defer file.Close()
 
-loader, _ := yaml.NewLoader(file, yaml.V3)
+loader, _ := yaml.NewLoader(file, yaml.WithV3Defaults())
 
 for {
     var doc map[string]any
@@ -423,13 +423,13 @@ Use preset options that match different go-yaml versions:
 
 ```go
 // v2: 2-space indent, non-compact sequences
-yaml.Dump(&config, yaml.V2)
+yaml.Dump(&config, yaml.WithV2Defaults())
 
 // v3: 4-space indent, non-compact sequences
-yaml.Dump(&config, yaml.V3)
+yaml.Dump(&config, yaml.WithV3Defaults())
 
 // v4: 2-space indent, compact sequences (default)
-yaml.Dump(&config, yaml.V4)  // or just yaml.Dump(&config)
+yaml.Dump(&config, yaml.WithV4Defaults())  // or just yaml.Dump(&config)
 ```
 
 ### Combining Options
@@ -439,7 +439,7 @@ Mix presets with individual overrides:
 ```go
 // Start with v3, then override indent to 2
 yaml.NewDumper(w,
-    yaml.V3,
+    yaml.WithV3Defaults(),
     yaml.WithIndent(2),  // This wins
 )
 ```

--- a/docs/options.md
+++ b/docs/options.md
@@ -462,7 +462,7 @@ the historical non-compact behavior for backward compatibility.
 ### Using v2 Options
 
 ```go
-dumper, _ := yaml.NewDumper(writer, yaml.V2)
+dumper, _ := yaml.NewDumper(writer, yaml.WithV2Defaults())
 ```
 
 **When to use:** Matching go-yaml v2 output format (2-space indent).
@@ -470,7 +470,7 @@ dumper, _ := yaml.NewDumper(writer, yaml.V2)
 ### Using v3 Options
 
 ```go
-dumper, _ := yaml.NewDumper(writer, yaml.V3)
+dumper, _ := yaml.NewDumper(writer, yaml.WithV3Defaults())
 ```
 
 **When to use:** Explicitly requesting v3 behavior (4-space indent, non-compact
@@ -481,11 +481,11 @@ code that expects v3 formatting.
 ### Using v4 Options (Default)
 
 ```go
-dumper, _ := yaml.NewDumper(writer, yaml.V4)
+dumper, _ := yaml.NewDumper(writer, yaml.WithV4Defaults())
 ```
 
 **When to use:** Modern YAML output with 2-space indent and compact sequences.
-This is the default, so you usually don't need to specify `yaml.V4` unless you
+This is the default, so you usually don't need to specify `yaml.WithV4Defaults()` unless you
 want to be explicit.
 
 ## Mixing Presets with Individual Options
@@ -496,7 +496,7 @@ You can start with a preset and override specific options.
 ```go
 // Start with v3 defaults (4-space), then override to 2-space
 dumper, _ := yaml.NewDumper(writer,
-    yaml.V3,
+    yaml.WithV3Defaults(),
     yaml.WithIndent(2),  // This wins
 )
 ```
@@ -512,7 +512,7 @@ dumper, _ := yaml.NewDumper(writer,
 // Start with 2-space, then apply v3 (4-space wins)
 dumper, _ := yaml.NewDumper(writer,
     yaml.WithIndent(2),
-    yaml.V3,  // This overrides to 4
+    yaml.WithV3Defaults(),  // This overrides to 4
 )
 ```
 
@@ -571,7 +571,7 @@ func LoadConfig(filename string) (*AppConfig, error) {
     defer f.Close()
 
     loader, err := yaml.NewLoader(f,
-        yaml.V4,
+        yaml.WithV4Defaults(),
         yaml.WithKnownFields(),          // Catch typos (defaults to true)
         yaml.WithSingleDocument(),       // Expect exactly one doc
     )
@@ -597,7 +597,7 @@ func GenerateCI(config *CIConfig) ([]byte, error) {
     var buf bytes.Buffer
 
     dumper, err := yaml.NewDumper(&buf,
-        yaml.V2,
+        yaml.WithV2Defaults(),
     )
     if err != nil {
         return nil, err
@@ -687,7 +687,7 @@ dumper, _ := yaml.NewDumper(output)  // Uses v4 defaults (2-space, compact)
 ### Pattern: Match Legacy Format
 
 ```go
-dumper, _ := yaml.NewDumper(output, yaml.V3)  // 4-space like old go-yaml
+dumper, _ := yaml.NewDumper(output, yaml.WithV3Defaults())  // 4-space like old go-yaml
 ```
 
 ## Tips & Tricks
@@ -697,8 +697,8 @@ compact sequences).
 
 **Order matters:** Options are applied left-to-right, with later options
 overriding earlier ones.
-For example, `yaml.WithIndent(2), yaml.V3` gives you 4 spaces (V3 wins),
-while `yaml.V3, yaml.WithIndent(2)` gives you 2 spaces.
+For example, `yaml.WithIndent(2), yaml.WithV3Defaults()` gives you 4 spaces (V3 wins),
+while `yaml.WithV3Defaults(), yaml.WithIndent(2)` gives you 2 spaces.
 
 **Load from files:** Use `yaml.OptsYAML()` to make formatting configurable by
 users.

--- a/docs/v3-to-v4-migration.md
+++ b/docs/v3-to-v4-migration.md
@@ -7,7 +7,7 @@ This guide will help you migrate your code from `go.yaml.in/yaml/v3`
 
 - [ ] Update import path
 - [ ] Optionally migrate to new API (Load/Dump, Loader/Dumper)
-- [ ] Adjust formatting expectations or use yaml.V3 preset
+- [ ] Adjust formatting expectations or use yaml.WithV3Defaults() preset
 - [ ] Update tests
 
 ## Import Path Change
@@ -94,9 +94,9 @@ v4 introduces a functional options pattern for configuration:
 
 ```go
 // Version presets
-yaml.Dump(&data, yaml.V2)  // Use v2 defaults
-yaml.Dump(&data, yaml.V3)  // Use v3 defaults
-yaml.Dump(&data, yaml.V4)  // Use v4 defaults (2-space, compact)
+yaml.Dump(&data, yaml.WithV2Defaults())  // Use v2 defaults
+yaml.Dump(&data, yaml.WithV3Defaults())  // Use v3 defaults
+yaml.Dump(&data, yaml.WithV4Defaults())  // Use v4 defaults (2-space, compact)
 
 // Custom options
 yaml.Dump(&data,
@@ -106,7 +106,7 @@ yaml.Dump(&data,
 )
 
 // Combine presets with overrides
-yaml.Dump(&data, yaml.V3, yaml.WithIndent(2))
+yaml.Dump(&data, yaml.WithV3Defaults(), yaml.WithIndent(2))
 
 // Loading options
 yaml.Load(data, &config,
@@ -180,11 +180,11 @@ items:
 
 ### Preserving v3 Behavior
 
-If you need v3's formatting, use the `yaml.V3` preset:
+If you need v3's formatting, use the `yaml.WithV3Defaults()` preset:
 
 ```go
 // Get v3-style formatting in v4
-data, err := yaml.Dump(&config, yaml.V3)
+data, err := yaml.Dump(&config, yaml.WithV3Defaults())
 ```
 
 Or customize individual options:
@@ -218,12 +218,12 @@ You can migrate incrementally:
 
 1. Update import path
 2. If using TypeError.Errors directly, update that code
-3. Add `yaml.V3` preset to maintain v3 formatting
+3. Add `yaml.WithV3Defaults()` preset to maintain v3 formatting
 4. Done!
 
 ```go
 // Only change needed for basic migration
-data, err := yaml.Dump(&config, yaml.V3)
+data, err := yaml.Dump(&config, yaml.WithV3Defaults())
 ```
 
 ### Strategy 2: Adopt New API (Recommended)
@@ -256,9 +256,9 @@ go install go.yaml.in/yaml/v4/cmd/go-yaml@latest
 
 ### Issue: Output formatting changed
 
-**Solution:** Use `yaml.V3` preset to maintain v3 formatting:
+**Solution:** Use `yaml.WithV3Defaults()` preset to maintain v3 formatting:
 ```go
-yaml.Dump(&data, yaml.V3)
+yaml.Dump(&data, yaml.WithV3Defaults())
 ```
 
 ### Issue: Want more flexibility from classic API

--- a/example/README.md
+++ b/example/README.md
@@ -59,7 +59,7 @@ go run basic_loader.go
 ## Options System Examples
 
 **`with_v4_option.go`** - Using v4 option presets
-- Demonstrates yaml.V4
+- Demonstrates yaml.WithV4Defaults()
 - Shows v4 defaults (2-space indent)
 - Compares with default (v3) output
 
@@ -140,7 +140,7 @@ dumper.Close()
 
 ```go
 dumper, _ := yaml.NewDumper(writer,
-    yaml.V4,
+    yaml.WithV4Defaults(),
 )
 ```
 

--- a/example/node_dump_with_options/main.go
+++ b/example/node_dump_with_options/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	// Example 3: With v3 preset
 	var node3 yaml.Node
-	if err := node3.Dump(&config, yaml.V3); err != nil {
+	if err := node3.Dump(&config, yaml.WithV3Defaults()); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("3. With V3 preset:")

--- a/example/version_options/main.go
+++ b/example/version_options/main.go
@@ -25,23 +25,23 @@ func main() {
 	fmt.Println("Example: Comparing v2, v3, and v4 option presets")
 
 	// v2 options - 2-space indent, non-compact sequences
-	fmt.Println("=== yaml.V2 - 2-space indent, non-compact sequences ===")
-	out, _ := yaml.Dump(&cfg, yaml.V2)
+	fmt.Println("=== yaml.WithV2Defaults() - 2-space indent, non-compact sequences ===")
+	out, _ := yaml.Dump(&cfg, yaml.WithV2Defaults())
 	fmt.Print(string(out))
 
 	// v3 options - 4-space indent (default), non-compact sequences
-	fmt.Println("=== yaml.V3 - 4-space indent, non-compact sequences ===")
-	out, _ = yaml.Dump(&cfg, yaml.V3)
+	fmt.Println("=== yaml.WithV3Defaults() - 4-space indent, non-compact sequences ===")
+	out, _ = yaml.Dump(&cfg, yaml.WithV3Defaults())
 	fmt.Print(string(out))
 
 	// v4 options - 2-space indent, compact sequences
-	fmt.Println("=== yaml.V4 - 2-space indent, compact sequences ===")
-	out, _ = yaml.Dump(&cfg, yaml.V4)
+	fmt.Println("=== yaml.WithV4Defaults() - 2-space indent, compact sequences ===")
+	out, _ = yaml.Dump(&cfg, yaml.WithV4Defaults())
 	fmt.Print(string(out))
 
 	// Override v4 options
-	fmt.Println("=== yaml.V4 with WithIndent(3) override ===")
-	out, _ = yaml.Dump(&cfg, yaml.V4, yaml.WithIndent(3))
+	fmt.Println("=== yaml.WithV4Defaults() with WithIndent(3) override ===")
+	out, _ = yaml.Dump(&cfg, yaml.WithV4Defaults(), yaml.WithIndent(3))
 	fmt.Print(string(out))
 
 	fmt.Println("\nNotice how:")

--- a/example/with_v4_option/main.go
+++ b/example/with_v4_option/main.go
@@ -85,7 +85,7 @@ metadata:
 	// Compare with v3 defaults for backward compatibility
 	fmt.Println("\n--- For comparison: v3 defaults (4-space indent, non-compact) ---")
 	buf.Reset()
-	dumper2, err := yaml.NewDumper(&buf, yaml.V3)
+	dumper2, err := yaml.NewDumper(&buf, yaml.WithV3Defaults())
 	if err != nil {
 		panic(err)
 	}

--- a/example/with_v4_override/main.go
+++ b/example/with_v4_override/main.go
@@ -19,7 +19,7 @@ type Config struct {
 }
 
 func main() {
-	fmt.Println("Example: Overriding yaml.V4 options")
+	fmt.Println("Example: Overriding yaml.WithV4Defaults() options")
 
 	cfg := Config{
 		Name: "myapp",
@@ -31,9 +31,9 @@ func main() {
 	}
 
 	// Test 1: v4 options - should use 2-space indent
-	fmt.Println("1. yaml.V4 - 2-space indent:")
+	fmt.Println("1. yaml.WithV4Defaults() - 2-space indent:")
 	var buf bytes.Buffer
-	dumper, err := yaml.NewDumper(&buf, yaml.V4)
+	dumper, err := yaml.NewDumper(&buf, yaml.WithV4Defaults())
 	if err != nil {
 		panic(err)
 	}
@@ -46,9 +46,9 @@ func main() {
 	fmt.Print(buf.String())
 
 	// Test 2: v4 options then WithIndent(3) - WithIndent(3) overrides
-	fmt.Println("\n2. v4 options, then WithIndent(3) - should use 3-space indent:")
+	fmt.Println("\n2. WithV4Defaults(), then WithIndent(3) - should use 3-space indent:")
 	buf.Reset()
-	dumper2, err := yaml.NewDumper(&buf, yaml.V4, yaml.WithIndent(3))
+	dumper2, err := yaml.NewDumper(&buf, yaml.WithV4Defaults(), yaml.WithIndent(3))
 	if err != nil {
 		panic(err)
 	}
@@ -61,9 +61,9 @@ func main() {
 	fmt.Print(buf.String())
 
 	// Test 3: WithIndent(5) then v4 options - v4 options override to 2
-	fmt.Println("\n3. WithIndent(5), then v4 options - should use 2-space indent (v4 wins):")
+	fmt.Println("\n3. WithIndent(5), then WithV4Defaults() - should use 2-space indent (v4 wins):")
 	buf.Reset()
-	dumper3, err := yaml.NewDumper(&buf, yaml.WithIndent(5), yaml.V4)
+	dumper3, err := yaml.NewDumper(&buf, yaml.WithIndent(5), yaml.WithV4Defaults())
 	if err != nil {
 		panic(err)
 	}

--- a/node_test.go
+++ b/node_test.go
@@ -721,13 +721,13 @@ func TestNodeDumpWithOptions(t *testing.T) {
 
 	// Dump with V4 (default)
 	var node1 yaml.Node
-	err := node1.Dump(value, yaml.V4)
+	err := node1.Dump(value, yaml.WithV4Defaults())
 	assert.NoError(t, err)
 	assert.Equal(t, yaml.MappingNode, node1.Kind)
 
 	// Dump with V3
 	var node2 yaml.Node
-	err = node2.Dump(value, yaml.V3)
+	err = node2.Dump(value, yaml.WithV3Defaults())
 	assert.NoError(t, err)
 	assert.Equal(t, yaml.MappingNode, node2.Kind)
 

--- a/yaml.go
+++ b/yaml.go
@@ -9,7 +9,7 @@
 //	https://github.com/yaml/go-yaml
 //
 // This file contains:
-// - Version presets (V2, V3, V4)
+// - Version preset functions (WithV2Defaults, WithV3Defaults, WithV4Defaults)
 // - Options API (WithIndent, WithKnownFields, etc.)
 // - Type and constant re-exports from internal/libyaml
 // - Helper functions for struct field handling
@@ -31,38 +31,44 @@ import (
 //-----------------------------------------------------------------------------
 
 // Usage:
-//	yaml.Dump(&data, yaml.V3)
-//	yaml.Dump(&data, yaml.V3, yaml.WithIndent(2), yaml.WithCompactSeqIndent())
+//	yaml.Dump(&data, yaml.WithV3Defaults())
+//	yaml.Dump(&data, yaml.WithV3Defaults(), yaml.WithIndent(2), yaml.WithCompactSeqIndent())
 
-// V2 defaults:
-var V2 = Options(
-	WithIndent(2),
-	WithCompactSeqIndent(false),
-	WithLineWidth(80),
-	WithUnicode(true),
-	WithUniqueKeys(true),
-	WithQuotePreference(QuoteLegacy),
-)
+// WithV2Defaults returns V2-compatible default options.
+func WithV2Defaults() Option {
+	return Options(
+		WithIndent(2),
+		WithCompactSeqIndent(false),
+		WithLineWidth(80),
+		WithUnicode(true),
+		WithUniqueKeys(true),
+		WithQuotePreference(QuoteLegacy),
+	)
+}
 
-// V3 defaults:
-var V3 = Options(
-	WithIndent(4),
-	WithCompactSeqIndent(false),
-	WithLineWidth(80),
-	WithUnicode(true),
-	WithUniqueKeys(true),
-	WithQuotePreference(QuoteLegacy),
-)
+// WithV3Defaults returns V3-compatible default options.
+func WithV3Defaults() Option {
+	return Options(
+		WithIndent(4),
+		WithCompactSeqIndent(false),
+		WithLineWidth(80),
+		WithUnicode(true),
+		WithUniqueKeys(true),
+		WithQuotePreference(QuoteLegacy),
+	)
+}
 
-// V4 defaults:
-var V4 = Options(
-	WithIndent(2),
-	WithCompactSeqIndent(true),
-	WithLineWidth(80),
-	WithUnicode(true),
-	WithUniqueKeys(true),
-	WithQuotePreference(QuoteSingle),
-)
+// WithV4Defaults returns the current V4 default options.
+func WithV4Defaults() Option {
+	return Options(
+		WithIndent(2),
+		WithCompactSeqIndent(true),
+		WithLineWidth(80),
+		WithUnicode(true),
+		WithUniqueKeys(true),
+		WithQuotePreference(QuoteSingle),
+	)
+}
 
 //-----------------------------------------------------------------------------
 // Options
@@ -243,7 +249,7 @@ var (
 //
 // Example:
 //
-//	opts := yaml.Options(yaml.V4, yaml.WithIndent(3))
+//	opts := yaml.Options(yaml.WithV4Defaults(), yaml.WithIndent(3))
 //	yaml.Dump(&data, opts)
 func Options(opts ...Option) Option {
 	return libyaml.CombineOptions(opts...)
@@ -467,8 +473,8 @@ type Decoder struct {
 // The decoder introduces its own buffering and may read
 // data from r beyond the YAML values requested.
 func NewDecoder(r io.Reader) *Decoder {
-	// NewLoader won't return error with V3 preset and withFromLegacy
-	loader, _ := NewLoader(r, V3, withFromLegacy())
+	// NewLoader won't return error with WithV3Defaults() and withFromLegacy
+	loader, _ := NewLoader(r, WithV3Defaults(), withFromLegacy())
 	return &Decoder{loader: loader}
 }
 
@@ -496,8 +502,8 @@ type Encoder struct {
 // The Encoder should be closed after use to flush all data
 // to w.
 func NewEncoder(w io.Writer) *Encoder {
-	// NewDumper won't return error with V3 preset
-	dumper, _ := NewDumper(w, V3)
+	// NewDumper won't return an error when using WithV3Defaults()
+	dumper, _ := NewDumper(w, WithV3Defaults())
 	return &Encoder{dumper: dumper}
 }
 
@@ -569,7 +575,7 @@ func (e *Encoder) Close() error {
 func Unmarshal(in []byte, out any) (err error) {
 	// Check for Unmarshaler interface first
 	if u, ok := out.(Unmarshaler); ok {
-		l, err := libyaml.NewLoader(bytes.NewReader(in), V3, withFromLegacy())
+		l, err := libyaml.NewLoader(bytes.NewReader(in), WithV3Defaults(), withFromLegacy())
 		if err != nil {
 			return err
 		}
@@ -583,7 +589,7 @@ func Unmarshal(in []byte, out any) (err error) {
 		return u.UnmarshalYAML(node)
 	}
 	// Normal path
-	return Load(in, out, V3, withFromLegacy())
+	return Load(in, out, WithV3Defaults(), withFromLegacy())
 }
 
 // withFromLegacy is a private option that indicates this call is from
@@ -640,6 +646,6 @@ func withFromLegacy() Option {
 //	yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
 //	yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
 func Marshal(in any) (out []byte, err error) {
-	// Use V3 preset with unlimited line width to match legacy DefaultOptions
-	return Dump(in, V3, WithLineWidth(-1))
+	// Use WithV3Defaults() with unlimited line width to match legacy DefaultOptions
+	return Dump(in, WithV3Defaults(), WithLineWidth(-1))
 }


### PR DESCRIPTION
The version presets V2, V3, and V4 were previously package-level vars evaluated at init time. While this works fine for simple formatting options, it becomes problematic for future enhancements where presets need to include heavier configuration like plugin registrations.

As vars:
- All three are instantiated at init even if unused
- External code can accidentally reassign them
- They cannot create fresh state per call (needed for future plugins)

Converting to functions solves these issues and establishes a solid foundation for presets that include more than just formatting options.

Replaced package-level vars with functions that return fresh Option values on each call:

- `var V2` → `func WithV2Defaults() Option`
- `var V3` → `func WithV3Defaults() Option`
- `var V4` → `func WithV4Defaults() Option`

The option contents are identical - only the delivery mechanism changed. No behavioral changes.

Updated internal callers:
- `Unmarshal()`: V3 → WithV3Defaults()
- `Marshal()`: V3 → WithV3Defaults()
- `NewDecoder()`: V3 → WithV3Defaults()
- `NewEncoder()`: V3 → WithV3Defaults()

Updated option registry to call preset functions:
- Default preset: yaml.V4 → yaml.WithV4Defaults()
- Option handlers for v2/v3/v4 presets updated

Updated all references in:
- `node_test.go`
- `example/version_options/main.go`
- `example/with_v4_option/main.go`
- `example/with_v4_override/main.go`
- `example/node_dump_with_options/main.go`

Updated all preset references in:
- `doc.go`
- `docs/options.md`
- `docs/v3-to-v4-migration.md`
- `docs/dev/dump-load-api.md`
- `example/README.md`

1. **Lazy evaluation**: Presets only instantiated when actually used
2. **Safety**: Cannot accidentally reassign presets
3. **Fresh state**: Each call creates new option state (foundation for future plugin support)
4. **Clearer intent**: Function call makes it explicit that options are being computed

This is a change to the current v4 public API before v4.0.0 is released. Users calling yaml.V3 as a var will see a compile error and need to change to yaml.WithV3Defaults(), but the functionality is identical.