### PR TITLE
Handle empty legacy YAML streams

### DIFF
--- a/internal/libyaml/composer.go
+++ b/internal/libyaml/composer.go
@@ -163,6 +163,11 @@ func (c *Composer) createStreamNode() *Node {
 	if !c.Textless && c.event.Type != NO_EVENT {
 		n.Line = c.event.StartMark.Line
 		n.Column = c.event.StartMark.Column
+		if c.event.Type == STREAM_END_EVENT {
+			n.HeadComment = string(c.event.HeadComment)
+			n.LineComment = string(c.event.LineComment)
+			n.FootComment = string(c.event.FootComment)
+		}
 	}
 	return n
 }

--- a/internal/libyaml/loader.go
+++ b/internal/libyaml/loader.go
@@ -221,6 +221,9 @@ func loadSingle(in []byte, out any, opts *Options) error {
 	// Load first document
 	err = l.Load(out)
 	if err == io.EOF {
+		if opts.FromLegacy {
+			return nil
+		}
 		msg := "yaml: no documents in stream"
 		return &LoadErrors{Errors: []*LoadError{{
 			Stage:   ConstructorStage,

--- a/internal/libyaml/loader_test.go
+++ b/internal/libyaml/loader_test.go
@@ -34,6 +34,30 @@ func TestStreamNodeEmptyStream(t *testing.T) {
 	assert.Equal(t, StreamNode, nodes[0].Kind)
 }
 
+// TestStreamNodeCommentOnlyStream tests that comments without documents are
+// preserved on the stream node.
+func TestStreamNodeCommentOnlyStream(t *testing.T) {
+	input := []byte("# comment\n")
+
+	loader, err := NewLoader(bytes.NewReader(input), WithStreamNodes())
+	assert.NoError(t, err)
+
+	var nodes []Node
+	for {
+		var node Node
+		err := loader.Load(&node)
+		if err == io.EOF {
+			break
+		}
+		assert.NoError(t, err)
+		nodes = append(nodes, node)
+	}
+
+	assert.Equal(t, 1, len(nodes))
+	assert.Equal(t, StreamNode, nodes[0].Kind)
+	assert.Equal(t, "# comment", nodes[0].HeadComment)
+}
+
 // TestStreamNodeSingleDocument tests the pattern [Stream, Doc, Stream] for single document
 func TestStreamNodeSingleDocument(t *testing.T) {
 	input := []byte("key: value\n")
@@ -259,6 +283,15 @@ func TestLoad_SingleDocument(t *testing.T) {
 // TestLoad_ZeroDocuments tests that 0 documents returns error
 func TestLoad_ZeroDocuments(t *testing.T) {
 	input := []byte("")
+
+	var config map[string]any
+	err := Load(input, &config)
+	assert.NotNil(t, err)
+	assert.ErrorMatches(t, ".*no documents in stream.*", err)
+}
+
+func TestLoad_CommentOnlyStream(t *testing.T) {
+	input := []byte("# comment\n")
 
 	var config map[string]any
 	err := Load(input, &config)

--- a/internal/libyaml/parser.go
+++ b/internal/libyaml/parser.go
@@ -550,6 +550,7 @@ func (parser *Parser) parseDocumentStart(event *Event, implicit bool) error {
 			StartMark: token.StartMark,
 			EndMark:   token.EndMark,
 		}
+		parser.setEventComments(event)
 		parser.skipToken()
 	}
 

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -788,6 +788,61 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
+func TestUnmarshalZeroDocumentStreams(t *testing.T) {
+	inputs := []string{
+		"",
+		"   \n\n",
+		"# comment\n",
+		"# head\n\n# after blank\n",
+	}
+
+	for _, input := range inputs {
+		t.Run(fmt.Sprintf("%q", input), func(t *testing.T) {
+			target := struct {
+				A string `yaml:"a"`
+			}{A: "keep"}
+			err := yaml.Unmarshal([]byte(input), &target)
+			assert.NoError(t, err)
+			assert.Equal(t, "keep", target.A)
+
+			m := map[string]any{"keep": "yes"}
+			err = yaml.Unmarshal([]byte(input), &m)
+			assert.NoError(t, err)
+			assert.DeepEqual(t, map[string]any{"keep": "yes"}, m)
+
+			node := yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Value: "keep",
+			}
+			err = yaml.Unmarshal([]byte(input), &node)
+			assert.NoError(t, err)
+			assert.Equal(t, yaml.ScalarNode, node.Kind)
+			assert.Equal(t, "!!str", node.Tag)
+			assert.Equal(t, "keep", node.Value)
+			assert.Equal(t, "", node.HeadComment)
+		})
+	}
+}
+
+func TestDecoderZeroDocumentStreams(t *testing.T) {
+	inputs := []string{
+		"",
+		"   \n\n",
+		"# comment\n",
+		"# head\n\n# after blank\n",
+	}
+
+	for _, input := range inputs {
+		t.Run(fmt.Sprintf("%q", input), func(t *testing.T) {
+			value := any("keep")
+			err := yaml.NewDecoder(strings.NewReader(input)).Decode(&value)
+			assert.ErrorIs(t, err, io.EOF)
+			assert.Equal(t, "keep", value)
+		})
+	}
+}
+
 type errReader struct{}
 
 func (errReader) Read([]byte) (int, error) {


### PR DESCRIPTION
fixes #342

Restore v3-compatible behavior for the classic decode APIs when the input contains zero YAML documents. yaml.Unmarshal now treats empty, whitespace-only, and comment-only streams as a no-op and returns nil, leaving the destination value unchanged. Decoder.Decode continues to report io.EOF for the same zero-document streams, matching v3 streaming behavior.

Keep the stricter v4 Load API behavior intact: Load still reports "no documents in stream" for empty and comment-only input unless it is being called through the internal legacy compatibility path.

Preserve comments that have no document node when callers opt into WithStreamNodes. Comments unfolded onto STREAM_END_EVENT are now copied onto the emitted StreamNode, so comment-only streams still return the existing single StreamNode shape but no longer drop the comments.

Tests cover Unmarshal no-op behavior for empty, whitespace-only, and comment-only streams across struct, map, and Node targets; Decoder io.EOF behavior; strict Load errors for comment-only input; and WithStreamNodes comment preservation.