### PR TITLE
Enable dependabot cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,10 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: /  # Location of package manifests
+  cooldown:
+    # Supply chain attacks are more likely to be detected and mitigated after a
+    # few days, so this can help reduce the risk of introducing malicious code.
+    default-days: 10
   schedule:
     interval: weekly
 
@@ -14,5 +18,9 @@ updates:
   groups:
     actions:
       patterns: ['*']
+  cooldown:
+    # Supply chain attacks are more likely to be detected and mitigated after a
+    # few days, so this can help reduce the risk of introducing malicious code.
+    default-days: 10
   schedule:
     interval: weekly


### PR DESCRIPTION
The idea is to mitigate supply chain attack risks by introducing a delay before updates are considered safe to merge.

Here is the documentation

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

Some references https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns