### PR TITLE
Fix: option KnownFields not being respected inside custom UnmarshalYAML()

### DIFF
--- a/internal/libyaml/loader.go
+++ b/internal/libyaml/loader.go
@@ -139,8 +139,8 @@ func (l *Loader) Load(v any) (err error) {
 	// Stage 2: Resolve - determine implicit types for untagged scalars
 	l.resolver.Resolve(node)
 
-	// Propagate loader options onto every node so that Node.Decode called inside
-	// custom UnmarshalYAML implementations inherits settings like KnownFields.
+	// Propagate a snapshot of loader options onto every node so that Node.Decode called
+	// inside custom UnmarshalYAML implementations inherits settings like KnownFields
 	propagateLoadOptions(node, l.options)
 
 	// Stage 3: Construct - convert node tree to Go values
@@ -164,9 +164,14 @@ func propagateLoadOptions(n *Node, opts *Options) {
 	if n == nil || opts == nil {
 		return
 	}
+	snapshot := *opts // pass a snapshot to avoid data race
+	propagateLoadOptionsRecursion(n, &snapshot)
+}
+
+func propagateLoadOptionsRecursion(n *Node, opts *Options) {
 	n.options = opts
 	for _, child := range n.Content {
-		propagateLoadOptions(child, opts)
+		propagateLoadOptionsRecursion(child, opts)
 	}
 }
 
@@ -299,6 +304,10 @@ func (l *Loader) ComposeAndResolve() *Node {
 
 	// Stage 2: Resolve - determine implicit types for untagged scalars
 	l.resolver.Resolve(node)
+
+	// Propagate a snapshot of loader options onto every node so that Node.Decode called
+	// inside custom UnmarshalYAML implementations inherits settings like KnownFields
+	propagateLoadOptions(node, l.options)
 
 	return node
 }

--- a/internal/libyaml/loader.go
+++ b/internal/libyaml/loader.go
@@ -139,6 +139,10 @@ func (l *Loader) Load(v any) (err error) {
 	// Stage 2: Resolve - determine implicit types for untagged scalars
 	l.resolver.Resolve(node)
 
+	// Propagate loader options onto every node so that Node.Decode called inside
+	// custom UnmarshalYAML implementations inherits settings like KnownFields.
+	propagateLoadOptions(node, filterLoadOptions(l.options))
+
 	// Stage 3: Construct - convert node tree to Go values
 	out := reflect.ValueOf(v)
 	if out.Kind() == reflect.Pointer && !out.IsNil() {
@@ -151,6 +155,31 @@ func (l *Loader) Load(v any) (err error) {
 		return &LoadErrors{Errors: typeErrors}
 	}
 	return nil
+}
+
+// filterLoadOptions returns opts when it contains settings that NewConstructor
+// reads and that would change behaviour relative to DefaultOptions.
+// Returns nil for default options so propagateLoadOptions can skip the walk entirely.
+// Update this function whenever a new option is added that affects construction.
+func filterLoadOptions(opts *Options) *Options {
+	if opts.KnownFields || !opts.UniqueKeys || opts.AliasCheck != nil {
+		return opts
+	}
+	return nil
+}
+
+// propagateLoadOptions stamps n and every node reachable through Content with opts.
+// Alias pointers are not followed: in valid YAML, anchors are defined before
+// their aliases, so the anchor node is always reachable through Content
+// traversal before any AliasNode that references it is encountered.
+func propagateLoadOptions(n *Node, opts *Options) {
+	if n == nil || opts == nil {
+		return
+	}
+	n.options = opts
+	for _, child := range n.Content {
+		propagateLoadOptions(child, opts)
+	}
 }
 
 // loadAll loads all documents from the input into a slice.

--- a/internal/libyaml/loader.go
+++ b/internal/libyaml/loader.go
@@ -291,6 +291,7 @@ func loadSingle(in []byte, out any, opts *Options) error {
 // This is used by the legacy Decoder.KnownFields() method.
 func (l *Loader) SetKnownFields(enable bool) {
 	l.constructor.KnownFields = enable
+	l.options.KnownFields = enable
 }
 
 // ComposeAndResolve composes and resolves the next document from the input

--- a/internal/libyaml/loader.go
+++ b/internal/libyaml/loader.go
@@ -141,7 +141,7 @@ func (l *Loader) Load(v any) (err error) {
 
 	// Propagate loader options onto every node so that Node.Decode called inside
 	// custom UnmarshalYAML implementations inherits settings like KnownFields.
-	propagateLoadOptions(node, filterLoadOptions(l.options))
+	propagateLoadOptions(node, l.options)
 
 	// Stage 3: Construct - convert node tree to Go values
 	out := reflect.ValueOf(v)
@@ -157,21 +157,9 @@ func (l *Loader) Load(v any) (err error) {
 	return nil
 }
 
-// filterLoadOptions returns opts when it contains settings that NewConstructor
-// reads and that would change behaviour relative to DefaultOptions.
-// Returns nil for default options so propagateLoadOptions can skip the walk entirely.
-// Update this function whenever a new option is added that affects construction.
-func filterLoadOptions(opts *Options) *Options {
-	if opts.KnownFields || !opts.UniqueKeys || opts.AliasCheck != nil {
-		return opts
-	}
-	return nil
-}
-
 // propagateLoadOptions stamps n and every node reachable through Content with opts.
 // Alias pointers are not followed: in valid YAML, anchors are defined before
-// their aliases, so the anchor node is always reachable through Content
-// traversal before any AliasNode that references it is encountered.
+// their aliases, so the anchor node is always reachable through n.Content traversal.
 func propagateLoadOptions(n *Node, opts *Options) {
 	if n == nil || opts == nil {
 		return

--- a/internal/libyaml/loader_test.go
+++ b/internal/libyaml/loader_test.go
@@ -275,3 +275,27 @@ func TestLoad_MultipleDocuments(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.ErrorMatches(t, ".*expected single document, found multiple.*", err)
 }
+
+// TestComposeAndResolveDoesNotPropagateOptions tests that ComposeAndResolve does not
+// propagate loader options onto the returned node tree.
+func TestComposeAndResolveDoesNotPropagateOptions(t *testing.T) {
+	type target struct {
+		Name string `yaml:"name"`
+	}
+
+	input := []byte("name: Alice\nunknown_field: oops\n")
+	loader, err := NewLoader(bytes.NewReader(input), WithKnownFields())
+	assert.NoError(t, err)
+
+	node := loader.ComposeAndResolve()
+	assert.NotNil(t, node)
+
+	// options is nil: ComposeAndResolve does not call propagateLoadOptions
+	assert.IsNil(t, node.options)
+
+	// Node.Decode uses DefaultOptions, so unknown fields are not rejected
+	var v target
+	err = node.Decode(&v)
+	assert.NoError(t, err)
+	assert.Equal(t, "Alice", v.Name)
+}

--- a/internal/libyaml/loader_test.go
+++ b/internal/libyaml/loader_test.go
@@ -276,9 +276,11 @@ func TestLoad_MultipleDocuments(t *testing.T) {
 	assert.ErrorMatches(t, ".*expected single document, found multiple.*", err)
 }
 
-// TestComposeAndResolveDoesNotPropagateOptions tests that ComposeAndResolve does not
-// propagate loader options onto the returned node tree.
-func TestComposeAndResolveDoesNotPropagateOptions(t *testing.T) {
+// TestComposeAndResolvePropagatesOptions tests that ComposeAndResolve propagates
+// a snapshot of the loader options onto the returned node tree so that
+// Node.Decode inside custom UnmarshalYAML implementations respects settings
+// like KnownFields.
+func TestComposeAndResolvePropagatesOptions(t *testing.T) {
 	type target struct {
 		Name string `yaml:"name"`
 	}
@@ -289,13 +291,10 @@ func TestComposeAndResolveDoesNotPropagateOptions(t *testing.T) {
 
 	node := loader.ComposeAndResolve()
 	assert.NotNil(t, node)
+	assert.NotNil(t, node.options)
 
-	// options is nil: ComposeAndResolve does not call propagateLoadOptions
-	assert.IsNil(t, node.options)
-
-	// Node.Decode uses DefaultOptions, so unknown fields are not rejected
 	var v target
 	err = node.Decode(&v)
-	assert.NoError(t, err)
-	assert.Equal(t, "Alice", v.Name)
+	assert.NotNil(t, err)
+	assert.ErrorMatches(t, ".*unknown_field.*", err)
 }

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -285,12 +285,12 @@ func (n *Node) SetString(s string) {
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
 func (n *Node) Decode(v any) (err error) {
+	defer handleErr(&err)
 	opts := DefaultOptions
 	if n.options != nil {
 		opts = n.options
 	}
 	d := NewConstructor(opts)
-	defer handleErr(&err)
 	out := reflect.ValueOf(v)
 	if out.Kind() == reflect.Pointer && !out.IsNil() {
 		out = out.Elem()

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -190,9 +190,9 @@ type Node struct {
 	// Stream holds stream metadata (non-nil only when Kind == StreamNode).
 	Stream *Stream
 
-	// options is set by propagateLoadOptions when a Loader produces this node.
-	// It carries the loader options so that Decode can inherit them inside
-	// custom UnmarshalYAML implementations. Nil for user-constructed nodes.
+	// options is set by propagateLoadOptions when a Loader produces this node. It carries
+	// the loader options so that Decode can inherit them in custom UnmarshalYAML functions.
+	// Is typically nil for user-constructed nodes.
 	options *Options
 }
 

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -196,7 +196,9 @@ type Node struct {
 	options *Options
 }
 
-// IsZero returns whether the node has all of its fields unset.
+// IsZero returns whether the node has all of its user-visible fields unset.
+// The unexported options field is intentionally excluded: it is set by loader
+// infrastructure and does not represent user-visible content.
 func (n *Node) IsZero() bool {
 	return n.Kind == 0 && n.Style == 0 && n.Tag == "" && n.Value == "" && n.Anchor == "" && n.Alias == nil && n.Content == nil &&
 		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0 &&

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -307,8 +307,10 @@ func (n *Node) Decode(v any) (err error) {
 // Load decodes the node and stores its data into the value pointed to by v,
 // applying the given options.
 //
-// This method is useful when you need to preserve options like WithKnownFields()
-// inside custom UnmarshalYAML implementations.
+// Unlike Decode, Load does not inherit options from the loader that produced
+// this node; the caller must supply all required options explicitly.
+// This method is useful when you need explicit control over options like
+// WithKnownFields() inside custom UnmarshalYAML implementations.
 //
 // Maps and pointers (to a struct, string, int, etc) are accepted as v
 // values. If an internal pointer within a struct is not initialized,

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -189,6 +189,11 @@ type Node struct {
 
 	// Stream holds stream metadata (non-nil only when Kind == StreamNode).
 	Stream *Stream
+
+	// options is set by propagateLoadOptions when a Loader produces this node.
+	// It carries the loader options so that Decode can inherit them inside
+	// custom UnmarshalYAML implementations. Nil for user-constructed nodes.
+	options *Options
 }
 
 // IsZero returns whether the node has all of its fields unset.
@@ -280,7 +285,11 @@ func (n *Node) SetString(s string) {
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
 func (n *Node) Decode(v any) (err error) {
-	d := NewConstructor(DefaultOptions)
+	opts := DefaultOptions
+	if n.options != nil {
+		opts = n.options
+	}
+	d := NewConstructor(opts)
 	defer handleErr(&err)
 	out := reflect.ValueOf(v)
 	if out.Kind() == reflect.Pointer && !out.IsNil() {

--- a/node_test.go
+++ b/node_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"go.yaml.in/yaml/v4"
@@ -862,4 +863,81 @@ func TestNodeDecodeInheritsKnownFields(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.ErrorMatches(t, ".*unknown_field.*", err)
 	})
+
+	t.Run("known fields enforced on all documents", func(t *testing.T) {
+		input := "name: Alice\n---\nname: Bob\nunknown_field: oops\n"
+		dec := yaml.NewDecoder(bytes.NewReader([]byte(input)))
+		dec.KnownFields(true)
+
+		var v1 nodeDecodeTarget
+		err := dec.Decode(&v1)
+		assert.NoError(t, err)
+		assert.Equal(t, "Alice", v1.Name)
+
+		var v2 nodeDecodeTarget
+		err = dec.Decode(&v2)
+		assert.NotNil(t, err)
+		assert.ErrorMatches(t, ".*unknown_field.*", err)
+	})
+
+	t.Run("known fields can be disabled between documents", func(t *testing.T) {
+		input := "name: Alice\n---\nname: Bob\nunknown_field: ok\n"
+		dec := yaml.NewDecoder(bytes.NewReader([]byte(input)))
+		dec.KnownFields(true)
+
+		var v1 nodeDecodeTarget
+		err := dec.Decode(&v1)
+		assert.NoError(t, err)
+		assert.Equal(t, "Alice", v1.Name)
+
+		dec.KnownFields(false)
+
+		var v2 nodeDecodeTarget
+		err = dec.Decode(&v2)
+		assert.NoError(t, err)
+		assert.Equal(t, "Bob", v2.Name)
+	})
+}
+
+type raceDecodeTarget struct {
+	Name     string `yaml:"name"`
+	onDecode func()
+}
+
+func (t *raceDecodeTarget) UnmarshalYAML(node *yaml.Node) error {
+	if t.onDecode != nil {
+		t.onDecode()
+	}
+	type plain struct {
+		Name string `yaml:"name"`
+	}
+	var p plain
+	if err := node.Decode(&p); err != nil {
+		return err
+	}
+	t.Name = p.Name
+	return nil
+}
+
+// TestSetKnownFieldsRaceWithNodeDecode checks for a data race between Decoder.KnownFields()
+// and Node.Decode() inside UnmarshalYAML (run with '-race')
+func TestSetKnownFieldsRaceWithNodeDecode(t *testing.T) {
+	input := "name: Alice\n"
+	dec := yaml.NewDecoder(bytes.NewReader([]byte(input)))
+	dec.KnownFields(true)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	v := &raceDecodeTarget{
+		onDecode: func() {
+			// Concurrently toggle KnownFields while node.Decode reads the same
+			// options pointer below.
+			go func() {
+				defer wg.Done()
+				dec.KnownFields(false)
+			}()
+		},
+	}
+	_ = dec.Decode(v)
+	wg.Wait()
 }

--- a/node_test.go
+++ b/node_test.go
@@ -784,3 +784,72 @@ func TestNodeDumpInvalidOptions(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.ErrorMatches(t, ".*indent must be.*", err)
 }
+
+type nodeDecodeTarget struct {
+	Name string `yaml:"name"`
+}
+
+func (t *nodeDecodeTarget) UnmarshalYAML(node *yaml.Node) error {
+	type plain nodeDecodeTarget
+	return node.Decode((*plain)(t))
+}
+
+type nodeDecodeChildInner struct {
+	Name string `yaml:"name"`
+}
+
+type nodeDecodeChildOuter struct {
+	Inner nodeDecodeChildInner
+}
+
+func (o *nodeDecodeChildOuter) UnmarshalYAML(node *yaml.Node) error {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == "inner" {
+			return node.Content[i+1].Decode(&o.Inner)
+		}
+	}
+	return nil
+}
+
+func TestNodeDecodeInheritsKnownFields(t *testing.T) {
+	t.Run("known fields rejected", func(t *testing.T) {
+		input := "name: Alice\nunknown_field: oops\n"
+		var v nodeDecodeTarget
+		err := yaml.Load([]byte(input), &v, yaml.WithKnownFields())
+		assert.NotNil(t, err)
+		assert.ErrorMatches(t, ".*unknown_field.*", err)
+	})
+
+	t.Run("unknown fields ignored without option", func(t *testing.T) {
+		input := "name: Alice\nunknown_field: oops\n"
+		var v nodeDecodeTarget
+		err := yaml.Unmarshal([]byte(input), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "Alice", v.Name)
+	})
+
+	t.Run("user-constructed node uses default options", func(t *testing.T) {
+		node := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Tag:  "!!map",
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "name"},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "Bob"},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "extra"},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "ignored"},
+			},
+		}
+		var v nodeDecodeChildInner
+		err := node.Decode(&v)
+		assert.NoError(t, err)
+		assert.Equal(t, "Bob", v.Name)
+	})
+
+	t.Run("child node inherits known fields", func(t *testing.T) {
+		input := "inner:\n  name: Carol\n  unknown_field: oops\n"
+		var v nodeDecodeChildOuter
+		err := yaml.Load([]byte(input), &v, yaml.WithKnownFields())
+		assert.NotNil(t, err)
+		assert.ErrorMatches(t, ".*unknown_field.*", err)
+	})
+}

--- a/node_test.go
+++ b/node_test.go
@@ -930,8 +930,6 @@ func TestSetKnownFieldsRaceWithNodeDecode(t *testing.T) {
 	wg.Add(1)
 	v := &raceDecodeTarget{
 		onDecode: func() {
-			// Concurrently toggle KnownFields while node.Decode reads the same
-			// options pointer below.
 			go func() {
 				defer wg.Done()
 				dec.KnownFields(false)

--- a/node_test.go
+++ b/node_test.go
@@ -852,4 +852,14 @@ func TestNodeDecodeInheritsKnownFields(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.ErrorMatches(t, ".*unknown_field.*", err)
 	})
+
+	t.Run("known fields via decoder api", func(t *testing.T) {
+		input := "name: Alice\nunknown_field: oops\n"
+		var v nodeDecodeTarget
+		dec := yaml.NewDecoder(bytes.NewReader([]byte(input)))
+		dec.KnownFields(true)
+		err := dec.Decode(&v)
+		assert.NotNil(t, err)
+		assert.ErrorMatches(t, ".*unknown_field.*", err)
+	})
 }

--- a/yaml_bench_test.go
+++ b/yaml_bench_test.go
@@ -54,7 +54,8 @@ func BenchmarkDecode(b *testing.B) {
 				dec := yaml.NewDecoder(bytes.NewReader(data))
 				dec.KnownFields(known)
 				return dec.Decode(&v)
-			}},
+			},
+		},
 		{
 			name: "custom",
 			decode: func(data []byte, known bool) error {
@@ -62,7 +63,8 @@ func BenchmarkDecode(b *testing.B) {
 				dec := yaml.NewDecoder(bytes.NewReader(data))
 				dec.KnownFields(known)
 				return dec.Decode(&v)
-			}},
+			},
+		},
 	}
 
 	options := []struct {

--- a/yaml_bench_test.go
+++ b/yaml_bench_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 The go-yaml Project Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	yaml "go.yaml.in/yaml/v4"
+)
+
+// benchPlain is a decode target with no custom UnmarshalYAML.
+type benchPlain struct {
+	Fields map[string]string `yaml:",inline"`
+}
+
+// benchCustom is a decode target whose UnmarshalYAML calls node.Decode —
+// the path that will inherit loader options after the tree-stamp fix.
+type benchCustom struct {
+	Fields map[string]string `yaml:",inline"`
+}
+
+func (b *benchCustom) UnmarshalYAML(node *yaml.Node) error {
+	type plain benchCustom
+	return node.Decode((*plain)(b))
+}
+
+func makeKVDoc(n int) []byte {
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "key%d: value%d\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+var (
+	benchSmallDoc  = makeKVDoc(10)
+	benchMediumDoc = makeKVDoc(100)
+	benchLargeDoc  = makeKVDoc(1000)
+)
+
+func BenchmarkDecode(b *testing.B) {
+	targets := []struct {
+		name   string
+		decode func(data []byte, known bool) error
+	}{
+		{
+			name: "plain",
+			decode: func(data []byte, known bool) error {
+				var v benchPlain
+				dec := yaml.NewDecoder(bytes.NewReader(data))
+				dec.KnownFields(known)
+				return dec.Decode(&v)
+			}},
+		{
+			name: "custom",
+			decode: func(data []byte, known bool) error {
+				var v benchCustom
+				dec := yaml.NewDecoder(bytes.NewReader(data))
+				dec.KnownFields(known)
+				return dec.Decode(&v)
+			}},
+	}
+
+	options := []struct {
+		name        string
+		knownFields bool
+	}{
+		{"default", false},
+		{"known-fields", true},
+	}
+
+	sizes := []struct {
+		name string
+		data []byte
+	}{
+		{"small", benchSmallDoc},
+		{"medium", benchMediumDoc},
+		{"large", benchLargeDoc},
+	}
+
+	for _, size := range sizes {
+		for _, target := range targets {
+			for _, opt := range options {
+				size, target, opt := size, target, opt
+				name := fmt.Sprintf("target=%s/option=%s/size=%s", target.name, opt.name, size.name)
+				b.Run(name, func(b *testing.B) {
+					b.ReportAllocs()
+					for i := 0; i < b.N; i++ {
+						if err := target.decode(size.data, opt.knownFields); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
When a type implements `UnmarshalYAML` and calls `node.Decode()` inside it, the
loader options (e.g. `KnownFields`) were silently dropped. `Node.Decode`
always constructed a new decoder from `DefaultOptions`, so unknown fields would
pass through unchecked regardless of what the caller configured.

Fixes #321

The fix walks the node tree after parsing and sets a snapshot of the loader's
options onto each node. `Node.Decode` then picks up the snapshot instead of
falling back to defaults.

The same propagation is applied in `ComposeAndResolve`, which previously had
the same gap.

The cost is one addition `Options` struct copy per document and an O(N)
pointer-write walk over the node tree. Benchmarks show little to low sec/op and allocs/op
impact (not reliably measurable); B/op is up ~4% due to an extra pointer field on the Node struct.

<details>
<summary>Benchmark results (n=10, benchstat)</summary>

```
goos: linux
goarch: amd64
pkg: go.yaml.in/yaml/v4
cpu: AMD Ryzen AI 9 HX PRO 370 w/ Radeon 890M       
                                                       │  baseline   │                fix                 │
                                                       │   sec/op    │   sec/op     vs base               │
Decode/target=plain/option=default/size=small-4          8.951µ ± 1%   9.028µ ± 1%       ~ (p=0.060 n=10)
Decode/target=plain/option=known-fields/size=small-4     9.052µ ± 1%   9.141µ ± 2%  +0.98% (p=0.035 n=10)
Decode/target=custom/option=default/size=small-4         9.299µ ± 1%   9.527µ ± 2%  +2.46% (p=0.000 n=10)
Decode/target=custom/option=known-fields/size=small-4    9.357µ ± 1%   9.661µ ± 1%  +3.25% (p=0.000 n=10)
Decode/target=plain/option=default/size=medium-4         78.10µ ± 1%   78.74µ ± 1%  +0.81% (p=0.023 n=10)
Decode/target=plain/option=known-fields/size=medium-4    78.65µ ± 1%   78.82µ ± 1%       ~ (p=0.579 n=10)
Decode/target=custom/option=default/size=medium-4        78.10µ ± 1%   79.10µ ± 3%  +1.28% (p=0.004 n=10)
Decode/target=custom/option=known-fields/size=medium-4   78.13µ ± 1%   78.92µ ± 2%  +1.02% (p=0.035 n=10)
Decode/target=plain/option=default/size=large-4          1.665m ± 3%   1.686m ± 1%  +1.21% (p=0.043 n=10)
Decode/target=plain/option=known-fields/size=large-4     1.675m ± 1%   1.674m ± 1%       ~ (p=0.853 n=10)
Decode/target=custom/option=default/size=large-4         1.671m ± 1%   1.666m ± 1%       ~ (p=0.739 n=10)
Decode/target=custom/option=known-fields/size=large-4    1.663m ± 1%   1.664m ± 1%       ~ (p=0.796 n=10)
geomean                                                  106.2µ        107.2µ       +0.98%

                                                       │   baseline   │                 fix                 │
                                                       │     B/op     │     B/op      vs base               │
Decode/target=plain/option=default/size=small-4          12.84Ki ± 0%   13.27Ki ± 0%  +3.41% (p=0.000 n=10)
Decode/target=plain/option=known-fields/size=small-4     12.84Ki ± 0%   13.27Ki ± 0%  +3.41% (p=0.000 n=10)
Decode/target=custom/option=default/size=small-4         13.09Ki ± 0%   13.53Ki ± 0%  +3.34% (p=0.000 n=10)
Decode/target=custom/option=known-fields/size=small-4    13.09Ki ± 0%   13.53Ki ± 0%  +3.34% (p=0.000 n=10)
Decode/target=plain/option=default/size=medium-4         67.82Ki ± 0%   71.07Ki ± 0%  +4.79% (p=0.000 n=10)
Decode/target=plain/option=known-fields/size=medium-4    67.82Ki ± 0%   71.07Ki ± 0%  +4.79% (p=0.000 n=10)
Decode/target=custom/option=default/size=medium-4        68.08Ki ± 0%   71.33Ki ± 0%  +4.77% (p=0.000 n=10)
Decode/target=custom/option=known-fields/size=medium-4   68.08Ki ± 0%   71.33Ki ± 0%  +4.77% (p=0.000 n=10)
Decode/target=plain/option=default/size=large-4          686.9Ki ± 0%   718.3Ki ± 0%  +4.57% (p=0.000 n=10)
Decode/target=plain/option=known-fields/size=large-4     686.9Ki ± 0%   718.3Ki ± 0%  +4.57% (p=0.000 n=10)
Decode/target=custom/option=default/size=large-4         687.2Ki ± 0%   718.5Ki ± 0%  +4.57% (p=0.000 n=10)
Decode/target=custom/option=known-fields/size=large-4    687.2Ki ± 0%   718.5Ki ± 0%  +4.57% (p=0.000 n=10)
geomean                                                  84.59Ki        88.17Ki       +4.24%

                                                       │  baseline   │                fix                 │
                                                       │  allocs/op  │  allocs/op   vs base               │
Decode/target=plain/option=default/size=small-4           179.0 ± 0%    180.0 ± 0%  +0.56% (p=0.000 n=10)
Decode/target=plain/option=known-fields/size=small-4      179.0 ± 0%    180.0 ± 0%  +0.56% (p=0.000 n=10)
Decode/target=custom/option=default/size=small-4          183.0 ± 0%    184.0 ± 0%  +0.55% (p=0.000 n=10)
Decode/target=custom/option=known-fields/size=small-4     183.0 ± 0%    184.0 ± 0%  +0.55% (p=0.000 n=10)
Decode/target=plain/option=default/size=medium-4         1.268k ± 0%   1.269k ± 0%  +0.08% (p=0.000 n=10)
Decode/target=plain/option=known-fields/size=medium-4    1.268k ± 0%   1.269k ± 0%  +0.08% (p=0.000 n=10)
Decode/target=custom/option=default/size=medium-4        1.272k ± 0%   1.273k ± 0%  +0.08% (p=0.000 n=10)
Decode/target=custom/option=known-fields/size=medium-4   1.272k ± 0%   1.273k ± 0%  +0.08% (p=0.000 n=10)
Decode/target=plain/option=default/size=large-4          12.08k ± 0%   12.08k ± 0%  +0.01% (p=0.000 n=10)
Decode/target=plain/option=known-fields/size=large-4     12.08k ± 0%   12.08k ± 0%  +0.01% (p=0.000 n=10)
Decode/target=custom/option=default/size=large-4         12.09k ± 0%   12.09k ± 0%  +0.01% (p=0.000 n=10)
Decode/target=custom/option=known-fields/size=large-4    12.09k ± 0%   12.09k ± 0%  +0.01% (p=0.000 n=10)
geomean       
```

</details>