### PR TITLE
Reorder TextUnmarshaler check in Constructor

### DIFF
--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -89,6 +89,18 @@ func (c *Constructor) Construct(n *Node, out reflect.Value) (good bool) {
 		return true
 	}
 
+	switch n.Kind {
+	case DocumentNode:
+		return c.document(n, out)
+	case AliasNode:
+		return c.alias(n, out)
+	}
+
+	out, constructed, good := c.prepare(n, out)
+	if constructed {
+		return good
+	}
+
 	// When out type implements [encoding.TextUnmarshaler], ensure the node
 	// is a scalar. Otherwise, for example, constructing a YAML mapping
 	// into a struct having no exported fields, but implementing
@@ -105,16 +117,7 @@ func (c *Constructor) Construct(n *Node, out reflect.Value) (good bool) {
 		})
 		return false
 	}
-	switch n.Kind {
-	case DocumentNode:
-		return c.document(n, out)
-	case AliasNode:
-		return c.alias(n, out)
-	}
-	out, constructed, good := c.prepare(n, out)
-	if constructed {
-		return good
-	}
+
 	switch n.Kind {
 	case ScalarNode:
 		good = c.scalar(n, out)

--- a/testdata/decode.yaml
+++ b/testdata/decode.yaml
@@ -1350,3 +1350,15 @@
     type: testStructA_TextUnmarshalerPtrPtr
     want:
       a: null
+
+- decode:
+    name: Aliases and TextUnmarshaler
+    yaml: |
+      a: &foo hello world
+      b: *foo
+    type: testStructAB_TextUnmarshaler
+    want:
+      a:
+        value: hello world
+      b:
+        value: hello world

--- a/testdata/unmarshal_errors.yaml
+++ b/testdata/unmarshal_errors.yaml
@@ -183,7 +183,7 @@
     yaml: 'a: {foo: bar}'
     want: |-
       yaml: construct errors:
-        line 1: cannot construct !!map into *yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+        line 1: cannot construct !!map into yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
 
 - unmarshal-error:
     name: Sequence into TextUnmarshaler (pointer field)
@@ -191,7 +191,7 @@
     yaml: 'a: [foo, bar]'
     want: |-
       yaml: construct errors:
-        line 1: cannot construct !!seq into *yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+        line 1: cannot construct !!seq into yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
 
 - unmarshal-error:
     name: Mapping into TextUnmarshaler (pointer-pointer field)
@@ -199,7 +199,7 @@
     yaml: 'a: {foo: bar}'
     want: |-
       yaml: construct errors:
-        line 1: cannot construct !!map into **yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+        line 1: cannot construct !!map into yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
 
 - unmarshal-error:
     name: Sequence into TextUnmarshaler (pointer-pointer field)
@@ -207,4 +207,4 @@
     yaml: 'a: [foo, bar]'
     want: |-
       yaml: construct errors:
-        line 1: cannot construct !!seq into **yaml_test.simpleTextUnmarshaler (TextUnmarshaler)
+        line 1: cannot construct !!seq into yaml_test.simpleTextUnmarshaler (TextUnmarshaler)


### PR DESCRIPTION
By moving `TextUnmarshaler` check after alias handling and `c.prepare` call, we resolve two issues:

* When the type implements `yaml.Unmarshaler`, `encoding.TextUnmarshaler` is irrelevant. In particular, we must not fail when decoding non-scalar nodes into such types (#293). `prepare` handles `yaml.Unmarshaler`, and skips the `TextUnmarshaler` check.

* We must resolve aliases before checking for the `TextUnmarshaler`. Otherwise, we would incorrectly fail unmarshaling into `TextUnmarshaler` types when YAML node is a alias (#299).

The only minor problem is that error messages are slightly changed: `prepare` removes pointer indirection, so instead of `*T` just `T` is now printed. This doesn't hurt understanding.

Fixes #293, #299