### PR TITLE
Fix !!merge tag regression for yq #2677

### DIFF
--- a/internal/libyaml/desolver.go
+++ b/internal/libyaml/desolver.go
@@ -68,8 +68,16 @@ func (d *Desolver) desolveScalar(n *Node) {
 	switch stag {
 	case nullTag, boolTag, strTag, intTag, floatTag, timestampTag:
 		isStandardTag = true
-	case binaryTag, mergeTag:
-		// Special tags - never remove
+	case binaryTag:
+		// Binary scalars are not implicitly resolvable - never remove.
+		return
+	case mergeTag:
+		// Elide the implicit !!merge tag when the value is the canonical
+		// merge key marker. The TaggedStyle early-return above already
+		// preserves !!merge when it was explicit in the source.
+		if n.Value == "<<" {
+			n.Tag = ""
+		}
 		return
 	default:
 		// Custom tag - preserve it

--- a/internal/libyaml/testdata/desolver.yaml
+++ b/internal/libyaml/testdata/desolver.yaml
@@ -68,14 +68,24 @@
       tag: '!tag:something'
       style: Plain
 
-- desolve-preserve:
-    name: Preserve merge tag
+- desolve-inferable:
+    name: Elide implicit merge tag
     node:
       tag: '!!merge'
       value: '<<'
     want:
-      tag: '!!merge'
+      tag: ''
       style: Plain
+
+- desolve-preserve:
+    name: Preserve merge tag with TaggedStyle
+    node:
+      tag: '!!merge'
+      value: '<<'
+      style: Tagged
+    want:
+      tag: '!!merge'
+      style: Tagged
 
 - desolve-preserve:
     name: Preserve binary tag

--- a/testdata/node.yaml
+++ b/testdata/node.yaml
@@ -2474,10 +2474,13 @@
           style: Flow
           content: [{kind: Scalar, text: qux}, {kind: Scalar, tag: '!!int', text: '1'}]
 
-# Merge key encoding tests - verifies !!merge tag is preserved in output
+# Merge key encoding tests.
+# An implicit !!merge tag (Tag set but no TaggedStyle) is elided on output
+# so callers that hand-build a node with Value: "<<" get clean `<<:` syntax
+# (yq issue #2677). An explicit !!merge (TaggedStyle set) is preserved.
 - node-test:
     name: merge key with flow mapping value
-    yaml: "!!merge <<: {a: 1}\n"
+    yaml: "<<: {a: 1}\n"
     decode: false
     node:
       kind: Document
@@ -2495,7 +2498,7 @@
 
 - node-test:
     name: merge key in nested mapping
-    yaml: "foo:\n  !!merge <<: {a: 1}\n"
+    yaml: "foo:\n  <<: {a: 1}\n"
     decode: false
     node:
       kind: Document
@@ -2514,3 +2517,39 @@
             content:
             - {kind: Scalar, text: a}
             - {kind: Scalar, tag: '!!int', text: '1'}
+
+- node-test:
+    name: merge key with explicit tag preserved
+    yaml: "!!merge <<: {a: 1}\n"
+    decode: false
+    node:
+      kind: Document
+      content:
+      - kind: Mapping
+        content:
+        - kind: Scalar
+          tag: '!!merge'
+          style: Tagged
+          text: '<<'
+        - kind: Mapping
+          style: Flow
+          content:
+          - {kind: Scalar, text: a}
+          - {kind: Scalar, tag: '!!int', text: '1'}
+
+- node-test:
+    name: bare merge key with untagged scalar
+    yaml: "<<: {a: 1}\n"
+    decode: false
+    node:
+      kind: Document
+      content:
+      - kind: Mapping
+        content:
+        - kind: Scalar
+          text: '<<'
+        - kind: Mapping
+          style: Flow
+          content:
+          - {kind: Scalar, text: a}
+          - {kind: Scalar, tag: '!!int', text: '1'}


### PR DESCRIPTION
Commit cb0eff8 added `&& stag != mergeTag` to the desolver's implicit-tag stripping logic to preserve `!!merge` on round-trip. That over-corrected: it stops the resolver-assigned (implicit) merge tag from being elided on encode, which breaks yq.
yq builds the merge-key node tree from parsed YAML where the resolver fills in `Tag = "!!merge"` on the bare `<<` scalar (no TaggedStyle), then emits the tree back out and now sees `!!merge <<:` where the source had `<<:`.

The explicit-tag preservation case that cb0eff8 was solving is already handled by the TaggedStyle bit (set by the composer when the source has an explicit tag) and the early return at desolver.go:55. So the fix is to let `!!merge` be elided like every other implicit tag when TaggedStyle is not set.

Changes:

- internal/libyaml/desolver.go: split the `case binaryTag, mergeTag:` in desolveScalar. `binaryTag` keeps its always-preserve behavior since binary scalars are not implicitly resolvable. `mergeTag` now strips the tag when `n.Value == "<<"`, the canonical merge-key marker. Explicit `!!merge` is still preserved via the TaggedStyle early return above.

- internal/libyaml/testdata/desolver.yaml: convert the "Preserve merge tag" case (which asserted the buggy behavior) into "Elide implicit merge tag" (asserts the tag is removed), and add a "Preserve merge tag with TaggedStyle" case that confirms explicit tags still survive.

- testdata/node.yaml: update the two cb0eff8 cases so their expected output drops the `!!merge ` prefix (the nodes have no TaggedStyle, so the tag should be elided). Add two new cases: "merge key with explicit tag preserved" (uses style: Tagged to verify preservation) and "bare merge key with untagged scalar" (documents that a tag-less `<<` scalar round-trips cleanly).

Verified:

- go test ./internal/libyaml/ -run TestDesolver: all cases pass, including the new Elide implicit / Preserve TaggedStyle pair.
- go test . -run TestNodeFromYAML: all four merge-key cases pass.
- go test . -run TestMerge: passes.
- go test ./...: full suite green (TestYAMLSuite skipped, needs yaml-test-suite data download).
- End-to-end repro: parsing `m:\n  <<: *x\n` with yaml.Unmarshal then yaml.Marshal now produces `<<: *x` again, not `!!merge <<: *x`.