### PR TITLE
chore: enable require-stdlib-doclinks rule from godoclint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,13 +6,14 @@ version: '2'
 linters:
   enable:
   - dupword
+  - godoclint
   - govet
   - mirror
   - misspell
-  - nolintlint
-  - staticcheck
   - modernize
   - nilnesserr
+  - nolintlint
+  - staticcheck
   - thelper
   - unconvert
   disable:
@@ -25,17 +26,21 @@ linters:
       - 'NULL'
       - DOCUMENT-START
       - BLOCK-END
+    godoclint:
+      default: none
+      enable:
+      - require-stdlib-doclink
+    govet:
+      enable-all: true
+      disable:
+      - fieldalignment
+      - shadow
     misspell:
       locale: US
     nolintlint:
       allow-unused: false
       require-specific: true
       require-explanation: true
-    govet:
-      enable-all: true
-      disable:
-      - fieldalignment
-      - shadow
     staticcheck:
       checks:
       # enable all rules

--- a/cmd/go-yaml/main.go
+++ b/cmd/go-yaml/main.go
@@ -26,7 +26,7 @@ const version = "4.0.0.1"
 // stringSlice is a custom flag type for collecting multiple -o flags
 type stringSlice []string
 
-// String returns the string representation of the slice for flag.Value interface.
+// String returns the string representation of the slice for [flag.Value] interface.
 func (s *stringSlice) String() string {
 	if s == nil {
 		return ""
@@ -34,7 +34,7 @@ func (s *stringSlice) String() string {
 	return fmt.Sprint(*s)
 }
 
-// Set appends a value to the slice for flag.Value interface.
+// Set appends a value to the slice for [flag.Value] interface.
 func (s *stringSlice) Set(value string) error {
 	// Special case: empty value or explicit help request
 	if value == "" || value == "help" || value == "?" {

--- a/internal/libyaml/composer.go
+++ b/internal/libyaml/composer.go
@@ -40,7 +40,7 @@ func NewComposer(b []byte, opts *Options) *Composer {
 	return &p
 }
 
-// NewComposerFromReader creates a new composer from an io.Reader.
+// NewComposerFromReader creates a new composer from an [io.Reader].
 func NewComposerFromReader(r io.Reader, opts *Options) *Composer {
 	p := Composer{
 		Parser: NewParser(),

--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -1093,7 +1093,7 @@ func (c *Constructor) null(out reflect.Value) bool {
 	return false
 }
 
-// isTextUnmarshaler checks if a value implements encoding.TextUnmarshaler.
+// isTextUnmarshaler checks if a value implements [encoding.TextUnmarshaler].
 // It dereferences pointers to check the underlying type.
 func isTextUnmarshaler(out reflect.Value) bool {
 	// Dereference pointers to check the underlying type,
@@ -1113,7 +1113,7 @@ func isTextUnmarshaler(out reflect.Value) bool {
 	return false
 }
 
-// settableValueOf returns a settable reflect.Value for the given value.
+// settableValueOf returns a settable [reflect.Value] for the given value.
 func settableValueOf(i any) reflect.Value {
 	v := reflect.ValueOf(i)
 	sv := reflect.New(v.Type()).Elem()

--- a/internal/libyaml/errors.go
+++ b/internal/libyaml/errors.go
@@ -128,7 +128,7 @@ func (e *LoadErrors) Error() string {
 	return b.String()
 }
 
-// As implements errors.As for Go versions prior to 1.20 that don't support
+// As implements [errors.As] for Go versions prior to 1.20 that don't support
 // the Unwrap() []error interface. It allows [LoadErrors] to match against
 // *ConstructError targets by returning the first error in the list.
 func (e *LoadErrors) As(target any) bool {
@@ -150,7 +150,7 @@ func (e *LoadErrors) As(target any) bool {
 	return false
 }
 
-// Is implements errors.Is for Go versions prior to 1.20 that don't support
+// Is implements [errors.Is] for Go versions prior to 1.20 that don't support
 // the Unwrap() []error interface. It checks if any wrapped error matches
 // the target error.
 func (e *LoadErrors) Is(target error) bool {

--- a/internal/libyaml/loader.go
+++ b/internal/libyaml/loader.go
@@ -106,9 +106,9 @@ func Load(in []byte, out any, opts ...Option) error {
 // Load reads the next YAML-encoded document from its input and stores it
 // in the value pointed to by v.
 //
-// Returns io.EOF when there are no more documents to read.
+// Returns [io.EOF] when there are no more documents to read.
 // If WithSingleDocument option was set and a document was already read,
-// subsequent calls return io.EOF.
+// subsequent calls return [io.EOF].
 //
 // Maps and pointers (to a struct, string, int, etc) are accepted as v
 // values. If an internal pointer within a struct is not initialized,

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -401,7 +401,7 @@ type Unmarshaler interface {
 
 // IsZeroer is used to check whether an object is zero to determine whether
 // it should be omitted when marshaling with the ,omitempty flag. One notable
-// implementation is time.Time.
+// implementation is [time.Time].
 type IsZeroer interface {
 	IsZero() bool
 }

--- a/internal/libyaml/options.go
+++ b/internal/libyaml/options.go
@@ -95,7 +95,7 @@ func WithKnownFields(knownFields ...bool) Option {
 
 // WithSingleDocument configures the Loader to only process the first document
 // in a YAML stream. After the first document is loaded, subsequent calls to
-// Load will return io.EOF.
+// Load will return [io.EOF].
 //
 // When called without arguments, defaults to true.
 //

--- a/internal/libyaml/representer.go
+++ b/internal/libyaml/representer.go
@@ -346,7 +346,7 @@ func (r *Representer) uintv(tag string, in reflect.Value) *Node {
 	}
 }
 
-// timev converts a Go time.Time to a YAML scalar node in RFC3339Nano format.
+// timev converts a Go [time.Time] to a YAML scalar node in RFC3339Nano format.
 func (r *Representer) timev(tag string, in reflect.Value) *Node {
 	t := in.Interface().(time.Time)
 	s := t.Format(time.RFC3339Nano)

--- a/internal/libyaml/resolver.go
+++ b/internal/libyaml/resolver.go
@@ -85,7 +85,7 @@ func (r *Resolver) Resolve(n *Node) {
 
 // resolve determines the YAML tag and Go value for a scalar string.
 // It takes a tag hint and the scalar string value, and returns the resolved
-// tag and the corresponding Go value (int, float, bool, time.Time, etc.).
+// tag and the corresponding Go value (int, float, bool, [time.Time], etc.).
 // If the tag is already specified and non-resolvable, it returns the input
 // unchanged.
 func resolve(tag string, in string) (rtag string, out any) {

--- a/internal/libyaml/structmeta.go
+++ b/internal/libyaml/structmeta.go
@@ -57,7 +57,7 @@ type fieldInfo struct {
 
 // structMap caches struct reflection information.
 // fieldMapMutex protects access to structMap.
-// constructorType holds the reflect.Type for the constructor interface.
+// constructorType holds the [reflect.Type] for the constructor interface.
 var (
 	structMap       = make(map[reflect.Type]*structInfo)
 	fieldMapMutex   sync.RWMutex
@@ -70,7 +70,7 @@ type constructor interface {
 	UnmarshalYAML(value *Node) error
 }
 
-// init initializes the constructorType variable with the reflect.Type of constructor interface.
+// init initializes the constructorType variable with the [reflect.Type] of constructor interface.
 func init() {
 	var v constructor
 	constructorType = reflect.ValueOf(&v).Elem().Type()

--- a/internal/libyaml/testdata_test.go
+++ b/internal/libyaml/testdata_test.go
@@ -976,7 +976,7 @@ func RunRoundTripTest(t *testing.T, tc TestCase) {
 	}
 }
 
-// GetWriter extracts an io.Writer from an interface value
+// GetWriter extracts an [io.Writer] from an interface value
 func GetWriter(t *testing.T, v any) io.Writer {
 	t.Helper()
 	if w, ok := v.(io.Writer); ok {
@@ -986,7 +986,7 @@ func GetWriter(t *testing.T, v any) io.Writer {
 	return nil
 }
 
-// GetReader extracts an io.Reader from an interface value
+// GetReader extracts an [io.Reader] from an interface value
 func GetReader(t *testing.T, v any) io.Reader {
 	t.Helper()
 	if r, ok := v.(io.Reader); ok {

--- a/internal/testutil/datatest/helpers.go
+++ b/internal/testutil/datatest/helpers.go
@@ -42,7 +42,7 @@ func GetField(t *testing.T, obj any, fieldName string) any {
 
 // CallMethod calls a method on an object using reflection.
 // This is useful for test cases that need to call methods dynamically.
-// Returns the slice of return values from the method call as reflect.Value wrappers.
+// Returns the slice of return values from the method call as [reflect.Value] wrappers.
 // Callers must extract the actual values using methods like .Interface(), .Int(), .String(), etc.
 func CallMethod(t *testing.T, obj any, methodName string, args []any) []reflect.Value {
 	t.Helper()

--- a/internal/testutil/datatest/loader.go
+++ b/internal/testutil/datatest/loader.go
@@ -123,7 +123,7 @@ func UnmarshalStruct(target any, data map[string]any) error {
 	return nil
 }
 
-// setField sets a reflect.Value from an interface{} value
+// setField sets a [reflect.Value] from an interface{} value
 func setField(field reflect.Value, value any) error {
 	if !field.CanSet() {
 		return fmt.Errorf("field cannot be set")

--- a/internal/testutil/datatest/registry.go
+++ b/internal/testutil/datatest/registry.go
@@ -94,7 +94,7 @@ func (r *TypeRegistry) NewPointerInstance(name string) (any, error) {
 	return reflect.New(typ).Interface(), nil
 }
 
-// GetType returns the reflect.Type for a registered type name.
+// GetType returns the [reflect.Type] for a registered type name.
 func (r *TypeRegistry) GetType(name string) (reflect.Type, bool) {
 	typ, ok := r.types[name]
 	return typ, ok

--- a/node.go
+++ b/node.go
@@ -51,7 +51,7 @@ type (
 
 	// IsZeroer is used to check whether an object is zero to determine whether
 	// it should be omitted when marshaling with the ,omitempty flag.
-	// One notable implementation is time.Time.
+	// One notable implementation is [time.Time].
 	IsZeroer = libyaml.IsZeroer
 )
 

--- a/yaml.go
+++ b/yaml.go
@@ -103,7 +103,7 @@ var (
 
 	// WithSingleDocument configures the Loader to only process the first
 	// document in a YAML stream. After the first document is loaded,
-	// subsequent calls to Load will return io.EOF.
+	// subsequent calls to Load will return [io.EOF].
 	//
 	// When called without arguments, defaults to true.
 	//

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -96,7 +96,7 @@ type (
 	}
 )
 
-// simpleTextUnmarshaler is a simple type implementing encoding.TextUnmarshaler
+// simpleTextUnmarshaler is a simple type implementing [encoding.TextUnmarshaler]
 // for testing TextUnmarshaler validation.
 type simpleTextUnmarshaler struct {
 	Value string


### PR DESCRIPTION
Fixes #225

This PR only enables the `require-stdlib-doclinks` rule, as I don't know if there's any plan for enabling more rules from `godoclint`.

Feel free to close if doesn't fit the purpose, without any comment. :heart: 