### PR TITLE
Make the aliasing restrictions configurable

### DIFF
--- a/internal/libyaml/options.go
+++ b/internal/libyaml/options.go
@@ -23,6 +23,11 @@ type Options struct {
 	StreamNodes    bool // Enable stream node emission
 	AllDocuments   bool // Load/Dump all documents in multi-document streams
 
+	AliasingRestrictionsNotEnforced bool    // Disable aliasing limits
+	AliasRatioRangeLow              int     // Low range of aliasing expansion limits
+	AliasRatioRangeHigh             int     // High range of aliasing expansion limits
+	AliasRatioRange                 float64 // Range over which allowed alias ratios are scaled
+
 	// Dumping options
 	Indent                int        // Indentation spaces (2-9)
 	CompactSeqIndent      bool       // Whether '- ' counts as indentation
@@ -344,6 +349,38 @@ func WithQuotePreference(style QuoteStyle) Option {
 		default:
 			return fmt.Errorf("invalid QuoteStyle value: %d", style)
 		}
+	}
+}
+
+// WithAliasingRestrictionsNotEnforced sets whether aliasing restrictions are enforced.
+func WithAliasingRestrictionsNotEnforced(value bool) Option {
+	return func(o *Options) error {
+		o.AliasingRestrictionsNotEnforced = value
+		return nil
+	}
+}
+
+// WithAliasRatioRangeLow sets the low range of alias expansion limits
+func WithAliasRatioRangeLow(value int) Option {
+	return func(o *Options) error {
+		o.AliasRatioRangeLow = value
+		return nil
+	}
+}
+
+// WithAliasRatioRangeHigh sets the low range of alias expansion limits
+func WithAliasRatioRangeHigh(value int) Option {
+	return func(o *Options) error {
+		o.AliasRatioRangeHigh = value
+		return nil
+	}
+}
+
+// WithAliasRatioRange sets the range over which allowed alias ratios are scaled
+func WithAliasRatioRange(value float64) Option {
+	return func(o *Options) error {
+		o.AliasRatioRange = value
+		return nil
 	}
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -241,6 +241,14 @@ var (
 	//   - QuoteDouble: Use double quotes
 	//   - QuoteLegacy: Legacy v2/v3 behavior (mixed quoting)
 	WithQuotePreference = libyaml.WithQuotePreference
+
+	WithAliasingRestrictionsNotEnforced = libyaml.WithAliasingRestrictionsNotEnforced
+
+	WithAliasRatioRangeLow = libyaml.WithAliasRatioRangeLow
+
+	WithAliasRatioRangeHigh = libyaml.WithAliasRatioRangeHigh
+
+	WithAliasRatioRange = libyaml.WithAliasRatioRange
 )
 
 // Options combines multiple options into a single Option.


### PR DESCRIPTION
Resolves #296 

This is a fairly straight forward patch to remove the hard coded aliasing restrictions and instead allow them to be customized or disabled at runtime. In testing with a document with about 11,000 aliases I saw no noticeable performance but this document did trip over the aliasing limits. Since the source and nature of it is programmatically controlled, this is a use case where I'd like to disable the restrictions.

This patch takes the concept further by enabling all parameters to be configured, which is more likely to be what DoS style restrictions here are intended for.