### PR TITLE
Add perfsprint linter, address findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
   - modernize
   - nilnesserr
   - nolintlint
+  - perfsprint
   - staticcheck
   - thelper
   - unconvert

--- a/cmd/go-yaml/event.go
+++ b/cmd/go-yaml/event.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 
 	"go.yaml.in/yaml/v4"
 	"go.yaml.in/yaml/v4/internal/libyaml"
@@ -122,12 +123,12 @@ func processEventsDecode(reader io.Reader, profuse, compact bool) error {
 			if info.Implicit != nil {
 				compactNode.Content = append(compactNode.Content,
 					&yaml.Node{Kind: yaml.ScalarNode, Value: "implicit"},
-					&yaml.Node{Kind: yaml.ScalarNode, Value: fmt.Sprintf("%t", *info.Implicit)})
+					&yaml.Node{Kind: yaml.ScalarNode, Value: strconv.FormatBool(*info.Implicit)})
 			}
 			if info.Explicit != nil {
 				compactNode.Content = append(compactNode.Content,
 					&yaml.Node{Kind: yaml.ScalarNode, Value: "explicit"},
-					&yaml.Node{Kind: yaml.ScalarNode, Value: fmt.Sprintf("%t", *info.Explicit)})
+					&yaml.Node{Kind: yaml.ScalarNode, Value: strconv.FormatBool(*info.Explicit)})
 			}
 			if info.Head != "" {
 				compactNode.Content = append(compactNode.Content,
@@ -242,12 +243,12 @@ func processEventsUnmarshal(reader io.Reader, profuse, compact bool) error {
 			if info.Implicit != nil {
 				compactNode.Content = append(compactNode.Content,
 					&yaml.Node{Kind: yaml.ScalarNode, Value: "implicit"},
-					&yaml.Node{Kind: yaml.ScalarNode, Value: fmt.Sprintf("%t", *info.Implicit)})
+					&yaml.Node{Kind: yaml.ScalarNode, Value: strconv.FormatBool(*info.Implicit)})
 			}
 			if info.Explicit != nil {
 				compactNode.Content = append(compactNode.Content,
 					&yaml.Node{Kind: yaml.ScalarNode, Value: "explicit"},
-					&yaml.Node{Kind: yaml.ScalarNode, Value: fmt.Sprintf("%t", *info.Explicit)})
+					&yaml.Node{Kind: yaml.ScalarNode, Value: strconv.FormatBool(*info.Explicit)})
 			}
 			if info.Head != "" {
 				compactNode.Content = append(compactNode.Content,

--- a/cmd/go-yaml/main.go
+++ b/cmd/go-yaml/main.go
@@ -72,10 +72,10 @@ func initOptionRegistry() {
 		"indent": {typ: "int", handler: func(value string) ([]yaml.Option, error) {
 			var val int
 			if _, err := fmt.Sscanf(value, "%d", &val); err != nil {
-				return nil, fmt.Errorf("indent requires integer value (2-9)")
+				return nil, errors.New("indent requires integer value (2-9)")
 			}
 			if val < 2 || val > 9 {
-				return nil, fmt.Errorf("indent must be between 2 and 9")
+				return nil, errors.New("indent must be between 2 and 9")
 			}
 			return []yaml.Option{yaml.WithIndent(val)}, nil
 		}},
@@ -90,14 +90,14 @@ func initOptionRegistry() {
 		"line-width": {typ: "int", handler: func(value string) ([]yaml.Option, error) {
 			var val int
 			if _, err := fmt.Sscanf(value, "%d", &val); err != nil {
-				return nil, fmt.Errorf("line-width requires integer value")
+				return nil, errors.New("line-width requires integer value")
 			}
 			return []yaml.Option{yaml.WithLineWidth(val)}, nil
 		}},
 		"width": {typ: "int", handler: func(value string) ([]yaml.Option, error) {
 			var val int
 			if _, err := fmt.Sscanf(value, "%d", &val); err != nil {
-				return nil, fmt.Errorf("width requires integer value")
+				return nil, errors.New("width requires integer value")
 			}
 			return []yaml.Option{yaml.WithLineWidth(val)}, nil
 		}},
@@ -127,7 +127,7 @@ func initOptionRegistry() {
 			case "crln":
 				lb = yaml.LineBreakCRLN
 			default:
-				return nil, fmt.Errorf("line-break must be ln, cr, or crln")
+				return nil, errors.New("line-break must be ln, cr, or crln")
 			}
 			return []yaml.Option{yaml.WithLineBreak(lb)}, nil
 		}},

--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -10,6 +10,7 @@ package libyaml
 import (
 	"encoding"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -478,7 +479,7 @@ func (c *Constructor) scalar(n *Node, out reflect.Value) bool {
 			data, err := base64.StdEncoding.DecodeString(resolved.(string))
 			if err != nil {
 				Fail(formatConstructorError(
-					fmt.Errorf("!!binary value contains invalid base64 data"),
+					errors.New("!!binary value contains invalid base64 data"),
 					Mark{Line: n.Line, Column: n.Column},
 				))
 			}
@@ -845,7 +846,7 @@ func isMerge(n *Node) bool {
 // failWantMap panics with an error message for invalid merge key values.
 func failWantMap(n *Node) {
 	Fail(formatConstructorError(
-		fmt.Errorf("map merge requires map or sequence of maps as the value"),
+		errors.New("map merge requires map or sequence of maps as the value"),
 		Mark{Line: n.Line, Column: n.Column},
 	))
 }

--- a/internal/libyaml/errors.go
+++ b/internal/libyaml/errors.go
@@ -95,7 +95,7 @@ type EmitterError struct {
 
 // Error returns the error message.
 func (e EmitterError) Error() string {
-	return fmt.Sprintf("yaml: %s", e.Message)
+	return "yaml: " + e.Message
 }
 
 // WriterError represents an error that occurred while writing output.
@@ -179,7 +179,7 @@ type TypeError struct {
 
 // Error returns a formatted error message listing all unmarshal errors.
 func (e *TypeError) Error() string {
-	return fmt.Sprintf("yaml: unmarshal errors: %s", strings.Join(e.Errors, "; "))
+	return "yaml: unmarshal errors: " + strings.Join(e.Errors, "; ")
 }
 
 // YAMLError is an internal error wrapper type.

--- a/internal/testutil/assert/assert_test.go
+++ b/internal/testutil/assert/assert_test.go
@@ -26,7 +26,7 @@ func TestAssertDeepEqual_Success(t *testing.T) {
 }
 
 func TestErrorMatches_Success(t *testing.T) {
-	err := fmt.Errorf("http 404: not found")
+	err := errors.New("http 404: not found")
 	ErrorMatches(t, `http \d+: not found`, err)
 }
 
@@ -54,7 +54,7 @@ func TestIsNil_NotNil_Success(t *testing.T) {
 
 func TestPanicMatches_Success(t *testing.T) {
 	PanicMatches(t, `boom \d+`, func() { panic("boom 123") })
-	PanicMatches(t, `fail xyz`, func() { panic(fmt.Errorf("fail xyz")) })
+	PanicMatches(t, `fail xyz`, func() { panic(errors.New("fail xyz")) })
 }
 
 func TestAssertTrueAndFalse_Success(t *testing.T) {
@@ -142,23 +142,23 @@ func TestErrorMatches_Fails(t *testing.T) {
 
 	// invalid regexp (message may include parser details; check prefix)
 	mockTB2 := &fakeTB{}
-	ErrorMatches(mockTB2, `(`, fmt.Errorf("x"))
+	ErrorMatches(mockTB2, `(`, errors.New("x"))
 	assertFailureMessageMatches(t, mockTB2, `^invalid regexp "`)
 
 	// no match
 	mockTB3 := &fakeTB{}
-	ErrorMatches(mockTB3, `def`, fmt.Errorf("abc"))
+	ErrorMatches(mockTB3, `def`, errors.New("abc"))
 	assertFailureMessageMatches(t, mockTB3, `^error "abc" does not match "def"$`)
 }
 
 func TestAssertNoError_Fails(t *testing.T) {
 	m := &fakeTB{}
-	NoError(m, fmt.Errorf("problem"))
+	NoError(m, errors.New("problem"))
 	assertFailureMessageMatches(t, m, `^unexpected error: problem$`)
 }
 
 func TestErrorIs_Success(t *testing.T) {
-	base := fmt.Errorf("base error")
+	base := errors.New("base error")
 	wrapped := fmt.Errorf("wrap: %w", base)
 	// direct match
 	ErrorIs(t, base, base)
@@ -171,8 +171,8 @@ func TestErrorIs_Success(t *testing.T) {
 func TestErrorIs_Fails(t *testing.T) {
 	// mismatch
 	mock1 := &fakeTB{}
-	base := fmt.Errorf("base")
-	other := fmt.Errorf("other")
+	base := errors.New("base")
+	other := errors.New("other")
 	ErrorIs(mock1, base, other)
 	assertFailureMessageMatches(t, mock1, `got &errors.errorString{s:"base"}; want &errors.errorString{s:"other"}`)
 

--- a/internal/testutil/datatest/helpers.go
+++ b/internal/testutil/datatest/helpers.go
@@ -8,6 +8,7 @@ package datatest
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -188,7 +189,7 @@ func GenerateData(spec any) ([]byte, error) {
 		return result, nil
 	}
 
-	return nil, fmt.Errorf("data spec must have 'loop' or 'join' field")
+	return nil, errors.New("data spec must have 'loop' or 'join' field")
 }
 
 // generateSimpleLoop generates test data by repeating a string value n times.

--- a/internal/testutil/datatest/loader.go
+++ b/internal/testutil/datatest/loader.go
@@ -8,6 +8,7 @@
 package datatest
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -126,7 +127,7 @@ func UnmarshalStruct(target any, data map[string]any) error {
 // setField sets a [reflect.Value] from an interface{} value
 func setField(field reflect.Value, value any) error {
 	if !field.CanSet() {
-		return fmt.Errorf("field cannot be set")
+		return errors.New("field cannot be set")
 	}
 
 	if value == nil {
@@ -173,7 +174,7 @@ func setField(field reflect.Value, value any) error {
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		if !field.CanInt() {
-			return fmt.Errorf("field cannot store int values")
+			return errors.New("field cannot store int values")
 		}
 		if !valueRefl.CanInt() {
 			return fmt.Errorf("field type %v expects an integer value, but got %T", fieldType, value)
@@ -186,7 +187,7 @@ func setField(field reflect.Value, value any) error {
 		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		if !field.CanUint() {
-			return fmt.Errorf("field cannot store uint values")
+			return errors.New("field cannot store uint values")
 		}
 		// Check for negative integers first (most specific error case)
 		if valueRefl.CanInt() && valueRefl.Int() < 0 {
@@ -215,7 +216,7 @@ func setField(field reflect.Value, value any) error {
 		return nil
 	case reflect.Float32, reflect.Float64:
 		if !field.CanFloat() {
-			return fmt.Errorf("field cannot store float values")
+			return errors.New("field cannot store float values")
 		}
 		if !valueRefl.CanFloat() {
 			return fmt.Errorf("field type %v expects a floating-point value, but got %T", fieldType, value)
@@ -234,7 +235,7 @@ func setField(field reflect.Value, value any) error {
 		// Recursively unmarshal nested structs
 		if m, ok := value.(map[string]any); ok {
 			if !field.CanAddr() {
-				return fmt.Errorf("cannot take address of field for nested struct unmarshaling")
+				return errors.New("cannot take address of field for nested struct unmarshaling")
 			}
 			return UnmarshalStruct(field.Addr().Interface(), m)
 		}
@@ -384,7 +385,7 @@ func setMapField(field reflect.Value, value any) error {
 
 	mapType := field.Type()
 	if mapType.Key().Kind() != reflect.String {
-		return fmt.Errorf("only string keys supported for maps")
+		return errors.New("only string keys supported for maps")
 	}
 
 	newMap := reflect.MakeMap(mapType)

--- a/node_test.go
+++ b/node_test.go
@@ -9,6 +9,7 @@ package yaml_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -325,7 +326,7 @@ func isStandardTag(tag string) bool {
 // parseNodeInfo converts a NodeInfo structure into a yaml.Node
 func parseNodeInfo(info *NodeInfo) (*yaml.Node, error) {
 	if info == nil {
-		return nil, fmt.Errorf("nil NodeInfo")
+		return nil, errors.New("nil NodeInfo")
 	}
 
 	node := &yaml.Node{}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1499,7 +1499,7 @@ func TestMerge(t *testing.T) {
 
 	wantStringMap := make(map[string]any)
 	for k, v := range want {
-		wantStringMap[fmt.Sprintf("%v", k)] = v
+		wantStringMap[k] = v
 	}
 
 	var m map[any]any
@@ -2399,7 +2399,7 @@ func TestEncoderWriteError(t *testing.T) {
 type errorWriter struct{}
 
 func (errorWriter) Write([]byte) (int, error) {
-	return 0, fmt.Errorf("some write error")
+	return 0, errors.New("some write error")
 }
 
 var marshalErrorTests = []struct {


### PR DESCRIPTION
None of the findings here are in hot paths, but they don't hurt readability or otherwise IMHO, so why not.