### PR TITLE
Fix float-to-string unmarshal regression

### DIFF
--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -374,6 +374,9 @@ func (c *Constructor) constructFloat(n *Node, resolved any, out reflect.Value) b
 				}
 			}
 		}
+	case reflect.String:
+		out.SetString(n.Value)
+		return true
 	case reflect.Interface:
 		out.Set(reflect.ValueOf(resolved))
 		return true

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -418,6 +418,59 @@ var unmarshalTests = []struct {
 		map[string]string{"a": strings.Repeat("\x00", 52)},
 	},
 
+	// Scalar to string conversions.
+	// Float to string (regression test for constructFloat missing reflect.String case).
+	{
+		"a: 55.7351",
+		map[string]string{"a": "55.7351"},
+	},
+	{
+		"a: -3.14159",
+		map[string]string{"a": "-3.14159"},
+	},
+	{
+		"a: 1.23e10",
+		map[string]string{"a": "1.23e10"},
+	},
+	{
+		"a: .inf",
+		map[string]string{"a": ".inf"},
+	},
+	{
+		"a: -.inf",
+		map[string]string{"a": "-.inf"},
+	},
+	{
+		"a: .nan",
+		map[string]string{"a": ".nan"},
+	},
+	// Int to string (verify existing constructInt string case).
+	{
+		"a: 42",
+		map[string]string{"a": "42"},
+	},
+	{
+		"a: -100",
+		map[string]string{"a": "-100"},
+	},
+	{
+		"a: 0x1A",
+		map[string]string{"a": "0x1A"},
+	},
+	{
+		"a: 0o755",
+		map[string]string{"a": "0o755"},
+	},
+	// Bool to string (verify existing constructBool string case).
+	{
+		"a: true",
+		map[string]string{"a": "true"},
+	},
+	{
+		"a: false",
+		map[string]string{"a": "false"},
+	},
+
 	// Issue #39.
 	{
 		"a:\n b:\n  c: d\n",


### PR DESCRIPTION
Fix https://github.com/yaml/go-yaml/issues/331

## Summary

- Add `reflect.String` case to `constructFloat`, allowing YAML float values to be unmarshaled into Go string fields
- This follows the same pattern already used by `constructInt` and `constructBool`
- Fixes the error: `cannot construct !!float into string`

## Problem

When unmarshaling YAML like:
```yaml
value: 55.7351
```

Into a Go struct with a string field:
```go
var result map[string]string
yaml.Unmarshal(data, &result)
```

It fails with: `yaml: construct errors: line 1: cannot construct !!float '55.7351' into string`

## Solution

Added the missing `reflect.String` case to `constructFloat` in `internal/libyaml/constructor.go`:

```go
case reflect.String:
    // Allow float to string conversion
    out.SetString(n.Value)
    return true
```

## Test plan

- [x] Added 12 test cases covering float/int/bool to string conversions
- [x] All existing tests pass
- [x] Tested edge cases: negative floats, scientific notation, infinity, NaN

🤖 Generated with [Claude Code](https://claude.ai/code)