### PR TITLE
v3: Revert incorrect gofmt changes

### DIFF
--- a/parserc.go
+++ b/parserc.go
@@ -226,9 +226,9 @@ func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool 
 }
 
 // Parse the production:
-// stream   ::= STREAM-START implicit_document? explicit_document* STREAM-END
 //
-//	************
+//	stream   ::= STREAM-START implicit_document? explicit_document* STREAM-END
+//	             ************
 func yaml_parser_parse_stream_start(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -249,13 +249,11 @@ func yaml_parser_parse_stream_start(parser *yaml_parser_t, event *yaml_event_t) 
 }
 
 // Parse the productions:
-// implicit_document    ::= block_node DOCUMENT-END*
 //
-//	*
-//
-// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
-//
-//	*************************
+//	implicit_document    ::= block_node DOCUMENT-END*
+//	                         *
+//	explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
+//	                         *************************
 func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t, implicit bool) bool {
 
 	token := peek_token(parser)
@@ -359,9 +357,9 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 }
 
 // Parse the productions:
-// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 //
-//	***********
+//	explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
+//	                                                   ***********
 func yaml_parser_parse_document_content(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -382,11 +380,10 @@ func yaml_parser_parse_document_content(parser *yaml_parser_t, event *yaml_event
 }
 
 // Parse the productions:
-// implicit_document    ::= block_node DOCUMENT-END*
 //
-//	*************
-//
-// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
+//	implicit_document    ::= block_node DOCUMENT-END*
+//	                                    *************
+//	explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 func yaml_parser_parse_document_end(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -432,42 +429,32 @@ func yaml_parser_set_event_comments(parser *yaml_parser_t, event *yaml_event_t) 
 }
 
 // Parse the productions:
-// block_node_or_indentless_sequence    ::=
 //
-//	ALIAS
-//	*****
-//	| properties (block_content | indentless_block_sequence)?
-//	  **********  *
-//	| block_content | indentless_block_sequence
-//	  *
-//
-// block_node           ::= ALIAS
-//
-//	*****
-//	| properties block_content?
-//	  ********** *
-//	| block_content
-//	  *
-//
-// flow_node            ::= ALIAS
-//
-//	*****
-//	| properties flow_content?
-//	  ********** *
-//	| flow_content
-//	  *
-//
-// properties           ::= TAG ANCHOR? | ANCHOR TAG?
-//
-//	*************************
-//
-// block_content        ::= block_collection | flow_collection | SCALAR
-//
-//	******
-//
-// flow_content         ::= flow_collection | SCALAR
-//
-//	******
+//	block_node_or_indentless_sequence    ::=
+//	                         ALIAS
+//	                         *****
+//	                         | properties (block_content | indentless_block_sequence)?
+//	                           **********  *
+//	                         | block_content | indentless_block_sequence
+//	                           *
+//	block_node           ::= ALIAS
+//	                         *****
+//	                         | properties block_content?
+//	                           ********** *
+//	                         | block_content
+//	                           *
+//	flow_node            ::= ALIAS
+//	                         *****
+//	                         | properties flow_content?
+//	                           ********** *
+//	                         | flow_content
+//	                           *
+//	properties           ::= TAG ANCHOR? | ANCHOR TAG?
+//	                         *************************
+//	block_content        ::= block_collection | flow_collection | SCALAR
+//	                                                              ******
+//	flow_content         ::= flow_collection | SCALAR
+//	                                           ******
 func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, indentless_sequence bool) bool {
 	//defer trace("yaml_parser_parse_node", "block:", block, "indentless_sequence:", indentless_sequence)()
 
@@ -697,9 +684,9 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 }
 
 // Parse the productions:
-// block_sequence ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
 //
-//	********************  *********** *             *********
+//	block_sequence ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
+//	                   ********************  *********** *             *********
 func yaml_parser_parse_block_sequence_entry(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
 	if first {
 		token := peek_token(parser)
@@ -755,9 +742,9 @@ func yaml_parser_parse_block_sequence_entry(parser *yaml_parser_t, event *yaml_e
 }
 
 // Parse the productions:
-// indentless_sequence  ::= (BLOCK-ENTRY block_node?)+
 //
-//	*********** *
+//	indentless_sequence  ::= (BLOCK-ENTRY block_node?)+
+//	                          *********** *
 func yaml_parser_parse_indentless_sequence_entry(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -821,15 +808,15 @@ func yaml_parser_split_stem_comment(parser *yaml_parser_t, stem_len int) {
 }
 
 // Parse the productions:
-// block_mapping        ::= BLOCK-MAPPING_START
 //
-//	*******************
-//	((KEY block_node_or_indentless_sequence?)?
-//	  *** *
-//	(VALUE block_node_or_indentless_sequence?)?)*
+//	block_mapping        ::= BLOCK-MAPPING_START
+//	                         *******************
+//	                         ((KEY block_node_or_indentless_sequence?)?
+//	                           *** *
+//	                         (VALUE block_node_or_indentless_sequence?)?)*
 //
-//	BLOCK-END
-//	*********
+//	                         BLOCK-END
+//	                         *********
 func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
 	if first {
 		token := peek_token(parser)
@@ -896,13 +883,14 @@ func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_even
 }
 
 // Parse the productions:
-// block_mapping        ::= BLOCK-MAPPING_START
 //
-//	((KEY block_node_or_indentless_sequence?)?
+//	block_mapping        ::= BLOCK-MAPPING_START
 //
-//	(VALUE block_node_or_indentless_sequence?)?)*
-//	 ***** *
-//	BLOCK-END
+//	                          ((KEY block_node_or_indentless_sequence?)?
+//
+//	                          (VALUE block_node_or_indentless_sequence?)?)*
+//	                           ***** *
+//	                          BLOCK-END
 func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -929,19 +917,17 @@ func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_ev
 }
 
 // Parse the productions:
-// flow_sequence        ::= FLOW-SEQUENCE-START
 //
-//	*******************
-//	(flow_sequence_entry FLOW-ENTRY)*
-//	 *                   **********
-//	flow_sequence_entry?
-//	*
-//	FLOW-SEQUENCE-END
-//	*****************
-//
-// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//
-//	*
+//	flow_sequence        ::= FLOW-SEQUENCE-START
+//	                         *******************
+//	                         (flow_sequence_entry FLOW-ENTRY)*
+//	                          *                   **********
+//	                         flow_sequence_entry?
+//	                         *
+//	                         FLOW-SEQUENCE-END
+//	                         *****************
+//	flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//	                         *
 func yaml_parser_parse_flow_sequence_entry(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
 	if first {
 		token := peek_token(parser)
@@ -1005,9 +991,9 @@ func yaml_parser_parse_flow_sequence_entry(parser *yaml_parser_t, event *yaml_ev
 }
 
 // Parse the productions:
-// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //
-//	*** *
+//	flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//	                                     *** *
 func yaml_parser_parse_flow_sequence_entry_mapping_key(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -1026,9 +1012,9 @@ func yaml_parser_parse_flow_sequence_entry_mapping_key(parser *yaml_parser_t, ev
 }
 
 // Parse the productions:
-// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //
-//	***** *
+//	flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//	                                                     ***** *
 func yaml_parser_parse_flow_sequence_entry_mapping_value(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -1050,9 +1036,9 @@ func yaml_parser_parse_flow_sequence_entry_mapping_value(parser *yaml_parser_t, 
 }
 
 // Parse the productions:
-// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //
-//	*
+//	flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//	                                                                     *
 func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -1068,18 +1054,17 @@ func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yaml_parser_t, ev
 }
 
 // Parse the productions:
-// flow_mapping         ::= FLOW-MAPPING-START
 //
-//	******************
-//	(flow_mapping_entry FLOW-ENTRY)*
-//	 *                  **********
-//	flow_mapping_entry?
-//	******************
-//	FLOW-MAPPING-END
-//	****************
-//
-// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//   - *** *
+//	flow_mapping         ::= FLOW-MAPPING-START
+//	                         ******************
+//	                         (flow_mapping_entry FLOW-ENTRY)*
+//	                          *                  **********
+//	                         flow_mapping_entry?
+//	                         ******************
+//	                         FLOW-MAPPING-END
+//	                         ****************
+//	flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//	                         *           *** *
 func yaml_parser_parse_flow_mapping_key(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
 	if first {
 		token := peek_token(parser)
@@ -1144,8 +1129,9 @@ func yaml_parser_parse_flow_mapping_key(parser *yaml_parser_t, event *yaml_event
 }
 
 // Parse the productions:
-// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//   - ***** *
+//
+//	flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//	                                  *                  ***** *
 func yaml_parser_parse_flow_mapping_value(parser *yaml_parser_t, event *yaml_event_t, empty bool) bool {
 	token := peek_token(parser)
 	if token == nil {

--- a/yamlh.go
+++ b/yamlh.go
@@ -433,21 +433,19 @@ type yaml_document_t struct {
 
 // The prototype of a read handler.
 //
-// The read handler is called when the parser needs to read more bytes from the
-// source. The handler should write not more than size bytes to the buffer.
-// The number of written bytes should be set to the size_read variable.
+//	The read handler is called when the parser needs to read more bytes from the
+//	source. The handler should write not more than size bytes to the buffer.
+//	The number of written bytes should be set to the size_read variable.
 //
-// [in,out]   data        A pointer to an application data specified by
+//	[in,out]   data        A pointer to an application data specified by
+//	                       yaml_parser_set_input().
+//	[out]      buffer      The buffer to write the data from the source.
+//	[in]       size        The size of the buffer.
+//	[out]      size_read   The actual number of bytes read from the source.
 //
-//	yaml_parser_set_input().
-//
-// [out]      buffer      The buffer to write the data from the source.
-// [in]       size        The size of the buffer.
-// [out]      size_read   The actual number of bytes read from the source.
-//
-// On success, the handler should return 1.  If the handler failed,
-// the returned value should be 0. On EOF, the handler should set the
-// size_read to 0 and return 1.
+//	On success, the handler should return 1.  If the handler failed,
+//	the returned value should be 0. On EOF, the handler should set the
+//	size_read to 0 and return 1.
 type yaml_read_handler_t func(parser *yaml_parser_t, buffer []byte) (n int, err error)
 
 // This structure holds information about a potential simple key.
@@ -655,19 +653,17 @@ type yaml_comment_t struct {
 
 // The prototype of a write handler.
 //
-// The write handler is called when the emitter needs to flush the accumulated
-// characters to the output.  The handler should write @a size bytes of the
-// @a buffer to the output.
+//	The write handler is called when the emitter needs to flush the accumulated
+//	characters to the output.  The handler should write @a size bytes of the
+//	@a buffer to the output.
 //
-// @param[in,out]   data        A pointer to an application data specified by
+//	@param[in,out]   data        A pointer to an application data specified by
+//	                             yaml_emitter_set_output().
+//	@param[in]       buffer      The buffer with bytes to be written.
+//	@param[in]       size        The size of the buffer.
 //
-//	yaml_emitter_set_output().
-//
-// @param[in]       buffer      The buffer with bytes to be written.
-// @param[in]       size        The size of the buffer.
-//
-// @returns On success, the handler should return @c 1.  If the handler failed,
-// the returned value should be @c 0.
+//	@returns On success, the handler should return @c 1.  If the handler failed,
+//	the returned value should be @c 0.
 type yaml_write_handler_t func(emitter *yaml_emitter_t, buffer []byte) error
 
 type yaml_emitter_state_t int


### PR DESCRIPTION
This partially reverts commit 5f3d8c3acdbcffdd5289a452767158ceb22d0003

gofmt made some incorrect changes to the godoc comments, which caused the documentation to be incorrect.

The previous format was using

```go
// Something is highlighted
// More details about something
//                    *********
```

We are now using this, that is stable against gofmt:

```go
// Something is highlighted
//
//<TAB>More details about something
//<TAB>                   *********
```

Fixes #344 