### PR TITLE
Fix shared aliases behavior between documents

### DIFF
--- a/internal/libyaml/composer.go
+++ b/internal/libyaml/composer.go
@@ -137,6 +137,9 @@ func (c *Composer) node(kind Kind, tag, value string) *Node {
 // document composes a document node by parsing its content between
 // DOCUMENT_START and DOCUMENT_END events.
 func (c *Composer) document() *Node {
+	// Anchors are scoped to a single document.
+	c.resetAnchors()
+
 	n := c.node(DocumentNode, "", "")
 	c.doc = n
 	c.expect(DOCUMENT_START_EVENT)
@@ -271,7 +274,7 @@ func (c *Composer) init() {
 	if c.doneInit {
 		return
 	}
-	c.anchors = make(map[string]*Node)
+	c.resetAnchors()
 	// Peek to get the encoding from STREAM_START_EVENT
 	if c.peek() == STREAM_START_EVENT {
 		c.encoding = c.event.GetEncoding()
@@ -283,6 +286,10 @@ func (c *Composer) init() {
 	if c.streamNodes {
 		c.returnStream = true
 	}
+}
+
+func (c *Composer) resetAnchors() {
+	c.anchors = make(map[string]*Node)
 }
 
 // Destroy cleans up the composer by deleting any pending event and the

--- a/internal/libyaml/composer.go
+++ b/internal/libyaml/composer.go
@@ -137,6 +137,9 @@ func (c *Composer) node(kind Kind, tag, value string) *Node {
 // document composes a document node by parsing its content between
 // DOCUMENT_START and DOCUMENT_END events.
 func (c *Composer) document() *Node {
+	// Anchors are scoped to a single document.
+	c.resetAnchors()
+
 	n := c.node(DocumentNode, "", "")
 	c.doc = n
 	c.expect(DOCUMENT_START_EVENT)
@@ -276,7 +279,7 @@ func (c *Composer) init() {
 	if c.doneInit {
 		return
 	}
-	c.anchors = make(map[string]*Node)
+	c.resetAnchors()
 	// Peek to get the encoding from STREAM_START_EVENT
 	if c.peek() == STREAM_START_EVENT {
 		c.encoding = c.event.GetEncoding()
@@ -288,6 +291,10 @@ func (c *Composer) init() {
 	if c.streamNodes {
 		c.returnStream = true
 	}
+}
+
+func (c *Composer) resetAnchors() {
+	c.anchors = make(map[string]*Node)
 }
 
 // Destroy cleans up the composer by deleting any pending event and the

--- a/testdata/decoder.yaml
+++ b/testdata/decoder.yaml
@@ -1,0 +1,74 @@
+# Copyright 2026 The go-yaml Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Decoder test cases for go-yaml
+#
+# Purpose: Tests yaml.Decoder stream decoding into Go values.
+#
+# Format: Test cases use type-as-key format:
+#   - decoder:
+#       name: Test case name
+#       yaml: YAML input string
+#       want: Expected sequence of decoded document values
+#   - decoder-error:
+#       name: Test case name
+#       yaml: YAML input string
+#       want: Expected error message
+
+- decoder:
+    name: empty stream
+    yaml: ''
+    want: []
+
+- decoder:
+    name: single implicit document
+    yaml: 'a: b'
+    want:
+    - a: b
+
+- decoder:
+    name: single explicit document
+    yaml: |
+      ---
+      a: b
+      ...
+    want:
+    - a: b
+
+- decoder:
+    name: multiple explicit documents
+    yaml: |
+      ---
+      'hello'
+      ...
+      ---
+      goodbye
+      ...
+    want:
+    - hello
+    - goodbye
+
+- decoder:
+    name: anchors reset between documents
+    yaml: |
+      ---
+      a: &anchor 1
+      b: *anchor
+      ---
+      a: &anchor 2
+      b: *anchor
+      ...
+    want:
+    - a: 1
+      b: 1
+    - a: 2
+      b: 2
+
+- decoder-error:
+    name: anchor not shared across documents
+    yaml: |
+      ---
+      &foo 42
+      ---
+      *foo
+    want: "go-yaml load error in composer at L4.C1: unknown anchor 'foo' referenced"

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -767,6 +767,12 @@ var decoderTests = []struct {
 		"hello",
 		"goodbye",
 	},
+}, {
+	"---\na: &anchor 1\nb: *anchor\n---\na: &anchor 2\nb: *anchor\n...\n",
+	[]any{
+		map[string]any{"a": 1, "b": 1},
+		map[string]any{"a": 2, "b": 2},
+	},
 }}
 
 func TestDecoder(t *testing.T) {
@@ -786,6 +792,20 @@ func TestDecoder(t *testing.T) {
 			assert.DeepEqual(t, item.values, values)
 		})
 	}
+}
+
+func TestDecoderAnchorNotSharedAcrossDocuments(t *testing.T) {
+	data := "---\n&foo 42\n---\n*foo\n"
+	dec := yaml.NewDecoder(strings.NewReader(data))
+
+	var first any
+	err := dec.Decode(&first)
+	assert.NoError(t, err)
+	assert.Equal(t, 42, first)
+
+	var second any
+	err = dec.Decode(&second)
+	assert.ErrorMatches(t, `go-yaml load error in composer at L4\.C1: unknown anchor 'foo' referenced`, err)
 }
 
 type errReader struct{}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -767,6 +767,12 @@ var decoderTests = []struct {
 		"hello",
 		"goodbye",
 	},
+}, {
+	"---\na: &anchor 1\nb: *anchor\n---\na: &anchor 2\nb: *anchor\n...\n",
+	[]any{
+		map[string]any{"a": 1, "b": 1},
+		map[string]any{"a": 2, "b": 2},
+	},
 }}
 
 func TestDecoder(t *testing.T) {
@@ -841,6 +847,20 @@ func TestDecoderZeroDocumentStreams(t *testing.T) {
 			assert.Equal(t, "keep", value)
 		})
 	}
+}
+
+func TestDecoderAnchorNotSharedAcrossDocuments(t *testing.T) {
+	data := "---\n&foo 42\n---\n*foo\n"
+	dec := yaml.NewDecoder(strings.NewReader(data))
+
+	var first any
+	err := dec.Decode(&first)
+	assert.NoError(t, err)
+	assert.Equal(t, 42, first)
+
+	var second any
+	err = dec.Decode(&second)
+	assert.ErrorMatches(t, `go-yaml load error in composer at L4\.C1: unknown anchor 'foo' referenced`, err)
 }
 
 type errReader struct{}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -745,52 +745,55 @@ func TestDecoderSingleDocument(t *testing.T) {
 	}
 }
 
