### PR TITLE
Add DumpError for all dump stack errors

### DIFF
--- a/internal/libyaml/dumper.go
+++ b/internal/libyaml/dumper.go
@@ -11,7 +11,6 @@ package libyaml
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"reflect"
 )
@@ -78,12 +77,10 @@ func Dump(in any, opts ...Option) (out []byte, err error) {
 		// Multi-document mode: in must be a slice
 		inVal := reflect.ValueOf(in)
 		if inVal.Kind() != reflect.Slice {
-			msg := "yaml: WithAllDocuments requires a slice input"
-			return nil, &LoadErrors{Errors: []*LoadError{{
-				Stage:   ConstructorStage,
-				Message: msg,
-				err:     errors.New(msg),
-			}}}
+			return nil, &DumpError{
+				Stage:   RepresenterStage,
+				Message: "WithAllDocuments requires a slice input",
+			}
 		}
 
 		// Dump each element as a separate document
@@ -139,7 +136,7 @@ func (d *Dumper) Close() (err error) {
 // This is used by the legacy Encoder.SetIndent() method.
 func (d *Dumper) SetIndent(spaces int) {
 	if spaces < 0 {
-		panic("yaml: cannot indent to a negative number of spaces")
+		failDumpf(SerializerStage, "cannot indent to a negative number of spaces")
 	}
 	// Set on serializer's emitter
 	d.serializer.Emitter.BestIndent = spaces

--- a/internal/libyaml/errors.go
+++ b/internal/libyaml/errors.go
@@ -12,16 +12,24 @@ import (
 	"strings"
 )
 
-// Stage identifies the processing stage where an error occurred during YAML loading.
+// Stage identifies the processing stage where an error occurred during YAML
+// loading or dumping.
 type Stage string
 
 const (
+	// Load stages
 	ReaderStage      Stage = "reader"      // Input reading and encoding
 	ScannerStage     Stage = "scanner"     // Tokenization
 	ParserStage      Stage = "parser"      // Event stream parsing
 	ComposerStage    Stage = "composer"    // Node tree construction
 	ResolverStage    Stage = "resolver"    // Tag resolution
 	ConstructorStage Stage = "constructor" // Go value construction
+
+	// Dump stages
+	RepresenterStage Stage = "representer" // Go value to Node tree
+	SerializerStage  Stage = "serializer"  // Node tree to events
+	EmitterStage     Stage = "emitter"     // Events to YAML bytes
+	WriterStage      Stage = "writer"      // Output writing
 )
 
 // LoadError represents an error that occurred while loading a YAML document.
@@ -86,6 +94,45 @@ func NewLoadError(stage Stage, message string, mark Mark, cause error) *LoadErro
 		Mark:    mark,
 		err:     cause,
 	}
+}
+
+// DumpError represents an error that occurred while dumping a YAML document.
+//
+// It identifies the processing stage where the error occurred and provides
+// an optional underlying cause via Unwrap.
+type DumpError struct {
+	Stage   Stage  // Processing stage where error occurred
+	Message string // Error description
+
+	// Error chaining
+	err error // Underlying error (for Unwrap support)
+}
+
+// Error returns the error message with stage information.
+// Format: "go-yaml dump error in <stage>: <message>"
+func (e *DumpError) Error() string {
+	return fmt.Sprintf("go-yaml dump error in %s: %s", e.Stage, e.Message)
+}
+
+// Unwrap returns the underlying error.
+func (e *DumpError) Unwrap() error {
+	return e.err
+}
+
+// NewDumpError creates a DumpError with an underlying cause.
+// The cause is accessible via Unwrap for use with [errors.Is] and [errors.As].
+func NewDumpError(stage Stage, message string, cause error) *DumpError {
+	return &DumpError{Stage: stage, Message: message, err: cause}
+}
+
+// failDump panics with a YAMLError wrapping a DumpError for the given stage.
+func failDump(stage Stage, err error) {
+	panic(&YAMLError{&DumpError{Stage: stage, Message: err.Error(), err: err}})
+}
+
+// failDumpf panics with a YAMLError wrapping a formatted DumpError.
+func failDumpf(stage Stage, format string, args ...any) {
+	panic(&YAMLError{&DumpError{Stage: stage, Message: fmt.Sprintf(format, args...)}})
 }
 
 // EmitterError represents an error that occurred during emitting.

--- a/internal/libyaml/errors.go
+++ b/internal/libyaml/errors.go
@@ -126,11 +126,12 @@ func NewDumpError(stage Stage, message string, cause error) *DumpError {
 }
 
 // failDump panics with a YAMLError wrapping a DumpError for the given stage.
-// If err is already a *DumpError it is passed through unchanged to avoid
+// If err is exactly a *DumpError it is passed through unchanged to avoid
 // double-wrapping (e.g. a user MarshalYAML that returns yaml.NewDumpError).
+// Errors that merely wrap a *DumpError are treated as ordinary errors so that
+// the outer wrapper's message and context are preserved.
 func failDump(stage Stage, err error) {
-	var de *DumpError
-	if errors.As(err, &de) {
+	if de, ok := err.(*DumpError); ok {
 		panic(&YAMLError{de})
 	}
 	panic(&YAMLError{&DumpError{Stage: stage, Message: err.Error(), err: err}})

--- a/internal/libyaml/errors.go
+++ b/internal/libyaml/errors.go
@@ -126,7 +126,13 @@ func NewDumpError(stage Stage, message string, cause error) *DumpError {
 }
 
 // failDump panics with a YAMLError wrapping a DumpError for the given stage.
+// If err is already a *DumpError it is passed through unchanged to avoid
+// double-wrapping (e.g. a user MarshalYAML that returns yaml.NewDumpError).
 func failDump(stage Stage, err error) {
+	var de *DumpError
+	if errors.As(err, &de) {
+		panic(&YAMLError{de})
+	}
 	panic(&YAMLError{&DumpError{Stage: stage, Message: err.Error(), err: err}})
 }
 

--- a/internal/libyaml/errors_test.go
+++ b/internal/libyaml/errors_test.go
@@ -66,16 +66,22 @@ func runDumpErrorTest(t *testing.T, tc TestCase) {
 	assert.Truef(t, ok, "from should be map[string]any, got %T", tc.From)
 
 	err := buildDumpError(t, errorSpec)
-	assert.NotNilf(t, err, "buildDumpError should not return nil")
+	if err == nil {
+		t.Fatal("buildDumpError returned nil")
+	}
 	got := err.Error()
 	want, ok := tc.Want.(string)
 	assert.Truef(t, ok, "want should be string, got %T", tc.Want)
 
 	assert.Equalf(t, want, got, "error message mismatch")
 
-	// Verify Stage field if specified
-	if stageStr, ok := errorSpec["stage"].(string); ok {
-		assert.Equalf(t, Stage(stageStr), err.Stage, "Stage mismatch")
+	// Verify Stage field if specified; fail if defined but not a string
+	if stageVal, hasStage := errorSpec["stage"]; hasStage {
+		stageStr, ok := stageVal.(string)
+		assert.Truef(t, ok, "stage should be string, got %T", stageVal)
+		if ok {
+			assert.Equalf(t, Stage(stageStr), err.Stage, "Stage mismatch")
+		}
 	}
 
 	// Test Unwrap if specified

--- a/internal/libyaml/errors_test.go
+++ b/internal/libyaml/errors_test.go
@@ -66,6 +66,7 @@ func runDumpErrorTest(t *testing.T, tc TestCase) {
 	assert.Truef(t, ok, "from should be map[string]any, got %T", tc.From)
 
 	err := buildDumpError(t, errorSpec)
+	assert.NotNilf(t, err, "buildDumpError should not return nil")
 	got := err.Error()
 	want, ok := tc.Want.(string)
 	assert.Truef(t, ok, "want should be string, got %T", tc.Want)

--- a/internal/libyaml/errors_test.go
+++ b/internal/libyaml/errors_test.go
@@ -16,6 +16,7 @@ import (
 func TestErrors(t *testing.T) {
 	RunTestCases(t, "errors.yaml", map[string]TestHandler{
 		"load-error":     runLoadErrorTest,
+		"dump-error":     runDumpErrorTest,
 		"emitter-error":  runEmitterYAMLErrorTest,
 		"writer-error":   runWriterYAMLErrorTest,
 		"load-errors":    runLoadErrorsTest,
@@ -56,6 +57,54 @@ func runLoadErrorTest(t *testing.T, tc TestCase) {
 			}
 		}
 	}
+}
+
+func runDumpErrorTest(t *testing.T, tc TestCase) {
+	t.Helper()
+
+	errorSpec, ok := tc.From.(map[string]any)
+	assert.Truef(t, ok, "from should be map[string]any, got %T", tc.From)
+
+	err := buildDumpError(t, errorSpec)
+	got := err.Error()
+	want, ok := tc.Want.(string)
+	assert.Truef(t, ok, "want should be string, got %T", tc.Want)
+
+	assert.Equalf(t, want, got, "error message mismatch")
+
+	// Verify Stage field if specified
+	if stageStr, ok := errorSpec["stage"].(string); ok {
+		assert.Equalf(t, Stage(stageStr), err.Stage, "Stage mismatch")
+	}
+
+	// Test Unwrap if specified
+	if tc.Also == "unwrap" {
+		unwrapped := err.Unwrap()
+		if err.err != nil {
+			assert.NotNilf(t, unwrapped, "Unwrap() should return non-nil when err is set")
+			assert.Equalf(t, err.err.Error(), unwrapped.Error(), "Unwrap() error message mismatch")
+		} else {
+			if unwrapped != nil {
+				t.Fatalf("Unwrap() should return nil when err is not set, got %v", unwrapped)
+			}
+		}
+	}
+}
+
+func buildDumpError(t *testing.T, spec map[string]any) *DumpError {
+	t.Helper()
+
+	err := &DumpError{
+		Stage:   Stage(getString(t, spec, "stage")),
+		Message: getString(t, spec, "message"),
+	}
+
+	// Add underlying error if specified
+	if errMsg, ok := spec["err"].(string); ok {
+		err.err = errors.New(errMsg)
+	}
+
+	return err
 }
 
 func runEmitterYAMLErrorTest(t *testing.T, tc TestCase) {

--- a/internal/libyaml/representer.go
+++ b/internal/libyaml/representer.go
@@ -9,7 +9,6 @@ package libyaml
 
 import (
 	"encoding"
-	"fmt"
 	"reflect"
 	"regexp"
 	"sort"
@@ -99,7 +98,7 @@ func (r *Representer) represent(tag string, in reflect.Value) *Node {
 	case Marshaler:
 		v, err := value.MarshalYAML()
 		if err != nil {
-			Fail(err)
+			failDump(RepresenterStage, err)
 		}
 		if v == nil {
 			return r.nilv()
@@ -108,7 +107,7 @@ func (r *Representer) represent(tag string, in reflect.Value) *Node {
 	case encoding.TextMarshaler:
 		text, err := value.MarshalText()
 		if err != nil {
-			Fail(err)
+			failDump(RepresenterStage, err)
 		}
 		in = reflect.ValueOf(string(text))
 	case nil:
@@ -136,7 +135,8 @@ func (r *Representer) represent(tag string, in reflect.Value) *Node {
 	case reflect.Bool:
 		return r.boolv(tag, in)
 	default:
-		panic("cannot represent type: " + in.Type().String())
+		failDumpf(RepresenterStage, "cannot represent type: %s", in.Type().String())
+		return nil // unreachable; failDumpf always panics
 	}
 }
 
@@ -172,7 +172,7 @@ func (r *Representer) mapv(tag string, in reflect.Value) *Node {
 func (r *Representer) structv(tag string, in reflect.Value) *Node {
 	sinfo, err := getStructInfo(in.Type())
 	if err != nil {
-		panic(err)
+		failDump(RepresenterStage, err)
 	}
 
 	if tag == "" {
@@ -210,7 +210,7 @@ func (r *Representer) structv(tag string, in reflect.Value) *Node {
 			sort.Sort(keys)
 			for _, k := range keys {
 				if _, found := sinfo.FieldsMap[k.String()]; found {
-					panic(fmt.Sprintf("cannot have key %q in inlined map: conflicts with struct field", k.String()))
+					failDumpf(RepresenterStage, "cannot have key %q in inlined map: conflicts with struct field", k.String())
 				}
 				content = append(content, r.represent("", k))
 				r.flow = false
@@ -262,10 +262,10 @@ func (r *Representer) stringv(tag string, in reflect.Value) *Node {
 	switch {
 	case !utf8.ValidString(s):
 		if tag == binaryTag {
-			failf("explicitly tagged !!binary data must be base64-encoded")
+			failDumpf(RepresenterStage, "explicitly tagged !!binary data must be base64-encoded")
 		}
 		if tag != "" {
-			failf("cannot represent invalid UTF-8 data as %s", shortTag(tag))
+			failDumpf(RepresenterStage, "cannot represent invalid UTF-8 data as %s", shortTag(tag))
 		}
 		// It can't be represented directly as YAML so use a binary tag
 		// and represent it as base64.

--- a/internal/libyaml/serializer.go
+++ b/internal/libyaml/serializer.go
@@ -9,6 +9,7 @@ package libyaml
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"unicode/utf8"
@@ -233,27 +234,28 @@ func (s *Serializer) emit(event Event) {
 
 // must panics if the given error is non-nil, routing to the appropriate stage.
 func (s *Serializer) must(err error) {
-	if err != nil {
-		var ee EmitterError
-		if errors.As(err, &ee) {
-			failDumpf(EmitterStage, "%s", ee.Message)
-		}
-		var we WriterError
-		if errors.As(err, &we) {
-			// Unwrap to get the original I/O error, stripping the
-			// "write error: " prefix that WriterError adds internally.
-			cause := we.Err
-			if unwrapped := errors.Unwrap(we.Err); unwrapped != nil {
-				cause = unwrapped
-			}
-			failDump(WriterStage, cause)
-		}
-		msg := err.Error()
-		if msg == "" {
-			msg = "unknown problem generating YAML content"
-		}
-		failDumpf(SerializerStage, "%s", msg)
+	if err == nil {
+		return
 	}
+	var ee EmitterError
+	if errors.As(err, &ee) {
+		failDumpf(EmitterStage, "%s", ee.Message)
+	}
+	var we WriterError
+	if errors.As(err, &we) {
+		// Unwrap to get the original I/O error, stripping the
+		// "write error: " prefix that WriterError adds internally.
+		cause := we.Err
+		if unwrapped := errors.Unwrap(we.Err); unwrapped != nil {
+			cause = unwrapped
+		}
+		failDump(WriterStage, cause)
+	}
+	msg := err.Error()
+	if msg == "" {
+		msg = fmt.Sprintf("unknown problem generating YAML content with %T", err)
+	}
+	failDumpf(SerializerStage, "%s", msg)
 }
 
 // emitScalar emits a scalar event with the given value, anchor, tag, style,

--- a/internal/libyaml/serializer.go
+++ b/internal/libyaml/serializer.go
@@ -8,6 +8,7 @@
 package libyaml
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"unicode/utf8"
@@ -192,10 +193,10 @@ func (s *Serializer) node(node *Node, tail string) {
 		if !utf8.ValidString(value) {
 			stag := shortTag(tag)
 			if stag == binaryTag {
-				failf("explicitly tagged !!binary data must be base64-encoded")
+				failDumpf(SerializerStage, "explicitly tagged !!binary data must be base64-encoded")
 			}
 			if stag != "" {
-				failf("cannot marshal invalid UTF-8 data as %s", stag)
+				failDumpf(SerializerStage, "cannot marshal invalid UTF-8 data as %s", stag)
 			}
 			// It can't be represented directly as YAML so use a binary tag
 			// and represent it as base64.
@@ -221,7 +222,7 @@ func (s *Serializer) node(node *Node, tail string) {
 
 		s.emitScalar(value, node.Anchor, tag, style, []byte(node.HeadComment), []byte(node.LineComment), []byte(node.FootComment), []byte(tail))
 	default:
-		failf("cannot represent node with unknown kind %d", node.Kind)
+		failDumpf(SerializerStage, "cannot represent node with unknown kind %d", node.Kind)
 	}
 }
 
@@ -230,14 +231,27 @@ func (s *Serializer) emit(event Event) {
 	s.must(s.Emitter.Emit(&event))
 }
 
-// must panics if the given error is non-nil.
+// must panics if the given error is non-nil, routing to the appropriate stage.
 func (s *Serializer) must(err error) {
 	if err != nil {
-		msg := err.Error()
-		if msg == "" {
-			msg = "unknown problem generating YAML content"
+		switch e := err.(type) {
+		case EmitterError:
+			failDumpf(EmitterStage, "%s", e.Message)
+		case WriterError:
+			// Unwrap to get the original I/O error, stripping the
+			// "write error: " prefix that WriterError adds internally.
+			cause := e.Err
+			if unwrapped := errors.Unwrap(e.Err); unwrapped != nil {
+				cause = unwrapped
+			}
+			failDump(WriterStage, cause)
+		default:
+			msg := err.Error()
+			if msg == "" {
+				msg = "unknown problem generating YAML content"
+			}
+			failDumpf(SerializerStage, "%s", msg)
 		}
-		failf("%s", msg)
 	}
 }
 

--- a/internal/libyaml/serializer.go
+++ b/internal/libyaml/serializer.go
@@ -234,24 +234,25 @@ func (s *Serializer) emit(event Event) {
 // must panics if the given error is non-nil, routing to the appropriate stage.
 func (s *Serializer) must(err error) {
 	if err != nil {
-		switch e := err.(type) {
-		case EmitterError:
-			failDumpf(EmitterStage, "%s", e.Message)
-		case WriterError:
+		var ee EmitterError
+		if errors.As(err, &ee) {
+			failDumpf(EmitterStage, "%s", ee.Message)
+		}
+		var we WriterError
+		if errors.As(err, &we) {
 			// Unwrap to get the original I/O error, stripping the
 			// "write error: " prefix that WriterError adds internally.
-			cause := e.Err
-			if unwrapped := errors.Unwrap(e.Err); unwrapped != nil {
+			cause := we.Err
+			if unwrapped := errors.Unwrap(we.Err); unwrapped != nil {
 				cause = unwrapped
 			}
 			failDump(WriterStage, cause)
-		default:
-			msg := err.Error()
-			if msg == "" {
-				msg = "unknown problem generating YAML content"
-			}
-			failDumpf(SerializerStage, "%s", msg)
 		}
+		msg := err.Error()
+		if msg == "" {
+			msg = "unknown problem generating YAML content"
+		}
+		failDumpf(SerializerStage, "%s", msg)
 	}
 }
 

--- a/internal/libyaml/testdata/errors.yaml
+++ b/internal/libyaml/testdata/errors.yaml
@@ -134,6 +134,47 @@
     want: 'go-yaml load error in constructor at <unknown position>: cannot construct value'
     also: unwrap
 
+# DumpError tests - dump stages
+
+- dump-error:
+    name: Representer stage error
+    from:
+      stage: representer
+      message: cannot represent type chan int
+    want: 'go-yaml dump error in representer: cannot represent type chan int'
+
+- dump-error:
+    name: Representer stage error with cause
+    from:
+      stage: representer
+      message: 'MarshalYAML failed: some error'
+      err: 'some error'
+    want: "go-yaml dump error in representer: MarshalYAML failed: some error"
+    also: unwrap
+
+- dump-error:
+    name: Serializer stage error
+    from:
+      stage: serializer
+      message: cannot represent node with unknown kind 99
+    want: 'go-yaml dump error in serializer: cannot represent node with unknown kind 99'
+
+- dump-error:
+    name: Emitter stage error
+    from:
+      stage: emitter
+      message: expected STREAM-START
+    want: 'go-yaml dump error in emitter: expected STREAM-START'
+
+- dump-error:
+    name: Writer stage error with cause
+    from:
+      stage: writer
+      message: write error
+      err: write error
+    want: 'go-yaml dump error in writer: write error'
+    also: unwrap
+
 # EmitterError tests (dump stack)
 
 - emitter-error:

--- a/node_test.go
+++ b/node_test.go
@@ -280,7 +280,7 @@ func TestNodeZeroEncodeDecode(t *testing.T) {
 	// Kind zero is still unknown, though.
 	n.Line = 1
 	_, err = yaml.Marshal(&n)
-	assert.ErrorMatches(t, "yaml: cannot represent node with unknown kind 0", err)
+	assert.ErrorMatches(t, "go-yaml dump error in serializer: cannot represent node with unknown kind 0", err)
 	err = n.Load(&v)
 	assert.ErrorMatches(t, `go-yaml load error in constructor at L1: cannot construct node with unknown kind: '0'`, err)
 }
@@ -297,7 +297,7 @@ func TestNodeOmitEmpty(t *testing.T) {
 
 	v.B.Line = 1
 	_, err = yaml.Marshal(&v)
-	assert.ErrorMatches(t, "yaml: cannot represent node with unknown kind 0", err)
+	assert.ErrorMatches(t, "go-yaml dump error in serializer: cannot represent node with unknown kind 0", err)
 }
 
 // NodeInfo represents the information about a YAML node in a test-friendly format

--- a/yaml.go
+++ b/yaml.go
@@ -462,17 +462,25 @@ const (
 	EncodingUTF16BE = libyaml.UTF16BE_ENCODING
 )
 
-// Stage identifies the processing stage where an error occurred during YAML loading.
+// Stage identifies the processing stage where an error occurred during YAML
+// loading or dumping.
 type Stage = libyaml.Stage
 
 // Stage constants for YAML processing pipeline.
 const (
+	// Load stages
 	ReaderStage      = libyaml.ReaderStage      // Input reading and encoding
 	ScannerStage     = libyaml.ScannerStage     // Tokenization
 	ParserStage      = libyaml.ParserStage      // Event stream parsing
 	ComposerStage    = libyaml.ComposerStage    // Node tree construction
 	ResolverStage    = libyaml.ResolverStage    // Tag resolution
 	ConstructorStage = libyaml.ConstructorStage // Go value construction
+
+	// Dump stages
+	RepresenterStage = libyaml.RepresenterStage // Go value to Node tree
+	SerializerStage  = libyaml.SerializerStage  // Node tree to events
+	EmitterStage     = libyaml.EmitterStage     // Events to YAML bytes
+	WriterStage      = libyaml.WriterStage      // Output writing
 )
 
 // Mark represents a position in the YAML document.
@@ -491,6 +499,12 @@ type (
 	// It contains multiple *[LoadError] instances with details about each error.
 	LoadErrors = libyaml.LoadErrors
 
+	// DumpError represents an error that occurred while dumping a YAML document.
+	//
+	// It identifies the processing stage where the error occurred and provides
+	// an optional underlying cause via Unwrap.
+	DumpError = libyaml.DumpError
+
 	// TypeError is a legacy error type retained for compatibility.
 	//
 	// Deprecated: Use [LoadErrors] instead.
@@ -502,6 +516,10 @@ type (
 // NewLoadError creates a LoadError with an underlying cause error.
 // The cause is accessible via Unwrap for use with [errors.Is] and [errors.As].
 var NewLoadError = libyaml.NewLoadError
+
+// NewDumpError creates a DumpError with an underlying cause error.
+// The cause is accessible via Unwrap for use with [errors.Is] and [errors.As].
+var NewDumpError = libyaml.NewDumpError
 
 // LineBreak represents the line ending style for YAML output.
 type LineBreak = libyaml.LineBreak

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -2446,7 +2446,10 @@ func TestEncoderMultipleDocuments(t *testing.T) {
 func TestEncoderWriteError(t *testing.T) {
 	enc := yaml.NewEncoder(errorWriter{})
 	err := enc.Encode(map[string]string{"a": "b"})
-	assert.ErrorMatches(t, `yaml: write error: some write error`, err) // Data not flushed yet
+	assert.ErrorMatches(t, `go-yaml dump error in writer: some write error`, err)
+	var dumpErr *yaml.DumpError
+	assert.True(t, errors.As(err, &dumpErr))
+	assert.Equal(t, yaml.WriterStage, dumpErr.Stage)
 }
 
 type errorWriter struct{}
@@ -2458,31 +2461,32 @@ func (errorWriter) Write([]byte) (int, error) {
 var marshalErrorTests = []struct {
 	value any
 	error string
-	panic string
+	stage yaml.Stage
 }{{
 	value: &struct {
 		B       int
 		inlineB `yaml:",inline"`
 	}{1, inlineB{2, inlineC{3}}},
 	//nolint:dupword // struct is duplicated here as the first one is the struct and the second is the name of the inline struct
-	panic: `duplicated key 'b' in struct struct \{ B int; .*`,
+	error: `go-yaml dump error in representer: duplicated key 'b' in struct struct \{ B int; .*`,
+	stage: yaml.RepresenterStage,
 }, {
 	value: &struct {
 		A int
 		B map[string]int `yaml:",inline"`
 	}{1, map[string]int{"a": 2}},
-	panic: `cannot have key "a" in inlined map: conflicts with struct field`,
+	error: `go-yaml dump error in representer: cannot have key "a" in inlined map: conflicts with struct field`,
+	stage: yaml.RepresenterStage,
 }}
 
 func TestMarshalErrors(t *testing.T) {
 	for _, item := range marshalErrorTests {
-		t.Run(item.panic, func(t *testing.T) {
-			if item.panic != "" {
-				assert.PanicMatches(t, item.panic, func() { yaml.Marshal(item.value) })
-			} else {
-				_, err := yaml.Marshal(item.value)
-				assert.ErrorMatches(t, item.error, err)
-			}
+		t.Run(item.error, func(t *testing.T) {
+			_, err := yaml.Marshal(item.value)
+			assert.ErrorMatches(t, item.error, err)
+			var dumpErr *yaml.DumpError
+			assert.True(t, errors.As(err, &dumpErr))
+			assert.Equal(t, item.stage, dumpErr.Stage)
 		})
 	}
 }
@@ -2558,7 +2562,7 @@ func (ft *failingMarshaler) MarshalYAML() (any, error) {
 
 func TestMarshalerError(t *testing.T) {
 	_, err := yaml.Marshal(&failingMarshaler{})
-	assert.ErrorIs(t, errFailing, err)
+	assert.ErrorIs(t, err, errFailing)
 }
 
 func TestSetIndent(t *testing.T) {


### PR DESCRIPTION
Introduce DumpError as the unified error type for the dump pipeline, mirroring the LoadError pattern added in PR #311 for the load stack.

## Motivation

Before this change the dump stack had no structured error type: errors escaped as a mix of bare panics (raw strings or raw error values), untyped fmt.Errorf strings from failf(), EmitterError, WriterError, and — incorrectly — LoadErrors/LoadError in dumper.go.  None of these were introspectable by callers: you couldn't tell which stage failed or extract the underlying cause without string-matching.

## What changed

### New types and helpers (internal/libyaml/errors.go)

* Four new Stage constants covering the dump pipeline: RepresenterStage, SerializerStage, EmitterStage, WriterStage.
* DumpError struct: Stage + Message + unexported err for Unwrap(). Error() format: "go-yaml dump error in <stage>: <message>".
* NewDumpError(stage, message, cause) public constructor.
* failDump(stage, err)  — wraps an existing error as DumpError.
* failDumpf(stage, fmt, args...) — formats a new DumpError message. Both helpers panic with *YAMLError so handleErr catches them and returns them as ordinary Go errors.

### representer.go — 7 error sites converted

| was | now |
|-----|-----|
| Fail(err) (MarshalYAML) | failDump(RepresenterStage, err) | | Fail(err) (MarshalText) | failDump(RepresenterStage, err) | | panic("cannot represent type: …") | failDumpf(RepresenterStage, …) | | panic(err) (getStructInfo) | failDump(RepresenterStage, err) | | panic(fmt.Sprintf("cannot have key…")) | failDumpf(RepresenterStage, …) | | failf("explicitly tagged !!binary…") | failDumpf(RepresenterStage, …) | | failf("cannot represent invalid UTF-8…") | failDumpf(RepresenterStage, …) |

The three bare panics (type, getStructInfo, inline-map key) previously escaped handleErr; they now become returned *DumpError values.  Unused fmt import removed.

### serializer.go — 3 error sites + must() rewritten

The three failf() calls in node() are now failDumpf(SerializerStage,…).

must() previously collapsed all emitter/writer errors into a single untyped failf string.  It now type-switches on the error:
* EmitterError  → failDumpf(EmitterStage, e.Message)
* WriterError   → failDump(WriterStage, unwrapped-cause)
  (errors.Unwrap strips the "write error: " prefix that writer.go adds
  so that WriterStage in the DumpError already communicates that context)
* default       → failDumpf(SerializerStage, msg)

### dumper.go — 2 fixes

* Lines 77-86: the AllDocuments slice-check incorrectly returned a LoadErrors/LoadError (load-stack types).  Replaced with a plain DumpError{Stage: RepresenterStage}.
* SetIndent: bare panic("yaml: cannot indent…") replaced with failDumpf(SerializerStage, …) for consistent error type. (SetIndent has no handleErr so the panic still propagates, but it is now a *YAMLError wrapping *DumpError instead of a raw string.) Unused errors import removed.

### yaml.go — public API additions

* Stage doc comment updated to cover load and dump.
* Four new Stage constants re-exported (RepresenterStage …WriterStage).
* DumpError type alias added to the error-types block.
* NewDumpError var added alongside NewLoadError.

## Tests

* errors_test.go: runDumpErrorTest handler + buildDumpError helper, registered under the "dump-error" key.
* testdata/errors.yaml: 5 new dump-error test cases covering all four dump stages and Unwrap behaviour.
* yaml_test.go TestMarshalErrors: changed from PanicMatches to ErrorMatches + errors.As checks now that the bare panics are caught. Test struct field renamed panic→stage to reflect the new approach.
* yaml_test.go TestEncoderWriteError: updated expected message from "yaml: write error: …" to "go-yaml dump error in writer: …" and added errors.As / Stage assertions.
* yaml_test.go TestMarshalerError: fixed argument order in ErrorIs (was assert.ErrorIs(t, errFailing, err); now assert.ErrorIs(t, err, errFailing)) — the old order was accidentally correct only because the returned error was the raw errFailing; now it is a DumpError that wraps errFailing via Unwrap().
* node_test.go: two ErrorMatches expectations updated to the new "go-yaml dump error in serializer: …" format.