### PR TITLE
Hide legacy loader and dumper setters

### DIFF
--- a/internal/libyaml/dumper.go
+++ b/internal/libyaml/dumper.go
@@ -135,9 +135,10 @@ func (d *Dumper) Close() (err error) {
 	return nil
 }
 
-// SetIndent changes the indentation used when encoding.
-// This is used by the legacy Encoder.SetIndent() method.
-func (d *Dumper) SetIndent(spaces int) {
+// SetLegacyEncoderIndent allows changing the indentation for the legacy Encoder API.
+//
+// Note: This is not a method on Dumper to avoid exposing it; callers should use [WithIndent] instead.
+func SetLegacyEncoderIndent(d *Dumper, spaces int) {
 	if spaces < 0 {
 		panic("yaml: cannot indent to a negative number of spaces")
 	}
@@ -145,8 +146,9 @@ func (d *Dumper) SetIndent(spaces int) {
 	d.serializer.Emitter.BestIndent = spaces
 }
 
-// SetCompactSeqIndent controls whether '- ' is considered part of the indentation.
-// This is used by the legacy Encoder methods.
-func (d *Dumper) SetCompactSeqIndent(compact bool) {
+// SetLegacyEncoderCompactSeqIndent allows changing the compact sequence indentation for the legacy Encoder API.
+//
+// Note: This is not a method on Dumper to avoid exposing it; callers should use [WithCompactSeqIndent] instead.
+func SetLegacyEncoderCompactSeqIndent(d *Dumper, compact bool) {
 	d.serializer.Emitter.CompactSequenceIndent = compact
 }

--- a/internal/libyaml/loader.go
+++ b/internal/libyaml/loader.go
@@ -257,10 +257,10 @@ func loadSingle(in []byte, out any, opts *Options) error {
 	return nil
 }
 
-// SetKnownFields enables or disables strict field checking for subsequent Load
-// calls.
-// This is used by the legacy Decoder.KnownFields() method.
-func (l *Loader) SetKnownFields(enable bool) {
+// SetLegacyLoaderKnownFields allows changing the known fields setting from the legacy Decoder API.
+//
+// Note: This is not a method on Loader to avoid exposing it; callers should use [WithKnownFields] instead.
+func SetLegacyLoaderKnownFields(l *Loader, enable bool) {
 	l.constructor.KnownFields = enable
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -579,7 +579,7 @@ func NewDecoder(r io.Reader) *Decoder {
 // KnownFields ensures that the keys in decoded mappings to
 // exist as fields in the struct being decoded into.
 func (dec *Decoder) KnownFields(enable bool) {
-	dec.loader.SetKnownFields(enable)
+	libyaml.SetLegacyLoaderKnownFields(dec.loader, enable)
 }
 
 // Decode reads the next YAML-encoded value from its input
@@ -618,17 +618,17 @@ func (e *Encoder) Encode(v any) error {
 
 // SetIndent changes the used indentation used when encoding.
 func (e *Encoder) SetIndent(spaces int) {
-	e.dumper.SetIndent(spaces)
+	libyaml.SetLegacyEncoderIndent(e.dumper, spaces)
 }
 
 // CompactSeqIndent makes it so that '- ' is considered part of the indentation.
 func (e *Encoder) CompactSeqIndent() {
-	e.dumper.SetCompactSeqIndent(true)
+	libyaml.SetLegacyEncoderCompactSeqIndent(e.dumper, true)
 }
 
 // DefaultSeqIndent makes it so that '- ' is not considered part of the indentation.
 func (e *Encoder) DefaultSeqIndent() {
-	e.dumper.SetCompactSeqIndent(false)
+	libyaml.SetLegacyEncoderCompactSeqIndent(e.dumper, false)
 }
 
 // Close closes the encoder by writing any remaining data.


### PR DESCRIPTION
Move the known-fields and indentation helpers used by the legacy Decoder and Encoder APIs off Loader and Dumper methods and into dedicated legacy-only functions.

This keeps legacy compatibility behavior intact while avoiding those setters being advertised as part of the newer Loader and Dumper APIs.

The modern APIs should continue to favor options such as WithKnownFields, WithIndent, and WithCompactSeqIndent.

This is a breaking change compared to earlier rc releases, and that is intentional: we do not want to maintain legacy-only setters in the new public API surface.

The underlying issue is that Loader and Dumper are publicly re-exported type aliases, so methods added for legacy internals also became public.

This change decouples the legacy call path from that public surface.