-var decoderTests = []struct {
-	data   string
-	values []any
-}{{
-	"",
-	nil,
-}, {
-	"a: b",
-	[]any{
-		map[string]any{"a": "b"},
-	},
-}, {
-	"---\na: b\n...\n",
-	[]any{
-		map[string]any{"a": "b"},
-	},
-}, {
-	"---\n'hello'\n...\n---\ngoodbye\n...\n",
-	[]any{
-		"hello",
-		"goodbye",
-	},
-}, {
-	"---\na: &anchor 1\nb: *anchor\n---\na: &anchor 2\nb: *anchor\n...\n",
-	[]any{
-		map[string]any{"a": 1, "b": 1},
-		map[string]any{"a": 2, "b": 2},
-	},
-}}
-
 func TestDecoder(t *testing.T) {
-	for i, item := range decoderTests {
-		t.Run(fmt.Sprintf("test %d: %q", i, item.data), func(t *testing.T) {
-			var values []any
-			dec := yaml.NewDecoder(strings.NewReader(item.data))
-			for {
-				var value any
-				err := dec.Decode(&value)
-				if err == io.EOF {
-					break
-				}
-				assert.NoError(t, err)
-				values = append(values, value)
-			}
-			assert.DeepEqual(t, item.values, values)
-		})
+	datatest.RunTestCases(t, func() ([]map[string]any, error) {
+		return datatest.LoadTestCasesFromFile("testdata/decoder.yaml", libyaml.LoadAny)
+	}, map[string]datatest.TestHandler{
+		"decoder":       runDecoderTest,
+		"decoder-error": runDecoderErrorTest,
+	})
+}
+
+func runDecoderTest(t *testing.T, tc map[string]any) {
+	t.Helper()
+
+	yamlInput := datatest.RequireString(t, tc, "yaml")
+	want := datatest.RequireSlice(t, tc, "want")
+
+	var values []any
+	dec := yaml.NewDecoder(strings.NewReader(yamlInput))
+	for {
+		var value any
+		err := dec.Decode(&value)
+		if err == io.EOF {
+			break
+		}
+		assert.NoError(t, err)
+		values = append(values, value)
+	}
+	if values == nil {
+		values = []any{}
+	}
+	assert.DeepEqual(t, want, values)
+}
+
+func runDecoderErrorTest(t *testing.T, tc map[string]any) {
+	t.Helper()
+
+	yamlInput := datatest.RequireString(t, tc, "yaml")
+	want := datatest.RequireString(t, tc, "want")
+
+	dec := yaml.NewDecoder(strings.NewReader(yamlInput))
+	for {
+		var value any
+		err := dec.Decode(&value)
+		if err == io.EOF {
+			t.Fatalf("got EOF; want error %q", want)
+		}
+		if err != nil {
+			assert.Equal(t, want, err.Error())
+			return
+		}
 	}
 }
 
@@ -847,20 +850,6 @@ func TestDecoderZeroDocumentStreams(t *testing.T) {
 			assert.Equal(t, "keep", value)
 		})
 	}
-}
-
-func TestDecoderAnchorNotSharedAcrossDocuments(t *testing.T) {
-	data := "---\n&foo 42\n---\n*foo\n"
-	dec := yaml.NewDecoder(strings.NewReader(data))
-
-	var first any
-	err := dec.Decode(&first)
-	assert.NoError(t, err)
-	assert.Equal(t, 42, first)
-
-	var second any
-	err = dec.Decode(&second)
-	assert.ErrorMatches(t, `go-yaml load error in composer at L4\.C1: unknown anchor 'foo' referenced`, err)
 }
 
 type errReader struct{}


### PR DESCRIPTION
Considering the YAML specification mentions that all documents are independent, alias should not be shared between documents

```console
$ cat /tmp/alias-bug.yaml
---
&foo 42
---
*foo
```

```console
$ ./go-yaml -t /tmp/alias-bug.yaml
- {token: STREAM-START}
- {token: DOCUMENT-START}
- {token: ANCHOR, value: foo}
- {token: SCALAR, value: 42}
- {token: DOCUMENT-START}
- {token: ALIAS, value: foo}
- {token: STREAM-END}
```

Before:

```console
$ ./go-yaml -y /tmp/alias-bug.yaml
42
---
42
```

After

```console
$ ./go-yaml -y /tmp/alias-bug.yaml
Failed to process YAML:failed to decode YAML: go-yaml load error in composer at L4.C1: unknown anchor 'foo' referenced
```

Fixes #328