### PR TITLE
Plugin system with Limit plugin API

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,5 @@
-//
-// Copyright (c) 2025 The go-yaml Project Contributors
+// Copyright 2025 The go-yaml Project Contributors
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package yaml implements YAML 1.1/1.2 encoding and decoding for Go programs.
 //

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,128 @@
+# Plugin System
+
+The go-yaml v4 plugin system extends YAML processing with custom logic while
+maintaining performance, safety and backward compatibility.
+
+## Overview
+
+Plugins allow you to customize certain internal processing during loading and
+dumping.
+Plugin interfaces use public types and can be implemented by external packages.
+
+## Available Plugins
+
+### Limit Plugin
+
+The limit plugin controls the maximum nesting depth and alias expansion
+allowed during parsing.
+By default, go-yaml enforces conservative limits to prevent DoS attacks.
+Use the limit plugin to relax or tighten those limits.
+
+```go
+import "go.yaml.in/yaml/v4/plugin/limit"
+
+// Default limits (same as library defaults)
+loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New()))
+
+// Disable alias checking (e.g. for documents with many programmatic aliases)
+loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New(limit.AliasNone())))
+
+// Custom depth limit
+loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New(limit.DepthValue(50))))
+```
+
+#### Limit Options
+
+| Option | Effect |
+|---|---|
+| `DepthValue(n)` | Max nesting depth (both flow and block) |
+| `DepthNone()` | Disable depth checking |
+| `DepthFunc(fn)` | Custom `func(depth int, ctx *yaml.DepthContext) error` |
+| `AliasValue(n)` | Max alias expansion count (simple threshold) |
+| `AliasNone()` | Disable alias ratio checking |
+| `AliasFunc(fn)` | Custom `func(aliasCount, constructCount int) error` |
+
+## Using Plugins
+
+### Basic Usage
+
+Register plugins with `WithPlugin()`:
+
+```go
+import (
+    "go.yaml.in/yaml/v4"
+    "go.yaml.in/yaml/v4/plugin/limit"
+)
+
+loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New(limit.AliasNone())))
+var result any
+loader.Load(&result)
+```
+
+## Default Behavior
+
+Both bare `NewLoader(data)` and version presets (`WithV4Defaults()`, etc.)
+include default limits equivalent to `limit.New()`.
+
+## YAML Configuration
+
+Plugins can be configured from YAML strings using `OptsYAML`:
+
+```go
+opts, err := yaml.OptsYAML(`
+  plugin:
+    limit:
+      depth: 50
+      alias: 1000
+`)
+```
+
+Each plugin key maps to a configuration object. For the limit plugin:
+- `depth` (int) — max nesting depth; `null` disables depth checking
+- `alias` (int) — max alias count; `null` disables alias checking
+- Omitted keys keep defaults
+- Bare `limit:` (null value) uses all defaults
+
+```yaml
+# Disable depth checking, keep default alias limits
+plugin:
+  limit:
+    depth: null
+```
+
+## Third-Party Plugins
+
+To write a third-party plugin, implement the `yaml.LimitPlugin`
+interface:
+
+```go
+type LimitPlugin interface {
+    CheckDepth(depth int, ctx *DepthContext) error
+    CheckAlias(aliasCount, constructCount int) error
+}
+```
+
+Pass an instance to `yaml.WithPlugin()` — no import of
+`plugin/limit` is needed.
+
+Example:
+
+```go
+type StrictLimit struct{}
+
+func (s *StrictLimit) CheckDepth(depth int, ctx *yaml.DepthContext) error {
+    if depth > 100 {
+        return fmt.Errorf("depth %d exceeds policy limit of 100", depth)
+    }
+    return nil
+}
+
+func (s *StrictLimit) CheckAlias(aliasCount, constructCount int) error {
+    if aliasCount > 1000 {
+        return fmt.Errorf("alias count %d exceeds policy limit", aliasCount)
+    }
+    return nil
+}
+
+yaml.NewLoader(data, yaml.WithPlugin(&StrictLimit{}))
+```

--- a/internal/libyaml/composer.go
+++ b/internal/libyaml/composer.go
@@ -37,6 +37,9 @@ func NewComposer(b []byte, opts *Options) *Composer {
 		b = []byte{'\n'}
 	}
 	p.Parser.SetInputString(b)
+	if opts != nil {
+		p.Parser.depthCheck = opts.DepthCheck
+	}
 	return &p
 }
 
@@ -47,6 +50,9 @@ func NewComposerFromReader(r io.Reader, opts *Options) *Composer {
 		opts:   opts,
 	}
 	p.Parser.SetInputReader(r)
+	if opts != nil {
+		p.Parser.depthCheck = opts.DepthCheck
+	}
 	return &p
 }
 

