### PR TITLE
Make the aliasing restrictions configurable (version 2)

### DIFF
--- a/internal/libyaml/testdata/options.yaml
+++ b/internal/libyaml/testdata/options.yaml
@@ -361,6 +361,12 @@
   from: 99
   like: "invalid QuoteStyle value"
 
+# WithAliasingRestrictionFunction tests
+- name: WithAliasingRestrictionFunction with aliasing-restrictions-func
+  type: with-aliasing-restrictions-func
+  want:
+    aliasing_restriction_function: true
+
 # ApplyOptions tests
 - name: ApplyOptions with no options (v4 defaults)
   type: apply-options

--- a/yaml.go
+++ b/yaml.go
@@ -241,6 +241,11 @@ var (
 	//   - QuoteDouble: Use double quotes
 	//   - QuoteLegacy: Legacy v2/v3 behavior (mixed quoting)
 	WithQuotePreference = libyaml.WithQuotePreference
+
+	// WithAliasingRestrictionFunction changes the default excessive aliasing check
+	// function. The function should return true if excessive aliasing in a YAML document
+	// has been detected.
+	WithAliasingRestrictionFunction = libyaml.WithAliasingRestrictionFunction
 )
 
 // Options combines multiple options into a single Option.
@@ -254,6 +259,14 @@ var (
 func Options(opts ...Option) Option {
 	return libyaml.CombineOptions(opts...)
 }
+
+// AliasingRestrictionFunction is the function signature for setting aliasing
+// restrictions.
+type AliasingRestrictionFunction = libyaml.AliasingRestrictionFunction
+
+// NoAliasingRestrictions simply returns false when set as the aliasing
+// restriction function, thus disabling the check.
+var NoAliasingRestrictions = libyaml.NoAliasingRestrictions
 
 // OptsYAML parses a YAML string containing option settings and returns
 // an Option that can be combined with other options using Options().


### PR DESCRIPTION
Resolves #296 and supercedes #297

This is a fairly straight forward patch to remove the hard coded aliasing restrictions and instead allow them to be customized or disabled at runtime. In testing with a document with about 11,000 aliases I saw no noticeable performance but this document did trip over the aliasing limits. Since the source and nature of it is programmatically controlled, this is a use case where I'd like to disable the restrictions.

This patch simplifies the #297 to allow users to fully replace the aliasing restrictions by replacing the function call which determines restrictions, and adds a built-in function for simply disabling the check. Tests are included to confirm that alternation of the implementation works.