### PR TITLE
Quote comma-separated numbers for YAML 1.1 parser compatibility

### DIFF
--- a/testdata/encode.yaml
+++ b/testdata/encode.yaml
@@ -318,6 +318,30 @@
       a: '1:1'
 
 - encode:
+    name: comma-separated string (YAML 1.1 number compat)
+    data:
+      a: '400,403,404'
+    type: map[string]string
+    want: |
+      a: '400,403,404'
+
+- encode:
+    name: comma with sign prefix (YAML 1.1 number compat)
+    data:
+      a: '+12,345'
+    type: map[string]string
+    want: |
+      a: '+12,345'
+
+- encode:
+    name: comma-separated float (YAML 1.1 number compat)
+    data:
+      a: '1,230.15'
+    type: map[string]string
+    want: |
+      a: '1,230.15'
+
+- encode:
     name: null byte in string
     data:
       a: "\x00"


### PR DESCRIPTION
## Summary

Quote strings matching YAML 1.1 comma-separated number notation (e.g., `+12,345`, `1,230.15`, `400,403,404`) for compatibility with parsers that interpret these as numeric values.

## Background

YAML 1.1 spec shows comma as a digit separator in:
- [Example 2.19 - Integers](https://yaml.org/spec/1.1/#id858734): `decimal: +12,345`
- [Example 2.20 - Floating Point](https://yaml.org/spec/1.1/#id858757): `fixed: 1,230.15`

While the formal regexes at yaml.org/type/{int,float}.html only allow underscores, some YAML 1.1 parsers (notably Ruby's Psych) interpret these examples literally:

```ruby
require 'yaml'
YAML.load("x: 400,403,404")  # => {"x"=>400403404}
YAML.load("x: +12,345")      # => {"x"=>12345}
YAML.load("x: 1,230.15")     # => {"x"=>1230.15}
```

This causes issues in multi-language pipelines where Go outputs unquoted YAML that other parsers misinterpret.

## Approach

This follows the existing pattern used for other YAML 1.1 compatibility cases:
- `isBase60Float()` - quotes base-60 floats like `190:20:30`
- `isOldBool()` - quotes old bools like `yes`, `no`, `on`, `off`
- `isCommaNumber()` (new) - quotes comma-separated numbers

## Changes

- Add `yaml11CommaNumber` regex and `isCommaNumber()` function in representer.go
- Include in `needsQuoting` check alongside existing compatibility functions
- Add test cases in encode.yaml