--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -53,6 +53,7 @@ type Constructor struct {
 	constructCount int
 	aliasCount     int
 	aliasDepth     int
+	aliasCheck     func(aliasCount, constructCount int) error
 
 	mergedFields map[any]bool
 }
@@ -66,6 +67,7 @@ func NewConstructor(opts *Options) *Constructor {
 		KnownFields:    opts.KnownFields,
 		UniqueKeys:     opts.UniqueKeys,
 		aliases:        make(map[*Node]bool),
+		aliasCheck:     opts.AliasCheck,
 	}
 }
 
@@ -81,11 +83,10 @@ func (c *Constructor) Construct(n *Node, out reflect.Value) (good bool) {
 	if c.aliasDepth > 0 {
 		c.aliasCount++
 	}
-	if c.aliasCount > 100 && c.constructCount > 1000 && float64(c.aliasCount)/float64(c.constructCount) > allowedAliasRatio(c.constructCount) {
-		Fail(formatConstructorError(
-			fmt.Errorf("document contains excessive aliasing"),
-			Mark{Line: n.Line, Column: n.Column},
-		))
+	if c.aliasCheck != nil {
+		if err := c.aliasCheck(c.aliasCount, c.constructCount); err != nil {
+			Fail(formatConstructorError(err, Mark{Line: n.Line, Column: n.Column}))
+		}
 	}
 	if out.Type() == nodeType {
 		out.Set(reflect.ValueOf(n).Elem())
@@ -159,45 +160,6 @@ var scalarConstructors = map[string]ScalarConstructFunc{
 	timestampTag: (*Constructor).constructTimestamp,
 	binaryTag:    (*Constructor).constructBinary,
 	mergeTag:     (*Constructor).constructMerge,
-}
-
-// Alias expansion limits to prevent DoS attacks via excessive aliasing.
-const (
-	// 400,000 decode operations is ~500kb of dense object declarations, or
-	// ~5kb of dense object declarations with 10000% alias expansion
-	alias_ratio_range_low = 400000
-
-	// 4,000,000 decode operations is ~5MB of dense object declarations, or
-	// ~4.5MB of dense object declarations with 10% alias expansion
-	alias_ratio_range_high = 4000000
-
-	// alias_ratio_range is the range over which we scale allowed alias
-	// ratios
-	alias_ratio_range = float64(alias_ratio_range_high - alias_ratio_range_low)
-)
-
-// allowedAliasRatio calculates the maximum allowed ratio of alias-driven
-// decodes to total decodes based on the construct count.
-// This prevents excessive alias expansion attacks while allowing reasonable
-// alias usage in both small and large documents.
-func allowedAliasRatio(constructCount int) float64 {
-	switch {
-	case constructCount <= alias_ratio_range_low:
-		// allow 99% to come from alias expansion for small-to-medium
-		// documents
-		return 0.99
-	case constructCount >= alias_ratio_range_high:
-		// allow 10% to come from alias expansion for very large
-		// documents
-		return 0.10
-	default:
-		// scale smoothly from 99% down to 10% over the range.
-		// this maps to 396,000 - 400,000 allowed alias-driven decodes
-		// over the range.
-		// 400,000 decode operations is ~100MB of allocations in
-		// worst-case scenarios (single-item maps).
-		return 0.99 - 0.89*(float64(constructCount-alias_ratio_range_low)/alias_ratio_range)
-	}
 }
 
 // --------------------------------------------------------------------------

--- a/internal/libyaml/options.go
+++ b/internal/libyaml/options.go
@@ -1,7 +1,5 @@
-//
-// Copyright (c) 2025 The go-yaml Project Contributors
+// Copyright 2025 The go-yaml Project Contributors
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Options configuration for loading and dumping YAML.
 // Provides centralized control for indentation, line width, strictness, and
@@ -35,12 +33,66 @@ type Options struct {
 	FlowSimpleCollections bool       // Use flow style for simple collections
 	QuotePreference       QuoteStyle // Preferred quote style when quoting is required
 
+	// Safety limit checks (set by ApplyOptions or WithPlugin(limit.New(...)))
+	DepthCheck func(depth int, ctx *DepthContext) error
+	AliasCheck func(aliasCount, constructCount int) error
+
 	// Private options (not exported, used internally)
 	FromLegacy bool // Indicates legacy Unmarshal()/Decoder path (check Unmarshaler, allow trailing content)
 }
 
 // Option allows configuring YAML loading and dumping operations.
 type Option func(*Options) error
+
+// DepthKind represents the type of nesting (flow or block).
+type DepthKind string
+
+// DepthKindFlow and DepthKindBlock are the possible values of DepthContext.Kind.
+const (
+	DepthKindFlow  DepthKind = "flow"
+	DepthKindBlock DepthKind = "block"
+)
+
+// DepthContext holds context about a nesting depth check.
+type DepthContext struct {
+	Kind DepthKind
+}
+
+// DefaultDepthCheck is the default depth check function.
+// It returns an error when depth exceeds 10000.
+func DefaultDepthCheck(depth int, ctx *DepthContext) error {
+	const maxDepth = 10000
+	if depth > maxDepth {
+		return fmt.Errorf("exceeded max depth of %d", maxDepth)
+	}
+	return nil
+}
+
+// DefaultAliasCheck is the default alias check function.
+// It uses a ratio-based heuristic to prevent DoS attacks via excessive aliasing.
+func DefaultAliasCheck(aliasCount, constructCount int) error {
+	const (
+		aliasRatioRangeLow  = 400000
+		aliasRatioRangeHigh = 4000000
+		aliasRatioRange     = float64(aliasRatioRangeHigh - aliasRatioRangeLow)
+	)
+	if aliasCount <= 100 || constructCount <= 1000 {
+		return nil
+	}
+	var allowed float64
+	switch {
+	case constructCount <= aliasRatioRangeLow:
+		allowed = 0.99
+	case constructCount >= aliasRatioRangeHigh:
+		allowed = 0.10
+	default:
+		allowed = 0.99 - 0.89*(float64(constructCount-aliasRatioRangeLow)/aliasRatioRange)
+	}
+	if float64(aliasCount)/float64(constructCount) > allowed {
+		return errors.New("document contains excessive aliasing")
+	}
+	return nil
+}
 
 // WithIndent sets the number of spaces to use for indentation when
 // dumping YAML content.
@@ -374,6 +426,10 @@ func ApplyOptions(opts ...Option) (*Options, error) {
 		LineWidth:        80,
 		Unicode:          true,
 		UniqueKeys:       true,
+
+		// Default safety limits
+		DepthCheck: DefaultDepthCheck,
+		AliasCheck: DefaultAliasCheck,
 	}
 	for _, opt := range opts {
 		if err := opt(o); err != nil {

--- a/internal/libyaml/parser.go
+++ b/internal/libyaml/parser.go
@@ -238,6 +238,8 @@ type Parser struct {
 	simple_key          SimpleKey   // The current simple key.
 	simple_key_stack    []SimpleKey // The stack of simple keys.
 
+	depthCheck func(int, *DepthContext) error // Depth limit check function
+
 	// Parser stuff
 
 	state          ParserState    // The current parser state.
@@ -256,6 +258,7 @@ func NewParser() Parser {
 		raw_buffer: make([]byte, 0, input_raw_buffer_size),
 		buffer:     make([]byte, 0, input_buffer_size),
 		mark:       Mark{Line: 1, Column: 1},
+		depthCheck: DefaultDepthCheck,
 	}
 }
 

--- a/internal/libyaml/scanner.go
+++ b/internal/libyaml/scanner.go
@@ -787,12 +787,6 @@ func (parser *Parser) Scan(token *Token) error {
 // formatScannerError creates a ScannerError with the given problem message
 // and mark position.
 
-// max_flow_level is the maximum nesting depth for flow collections.
-const max_flow_level = 10000
-
-// max_indents is the maximum nesting depth for indentation levels.
-const max_indents = 10000
-
 // max_number_length is the maximum length of a number suffix in a scalar tag.
 const max_number_length = 2
 
@@ -3144,7 +3138,6 @@ func (parser *Parser) removeSimpleKey() error {
 	return nil
 }
 
-// max_flow_level limits the flow_level
 func (parser *Parser) isFlowSequence() bool {
 	if len(parser.tokens) == 0 {
 		return false
@@ -3158,10 +3151,10 @@ func (parser *Parser) isFlowSequence() bool {
 func (parser *Parser) increaseFlowLevel() error {
 	// Increase the flow level.
 	parser.flow_level++
-	if parser.flow_level > max_flow_level {
+	if err := parser.depthCheck(parser.flow_level, &DepthContext{Kind: DepthKindFlow}); err != nil {
 		return formatScannerErrorContext(
 			"while increasing flow level", parser.simple_key.mark,
-			fmt.Sprintf("exceeded max depth of %d", max_flow_level), parser.mark)
+			err.Error(), parser.mark)
 	}
 
 	// If a simple key was possible, push it to the stack before resetting the key.
@@ -3194,7 +3187,6 @@ func (parser *Parser) decreaseFlowLevel() error {
 	return nil
 }
 
-// max_indents limits the indents stack size
 func (parser *Parser) rollIndent(column, number int, typ TokenType, mark Mark) error {
 	// In the flow context, do nothing.
 	if parser.flow_level > 0 {
@@ -3206,10 +3198,10 @@ func (parser *Parser) rollIndent(column, number int, typ TokenType, mark Mark) e
 		// indentation level.
 		parser.indents = append(parser.indents, parser.indent)
 		parser.indent = column
-		if len(parser.indents) > max_indents {
+		if err := parser.depthCheck(len(parser.indents), &DepthContext{Kind: DepthKindBlock}); err != nil {
 			return formatScannerErrorContext(
 				"while increasing indent level", parser.simple_key.mark,
-				fmt.Sprintf("exceeded max depth of %d", max_indents), parser.mark)
+				err.Error(), parser.mark)
 		}
 
 		// Create a token and insert it into the queue.

--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The go-yaml Project Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml
+
+// LimitPlugin configures safety limits for YAML parsing.
+//
+// When registered, CheckDepth is called on each nesting depth increase,
+// and CheckAlias is called on each alias expansion to detect excessive
+// aliasing.
+//
+// Example usage:
+//
+//	import "go.yaml.in/yaml/v4/plugin/limit"
+//	loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New(limit.AliasNone())))
+type LimitPlugin interface {
+	// CheckDepth is called when the parser increases nesting depth.
+	// depth is the current nesting level; ctx.Kind is "flow" or "block".
+	// Return an error to abort parsing.
+	CheckDepth(depth int, ctx *DepthContext) error
+
+	// CheckAlias is called during alias expansion.
+	// Return an error to abort construction.
+	CheckAlias(aliasCount, constructCount int) error
+}

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The go-yaml Project Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package plugin provides official YAML plugins for go-yaml.
+//
+// Plugins extend the core YAML library with optional processing capabilities.
+// This package contains official plugin implementations maintained by the
+// go-yaml project.
+//
+// # Available Plugins
+//
+// Limit plugin (plugin/limit):
+//   - Configurable depth and alias expansion limits
+//
+// # Usage
+//
+// Import the plugin you need and register it with WithPlugin:
+//
+//	import "go.yaml.in/yaml/v4"
+//	import "go.yaml.in/yaml/v4/plugin/limit"
+//
+//	// Disable alias checking for documents with many aliases
+//	loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New(limit.AliasNone())))
+//
+// # Third-Party Plugins
+//
+// Plugin interfaces use public types and can be implemented by external
+// packages.
+// Implement the relevant plugin interface (e.g., LimitPlugin) and register
+// with WithPlugin.
+package plugin

--- a/plugin/limit/plugin.go
+++ b/plugin/limit/plugin.go
@@ -1,0 +1,191 @@
+// Copyright 2026 The go-yaml Project Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package limit provides a configurable safety limit plugin for go-yaml.
+//
+// The limit plugin controls the maximum nesting depth and alias expansion
+// ratio during YAML parsing.
+// By default, go-yaml enforces conservative limits to prevent DoS attacks.
+// This plugin lets you relax or tighten those limits for your use case.
+//
+// # Usage
+//
+//	import (
+//	    "go.yaml.in/yaml/v4"
+//	    "go.yaml.in/yaml/v4/plugin/limit"
+//	)
+//
+//	// Default limits
+//	loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New()))
+//
+//	// Disable alias checking (e.g. for 11,000 programmatic aliases)
+//	loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New(limit.AliasNone())))
+//
+//	// Custom depth limit
+//	loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New(limit.DepthValue(50))))
+//
+// # Third-Party Plugins
+//
+// You can implement [yaml.LimitPlugin] directly instead of using this package:
+//
+//	type StrictLimit struct{}
+//	func (s *StrictLimit) CheckDepth(depth int, ctx *yaml.DepthContext) error { ... }
+//	func (s *StrictLimit) CheckAlias(aliasCount, constructCount int) error { ... }
+//	yaml.NewLoader(data, yaml.WithPlugin(&StrictLimit{}))
+package limit
+
+import (
+	"fmt"
+
+	"go.yaml.in/yaml/v4/internal/libyaml"
+)
+
+// DepthContext is an alias for the type used in depth check callbacks.
+// See [yaml.DepthContext] for field documentation.
+type DepthContext = libyaml.DepthContext
+
+// Plugin implements configurable safety limits for YAML parsing.
+type Plugin struct {
+	depthLimit    *int
+	depthDisabled bool
+	depthFn       func(int, *DepthContext) error
+	aliasLimit    *int
+	aliasDisabled bool
+	aliasFn       func(int, int) error
+}
+
+// Option configures a [Plugin].
+type Option func(*Plugin)
+
+// New creates a limit plugin with the given options.
+// With no options, it uses the same defaults as the bare go-yaml library.
+func New(opts ...Option) *Plugin {
+	p := &Plugin{}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// DepthValue sets a maximum nesting depth (both flow and block).
+func DepthValue(n int) Option {
+	return func(p *Plugin) {
+		p.depthLimit = &n
+		p.depthDisabled = false
+		p.depthFn = nil
+	}
+}
+
+// DepthNone disables depth checking entirely.
+func DepthNone() Option {
+	return func(p *Plugin) {
+		p.depthDisabled = true
+		p.depthLimit = nil
+		p.depthFn = nil
+	}
+}
+
+// DepthFunc sets a custom depth check function.
+func DepthFunc(fn func(depth int, ctx *DepthContext) error) Option {
+	return func(p *Plugin) {
+		p.depthFn = fn
+		p.depthLimit = nil
+		p.depthDisabled = false
+	}
+}
+
+// AliasValue sets a simple alias expansion count threshold.
+func AliasValue(n int) Option {
+	return func(p *Plugin) {
+		p.aliasLimit = &n
+		p.aliasDisabled = false
+		p.aliasFn = nil
+	}
+}
+
+// AliasNone disables alias checking entirely.
+func AliasNone() Option {
+	return func(p *Plugin) {
+		p.aliasDisabled = true
+		p.aliasLimit = nil
+		p.aliasFn = nil
+	}
+}
+
+// AliasFunc sets a custom alias check function.
+func AliasFunc(fn func(aliasCount, constructCount int) error) Option {
+	return func(p *Plugin) {
+		p.aliasFn = fn
+		p.aliasLimit = nil
+		p.aliasDisabled = false
+	}
+}
+
+// CheckDepth implements [yaml.LimitPlugin].
+func (p *Plugin) CheckDepth(depth int, ctx *DepthContext) error {
+	if p.depthFn != nil {
+		return p.depthFn(depth, ctx)
+	}
+	if p.depthDisabled {
+		return nil
+	}
+	if p.depthLimit != nil {
+		if depth > *p.depthLimit {
+			return fmt.Errorf("exceeded max depth of %d", *p.depthLimit)
+		}
+		return nil
+	}
+	return libyaml.DefaultDepthCheck(depth, ctx)
+}
+
+// CheckAlias implements [yaml.LimitPlugin].
+func (p *Plugin) CheckAlias(aliasCount, constructCount int) error {
+	if p.aliasFn != nil {
+		return p.aliasFn(aliasCount, constructCount)
+	}
+	if p.aliasDisabled {
+		return nil
+	}
+	if p.aliasLimit != nil {
+		if aliasCount > *p.aliasLimit {
+			return fmt.Errorf("exceeded max alias count of %d", *p.aliasLimit)
+		}
+		return nil
+	}
+	return libyaml.DefaultAliasCheck(aliasCount, constructCount)
+}
+
+// NewFromYAML creates a limit plugin from a YAML config map.
+// Keys: "depth" (int or null), "alias" (int or null).
+// Null values disable the corresponding check.
+// Omitted keys use defaults.
+func NewFromYAML(cfg map[string]any) (*Plugin, error) {
+	var opts []Option
+	for key, val := range cfg {
+		switch key {
+		case "depth":
+			if val == nil {
+				opts = append(opts, DepthNone())
+			} else {
+				n, ok := val.(int)
+				if !ok {
+					return nil, fmt.Errorf("limit: depth must be int or null, got %T", val)
+				}
+				opts = append(opts, DepthValue(n))
+			}
+		case "alias":
+			if val == nil {
+				opts = append(opts, AliasNone())
+			} else {
+				n, ok := val.(int)
+				if !ok {
+					return nil, fmt.Errorf("limit: alias must be int or null, got %T", val)
+				}
+				opts = append(opts, AliasValue(n))
+			}
+		default:
+			return nil, fmt.Errorf("limit: unknown key %q", key)
+		}
+	}
+	return New(opts...), nil
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The go-yaml Project Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v4/plugin/limit"
+)
+
+// generateAliases builds YAML with n aliases referencing a large anchor.
+func generateAliases(n int) []byte {
+	var sb strings.Builder
+	sb.WriteString("anchor: &anchor [1, 2, 3]\nrefs:\n")
+	for i := 0; i < n; i++ {
+		sb.WriteString("- *anchor\n")
+	}
+	return []byte(sb.String())
+}
+
+// generateDeepNesting builds deeply nested flow YAML.
+func generateDeepNesting(depth int) []byte {
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteString("[")
+	}
+	sb.WriteString("x")
+	for i := 0; i < depth; i++ {
+		sb.WriteString("]")
+	}
+	return []byte(sb.String())
+}
+
+func TestWithPlugin_Limit_AliasFunc(t *testing.T) {
+	called := false
+	fn := func(aliasCount, constructCount int) error {
+		called = true
+		return nil
+	}
+	data := generateAliases(200)
+	var result any
+	err := yaml.Load(data, &result, yaml.WithPlugin(limit.New(limit.AliasFunc(fn))))
+	if err != nil {
+		t.Fatalf("Expected success with custom AliasFunc, got: %v", err)
+	}
+	if !called {
+		t.Error("Expected custom AliasFunc to be called")
+	}
+}
+
+func TestWithPlugin_Limit_DepthFunc(t *testing.T) {
+	called := false
+	fn := func(depth int, ctx *yaml.DepthContext) error {
+		called = true
+		return nil
+	}
+	data := generateDeepNesting(5)
+	var result any
+	err := yaml.Load(data, &result, yaml.WithPlugin(limit.New(limit.DepthFunc(fn))))
+	if err != nil {
+		t.Fatalf("Expected success with custom DepthFunc, got: %v", err)
+	}
+	if !called {
+		t.Error("Expected custom DepthFunc to be called")
+	}
+}
+
+func TestWithPlugin_UnsupportedType(t *testing.T) {
+	data := []byte(`key: value`)
+	var result map[string]any
+	// Pass an unsupported type (integer) as a plugin
+	err := yaml.Load(data, &result, yaml.WithPlugin(42))
+	if err == nil {
+		t.Fatal("Expected error for unsupported plugin type, got nil")
+	}
+	if err.Error() != "yaml: unsupported plugin type: int" {
+		t.Errorf("Unexpected error message: %v", err)
+	}
+}
+
+func TestDefaultBehavior_HasLimit(t *testing.T) {
+	// Bare NewLoader should have default depth limits
+	data := generateDeepNesting(10001)
+	loader, err := yaml.NewLoader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("NewLoader failed: %v", err)
+	}
+	var result any
+	err = loader.Load(&result)
+	if err == nil {
+		t.Fatal("Expected error from default depth limits, got nil")
+	}
+}

--- a/testdata/plugin.yaml
+++ b/testdata/plugin.yaml
@@ -1,0 +1,107 @@
+# Copyright 2026 The go-yaml Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Plugin test cases for go-yaml
+#
+# Purpose: Tests YAML-based plugin configuration via OptsYAML.
+# Validates that plugins can be configured from YAML and enforce
+# their limits correctly.
+#
+# Test Types:
+#   plugin-pass  - Tests that should succeed with the given plugin config
+#   plugin-error - Tests that should fail with a specific error message
+#
+# Common Keys:
+#   name    - Test case name (string)
+#   plugin  - Plugin configuration (passed to OptsYAML)
+#   data    - YAML input specification (string or generator spec)
+#   want    - Expected error message (for plugin-error tests)
+
+- plugin-pass:
+    name: depth 50 allows nesting of 20
+    plugin:
+      limit:
+        depth: 50
+    data:
+      join:
+      - loop: ['[', 20]
+      - text: 'x'
+      - loop: [']', 20]
+
+- plugin-error:
+    name: depth 5 rejects nesting of 20
+    plugin:
+      limit:
+        depth: 5
+    data:
+      join:
+      - loop: ['[', 20]
+      - text: 'x'
+      - loop: [']', 20]
+    want: 'go-yaml load error in scanner (while increasing flow level) at L1.C6: exceeded max depth of 5'
+
+- plugin-pass:
+    name: depth null disables depth checking (10001 nesting)
+    plugin:
+      limit:
+        depth:
+    data:
+      join:
+      - loop: ['[', 10001]
+      - text: 'x'
+      - loop: [']', 10001]
+
+- plugin-pass:
+    name: alias null disables alias checking (11000 aliases)
+    plugin:
+      limit:
+        alias:
+    data:
+      join:
+      - text: 'anchor: &anchor [1, 2, 3]'
+      - text: "\nrefs:\n"
+      - loop: ["- *anchor\n", 11000]
+
+- plugin-error:
+    name: alias 5 rejects excessive aliases
+    plugin:
+      limit:
+        alias: 5
+    data:
+      join:
+      - text: 'anchor: &anchor [1, 2, 3]'
+      - text: "\nrefs:\n"
+      - loop: ["- *anchor\n", 200]
+    want: 'go-yaml load error in constructor at L1.C18: exceeded max alias count of 5'
+
+- plugin-pass:
+    name: alias 10000 allows moderate aliases
+    plugin:
+      limit:
+        alias: 10000
+    data:
+      join:
+      - text: 'anchor: &anchor [1, 2, 3]'
+      - text: "\nrefs:\n"
+      - loop: ["- *anchor\n", 200]
+
+- plugin-pass:
+    name: default limits (bare limits key)
+    plugin:
+      limit:
+    data:
+      join:
+      - loop: ['[', 20]
+      - text: 'x'
+      - loop: [']', 20]
+
+- plugin-error:
+    name: default limits reject deep nesting (10001)
+    plugin:
+      limit:
+    data:
+      join:
+      - loop: ['[', 10001]
+      - text: 'x'
+      - loop: [']', 10001]
+    want: 'go-yaml load error in scanner (while increasing flow level) at L1.C10001: exceeded max depth of 10000'

--- a/yaml.go
+++ b/yaml.go
@@ -20,9 +20,11 @@ package yaml
 
 import (
 	"errors"
+	"fmt"
 	"io"
 
 	"go.yaml.in/yaml/v4/internal/libyaml"
+	"go.yaml.in/yaml/v4/plugin/limit"
 )
 
 //-----------------------------------------------------------------------------
@@ -42,6 +44,7 @@ func WithV2Defaults() Option {
 		WithUnicode(true),
 		WithUniqueKeys(true),
 		WithQuotePreference(QuoteLegacy),
+		WithPlugin(limit.New()),
 	)
 }
 
@@ -54,6 +57,7 @@ func WithV3Defaults() Option {
 		WithUnicode(true),
 		WithUniqueKeys(true),
 		WithQuotePreference(QuoteLegacy),
+		WithPlugin(limit.New()),
 	)
 }
 
@@ -66,6 +70,7 @@ func WithV4Defaults() Option {
 		WithUnicode(true),
 		WithUniqueKeys(true),
 		WithQuotePreference(QuoteSingle),
+		WithPlugin(limit.New()),
 	)
 }
 
@@ -254,6 +259,49 @@ func Options(opts ...Option) Option {
 	return libyaml.CombineOptions(opts...)
 }
 
+// DepthKind represents the type of nesting (flow or block).
+type DepthKind = libyaml.DepthKind
+
+// DepthKind constants for nesting depth checks.
+const (
+	DepthKindFlow  = libyaml.DepthKindFlow
+	DepthKindBlock = libyaml.DepthKindBlock
+)
+
+// DepthContext holds context about a nesting depth check.
+type DepthContext = libyaml.DepthContext
+
+// WithPlugin registers one or more plugins for YAML processing.
+//
+// Plugins extend the YAML library with custom processing logic.
+// Each plugin implements one or more plugin interfaces.
+// Currently supported plugin types:
+//   - LimitPlugin: Controls depth and alias expansion limits
+//
+// Example:
+//
+//	import "go.yaml.in/yaml/v4/plugin/limit"
+//	loader := yaml.NewLoader(data, yaml.WithPlugin(limit.New(limit.AliasNone())))
+//
+// Plugins use public types and can be implemented by external packages.
+func WithPlugin(plugins ...any) Option {
+	return func(o *libyaml.Options) error {
+		for _, p := range plugins {
+			registered := false
+			if lp, ok := p.(LimitPlugin); ok {
+				o.DepthCheck = lp.CheckDepth
+				o.AliasCheck = lp.CheckAlias
+				registered = true
+			}
+			// Future plugin types add cases here (non-exclusive if)
+			if !registered {
+				return fmt.Errorf("yaml: unsupported plugin type: %T", p)
+			}
+		}
+		return nil
+	}
+}
+
 // OptsYAML parses a YAML string containing option settings and returns
 // an Option that can be combined with other options using Options().
 //
@@ -270,6 +318,12 @@ func Options(opts ...Option) Option {
 // - known-fields (bool)
 // - single-document (bool)
 // - unique-keys (bool)
+// - plugin (map of plugin name to config)
+//
+// The plugin field configures plugins by name. Each key is a plugin
+// name and the value is its configuration map (or null for defaults).
+// Currently supported: "limit" with keys "depth" and "alias" (int
+// or null to disable).
 //
 // Only fields specified in the YAML will override other options when
 // combined. Unspecified fields won't affect other options.
@@ -279,22 +333,26 @@ func Options(opts ...Option) Option {
 //	opts, err := yaml.OptsYAML(`
 //	  indent: 3
 //	  known-fields: true
+//	  plugin:
+//	    limit:
+//	      depth: 50
 //	`)
 //	yaml.Dump(&data, yaml.Options(V4, opts))
 func OptsYAML(yamlStr string) (Option, error) {
 	var cfg struct {
-		Indent                *int    `yaml:"indent"`
-		CompactSeqIndent      *bool   `yaml:"compact-seq-indent"`
-		LineWidth             *int    `yaml:"line-width"`
-		Unicode               *bool   `yaml:"unicode"`
-		Canonical             *bool   `yaml:"canonical"`
-		LineBreak             *string `yaml:"line-break"`
-		ExplicitStart         *bool   `yaml:"explicit-start"`
-		ExplicitEnd           *bool   `yaml:"explicit-end"`
-		FlowSimpleCollections *bool   `yaml:"flow-simple-coll"`
-		KnownFields           *bool   `yaml:"known-fields"`
-		SingleDocument        *bool   `yaml:"single-document"`
-		UniqueKeys            *bool   `yaml:"unique-keys"`
+		Indent                *int           `yaml:"indent"`
+		CompactSeqIndent      *bool          `yaml:"compact-seq-indent"`
+		LineWidth             *int           `yaml:"line-width"`
+		Unicode               *bool          `yaml:"unicode"`
+		Canonical             *bool          `yaml:"canonical"`
+		LineBreak             *string        `yaml:"line-break"`
+		ExplicitStart         *bool          `yaml:"explicit-start"`
+		ExplicitEnd           *bool          `yaml:"explicit-end"`
+		FlowSimpleCollections *bool          `yaml:"flow-simple-coll"`
+		KnownFields           *bool          `yaml:"known-fields"`
+		SingleDocument        *bool          `yaml:"single-document"`
+		UniqueKeys            *bool          `yaml:"unique-keys"`
+		Plugin                map[string]any `yaml:"plugin"`
 	}
 	if err := Load([]byte(yamlStr), &cfg, WithKnownFields()); err != nil {
 		return nil, err
@@ -345,6 +403,28 @@ func OptsYAML(yamlStr string) (Option, error) {
 			optList = append(optList, WithLineBreak(LineBreakCRLN))
 		default:
 			return nil, errors.New("yaml: invalid line-break value (use ln, cr, or crln)")
+		}
+	}
+
+	for name, val := range cfg.Plugin {
+		switch name {
+		case "limit":
+			var cfgMap map[string]any
+			switch v := val.(type) {
+			case nil:
+				cfgMap = map[string]any{}
+			case map[string]any:
+				cfgMap = v
+			default:
+				return nil, fmt.Errorf("yaml: plugin %q value must be a mapping or null", name)
+			}
+			p, err := limit.NewFromYAML(cfgMap)
+			if err != nil {
+				return nil, err
+			}
+			optList = append(optList, WithPlugin(p))
+		default:
+			return nil, fmt.Errorf("yaml: unknown plugin %q", name)
 		}
 	}
 

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -3124,7 +3124,59 @@ func FuzzEncodeFromJSON(f *testing.F) {
 	})
 }
 
-func TestLimits(t *testing.T) {
+func TestPlugins(t *testing.T) {
+	datatest.RunTestCases(t, func() ([]map[string]any, error) {
+		return datatest.LoadTestCasesFromFile("testdata/plugin.yaml", libyaml.LoadAny)
+	}, map[string]datatest.TestHandler{
+		"plugin-pass":  runPluginTest,
+		"plugin-error": runPluginTest,
+	})
+}
+
+func runPluginTest(t *testing.T, tc map[string]any) {
+	t.Helper()
+
+	// Build YAML string from plugin config for OptsYAML
+	pluginCfg := tc["plugin"]
+	pluginYAML, err := yaml.Dump(map[string]any{"plugin": pluginCfg})
+	if err != nil {
+		t.Fatalf("Failed to marshal plugin config: %v", err)
+	}
+
+	opts, err := yaml.OptsYAML(string(pluginYAML))
+	if err != nil {
+		t.Fatalf("OptsYAML failed: %v", err)
+	}
+
+	// Generate data from spec
+	data, err := datatest.GenerateData(tc["data"])
+	if err != nil {
+		t.Fatalf("Failed to generate data: %v", err)
+	}
+
+	// Load with plugin options
+	var result any
+	err = yaml.Load(data, &result, opts)
+
+	// Check result
+	expectedError := ""
+	if wantVal, hasWant := tc["want"]; hasWant {
+		if s, ok := wantVal.(string); ok {
+			expectedError = s
+		}
+	}
+
+	if expectedError != "" {
+		if err == nil {
+			t.Fatalf("expected error %q, got nil", expectedError)
+		}
+		assert.Equal(t, expectedError, err.Error())
+		return
+	}
+	assert.NoError(t, err)
+}
+
+func TestLimit(t *testing.T) {
 	datatest.RunTestCases(t, func() ([]map[string]any, error) {
 		return datatest.LoadTestCasesFromFile("testdata/limit.yaml", libyaml.LoadAny)
 	}, map[string]datatest.TestHandler{
@@ -3211,7 +3263,7 @@ var limitTests = []struct {
 	{name: "1000kb of 10000-nested lines", data: []byte(strings.Repeat(`- `+strings.Repeat(`[`, 10000)+strings.Repeat(`]`, 10000)+"\n", 1000*1024/20000))},
 }
 
-func BenchmarkLimits(b *testing.B) {
+func BenchmarkLimit(b *testing.B) {
 	for _, tc := range limitTests {
 		tc := tc
 		b.Run(tc.name, func(b *testing.B) {


### PR DESCRIPTION
Add plugin system with Limit plugin API

Introduce a plugin architecture for extending YAML processing.
The first plugin, "limit", provides configurable depth and alias
expansion checks that replace the previously hardcoded limits.

New public API:
- LimitPlugin interface (CheckDepth, CheckAlias)
- WithPlugin() / WithoutPlugin() options
- limit.New() with DepthValue/DepthNone/DepthFunc and 
  AliasValue/AliasNone/AliasFunc options

Refactor internal depth/alias checking from inline logic in
the composer and constructor into pluggable callback functions
on the Options struct. Version presets (V2/V3/V4) default to
limit.New() so existing behavior is preserved.
