### PR TITLE
Remove redundant float regex capturing groups

### DIFF
--- a/internal/libyaml/resolver.go
+++ b/internal/libyaml/resolver.go
@@ -198,7 +198,7 @@ var negativeZero = math.Copysign(0.0, -1.0)
 
 // yamlStyleFloat matches floating-point numbers in YAML style (including
 // scientific notation and numbers starting with a dot).
-var yamlStyleFloat = regexp.MustCompile(`^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$`)
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?)(?:[eE][-+]?[0-9]+)?$`)
 
 // allowedTimestampFormats lists the timestamp formats supported by the
 // resolver.


### PR DESCRIPTION
Capturing groups have a performance overhead over and allocate more than non-capturing ones.

I've no numbers for this repo, but some samples at https://github.com/scop/regex-groups-bench