### PR TITLE
Don't return internal parse errors

### DIFF
--- a/internal/libyaml/errors.go
+++ b/internal/libyaml/errors.go
@@ -44,12 +44,42 @@ func (e ParserError) Error() string {
 	return MarkedYAMLError(e).Error()
 }
 
+// Line returns the line number (1-indexed) of the error position.
+func (e ParserError) Line() int {
+	return e.Mark.Line
+}
+
+// Column returns the column number (1-indexed) of the error position.
+func (e ParserError) Column() int {
+	return e.Mark.Column + 1
+}
+
+// Offset returns the byte offset of the error position.
+func (e ParserError) Offset() int {
+	return e.Mark.Index
+}
+
 // ScannerError represents an error that occurred during scanning.
 type ScannerError MarkedYAMLError
 
 // Error returns the error message.
 func (e ScannerError) Error() string {
 	return MarkedYAMLError(e).Error()
+}
+
+// Line returns the line number (1-indexed) of the error position.
+func (e ScannerError) Line() int {
+	return e.Mark.Line
+}
+
+// Column returns the column number (1-indexed) of the error position.
+func (e ScannerError) Column() int {
+	return e.Mark.Column + 1
+}
+
+// Offset returns the byte offset of the error position.
+func (e ScannerError) Offset() int {
+	return e.Mark.Index
 }
 
 // ReaderError represents an error that occurred while reading input.

--- a/internal/libyaml/errors_test.go
+++ b/internal/libyaml/errors_test.go
@@ -58,6 +58,10 @@ func runParserYAMLErrorTest(t *testing.T, tc TestCase) {
 	assert.Truef(t, ok, "want should be string, got %T", tc.Want)
 
 	assert.Equalf(t, want, got, "error message mismatch")
+
+	assert.Equal(t, err.Mark.Line, err.Line())
+	assert.Equal(t, err.Mark.Column+1, err.Column())
+	assert.Equal(t, err.Mark.Index, err.Offset())
 }
 
 func runScannerYAMLErrorTest(t *testing.T, tc TestCase) {
@@ -73,6 +77,10 @@ func runScannerYAMLErrorTest(t *testing.T, tc TestCase) {
 	assert.Truef(t, ok, "want should be string, got %T", tc.Want)
 
 	assert.Equalf(t, want, got, "error message mismatch")
+
+	assert.Equal(t, err.Mark.Line, err.Line())
+	assert.Equal(t, err.Mark.Column+1, err.Column())
+	assert.Equal(t, err.Mark.Index, err.Offset())
 }
 
 func runReaderYAMLErrorTest(t *testing.T, tc TestCase) {

--- a/yaml.go
+++ b/yaml.go
@@ -397,6 +397,12 @@ type (
 	// It contains multiple *[LoadError] instances with details about each error.
 	LoadErrors = libyaml.LoadErrors
 
+	// ScannerError represents an error that occurred during scanning.
+	ScannerError = libyaml.ScannerError
+
+	// ParserError represents an error that occurred during parsing.
+	ParserError = libyaml.ParserError
+
 	// TypeError is a legacy error type retained for compatibility.
 	//
 	// Deprecated: Use [LoadErrors] instead.

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -798,9 +798,9 @@ func TestParserErrorUnmarshal(t *testing.T) {
 	}
 	data := "a: 1\n=\nb: 2"
 	err := yaml.Unmarshal([]byte(data), &v)
-	var asErr libyaml.ScannerError
+	var asErr yaml.ScannerError
 	assert.ErrorAs(t, err, &asErr)
-	expectedErr := libyaml.ScannerError{
+	expectedErr := yaml.ScannerError{
 		ContextMark: libyaml.Mark{
 			Index:  5,
 			Line:   2,
@@ -822,9 +822,9 @@ func TestParserErrorDecoder(t *testing.T) {
 	var v any
 	data := "value: -"
 	err := yaml.NewDecoder(strings.NewReader(data)).Decode(&v)
-	var asErr libyaml.ScannerError
+	var asErr yaml.ScannerError
 	assert.ErrorAs(t, err, &asErr)
-	expectedErr := libyaml.ScannerError{
+	expectedErr := yaml.ScannerError{
 		Mark: libyaml.Mark{
 			Index:  7,
 			Line:   1,
@@ -1780,9 +1780,9 @@ func TestParserErrorUnknownAnchorPosition(t *testing.T) {
 	for _, test := range tests {
 		var n yaml.Node
 		err := yaml.Unmarshal([]byte(test.data), &n)
-		asErr := new(libyaml.ParserError)
+		asErr := new(yaml.ParserError)
 		assert.ErrorAs(t, err, &asErr)
-		expected := &libyaml.ParserError{
+		expected := &yaml.ParserError{
 			Message: "unknown anchor 'x' referenced",
 			Mark: libyaml.Mark{
 				Line:   test.line,


### PR DESCRIPTION
Fix #288 

This PR fixes #288 by exposing `libyaml.ScannerError` and `libyaml.ParserError`. To access the details of the errors this patch also adds methods for the error positions.