### PR TITLE
Fixes cyclical reference in LoadErrors creation

### DIFF
--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -1022,7 +1022,7 @@ func (c *Constructor) callLegacyConstructor(n *Node, u legacyConstructor) (good 
 		defer handleErr(&err)
 		c.Construct(n, reflect.ValueOf(v))
 		if len(c.TypeErrors) > terrlen {
-			issues := c.TypeErrors[terrlen:]
+			issues := append([]*LoadError{}, c.TypeErrors[terrlen:]...)
 			c.TypeErrors = c.TypeErrors[:terrlen]
 			return &LoadErrors{issues}
 		}

--- a/internal/libyaml/constructor_test.go
+++ b/internal/libyaml/constructor_test.go
@@ -7,6 +7,7 @@
 package libyaml
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -18,15 +19,78 @@ func TestConstructor(t *testing.T) {
 		"scalar-resolution": func(t *testing.T, tc TestCase) {
 			t.Helper()
 
-			// Load the YAML
 			result, err := LoadAny([]byte(tc.Yaml))
 			assert.NoErrorf(t, err, "LoadAny() error: %v", err)
 
-			// Compare the result with expected value
 			if !reflect.DeepEqual(result, tc.Want) {
 				t.Errorf("LoadAny() = %v (type: %T), want %v (type: %T)",
 					result, result, tc.Want, tc.Want)
 			}
 		},
 	})
+}
+
+type wrappingLegacyConstructor struct{}
+
+func (wrappingLegacyConstructor) UnmarshalYAML(unmarshal func(any) error) error {
+	var target struct {
+		Value string `yaml:"value"`
+	}
+	if err := unmarshal(&target); err != nil {
+		return fmt.Errorf("wrapper failed: %w", err)
+	}
+	return nil
+}
+
+func loadErrorChainFinite(err error, limit int) bool {
+	count := 0
+	var walk func(error) bool
+	walk = func(e error) bool {
+		for e != nil {
+			count++
+			if count > limit {
+				return false
+			}
+			if le, ok := e.(*LoadErrors); ok {
+				for _, child := range le.Errors {
+					if !walk(child) {
+						return false
+					}
+				}
+				return true
+			}
+			switch x := e.(type) {
+			case interface{ Unwrap() []error }:
+				for _, child := range x.Unwrap() {
+					if !walk(child) {
+						return false
+					}
+				}
+				return true
+			case interface{ Unwrap() error }:
+				e = x.Unwrap()
+			default:
+				return true
+			}
+		}
+		return true
+	}
+	return walk(err)
+}
+
+func TestCallLegacyConstructorWrappedErrorNoCycle(t *testing.T) {
+	c := NewConstructor(&Options{})
+	n := &Node{Kind: ScalarNode, Tag: strTag, Value: "not-an-object", Line: 1, Column: 1}
+
+	good := c.callLegacyConstructor(n, wrappingLegacyConstructor{})
+	assert.False(t, good)
+	assert.NotNil(t, &c.TypeErrors)
+	if len(c.TypeErrors) == 0 {
+		t.Fatal("expected callLegacyConstructor to record a type error")
+	}
+
+	for _, e := range c.TypeErrors {
+		assert.Truef(t, loadErrorChainFinite(e, 1000),
+			"error chain is cyclic (issue #345 regression): %v", e)
+	}
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1360,6 +1360,74 @@ func TestLegacyUnmarshalerLoadErrorsProxying(t *testing.T) {
 	assert.ErrorMatches(t, expectedError, err)
 }
 
+type legacyWrappingUnmarshaler struct {
+	Value string `yaml:"value"`
+}
+
+func (w *legacyWrappingUnmarshaler) UnmarshalYAML(unmarshal func(any) error) error {
+	type plain legacyWrappingUnmarshaler
+	var p plain
+	if err := unmarshal(&p); err != nil {
+		return fmt.Errorf("wrapper failed: %w", err)
+	}
+	*w = legacyWrappingUnmarshaler(p)
+	return nil
+}
+
+func errorChainFinite(err error, limit int) bool {
+	count := 0
+	var walk func(error) bool
+	walk = func(e error) bool {
+		for e != nil {
+			count++
+			if count > limit {
+				return false
+			}
+			if le, ok := e.(*yaml.LoadErrors); ok {
+				for _, child := range le.Errors {
+					if !walk(child) {
+						return false
+					}
+				}
+				return true
+			}
+			switch x := e.(type) {
+			case interface{ Unwrap() []error }:
+				for _, child := range x.Unwrap() {
+					if !walk(child) {
+						return false
+					}
+				}
+				return true
+			case interface{ Unwrap() error }:
+				e = x.Unwrap()
+			default:
+				return true
+			}
+		}
+		return true
+	}
+	return walk(err)
+}
+
+func TestLegacyUnmarshalerWrappedErrorNoCycle(t *testing.T) {
+	type Root struct {
+		Items []legacyWrappingUnmarshaler `yaml:"items"`
+	}
+	var r Root
+	err := yaml.Unmarshal([]byte("items:\n  - not-an-object\n"), &r)
+	assert.NotNil(t, err)
+
+	assert.Truef(t, errorChainFinite(err, 1000),
+		"error chain is cyclic (issue #345 regression): %v", err)
+
+	assert.False(t, errors.Is(err, errFailing))
+
+	var loadErr *yaml.LoadError
+	assert.Truef(t, errors.As(err, &loadErr),
+		"expected to extract *yaml.LoadError from %v", err)
+}
+
 var errFailing = errors.New("failingErr")
 
 type failingUnmarshaler struct{}


### PR DESCRIPTION
The issue was a self-reference in the error chain, causing unwrap to iterate over the same item in the `LoadErrors` slice. The slice returned to the custom unmarshaler shared backing storage with `c.TypeErrors`, so when the %w-wrapped error was later appended to `c.TypeErrors`, it overwrote the very slot that wrapped error pointed back to — closing the loop. This fix copies the sub-slice in callLegacyConstructor so the returned LoadErrors has its own slot in memory.

To test:
```sh
# Setup
git clone --depth 1 --branch issue345 https://github.com/colinjlacy/go-yaml.git /tmp/go-yaml
mkdir /tmp/repro && cd /tmp/repro
go mod init repro
go mod edit -replace go.yaml.in/yaml/v4=/tmp/go-yaml

# Test file
cat > main.go <<'EOF'
package main
import (
	"errors"
	"fmt"
	"os"
	"time"
	"go.yaml.in/yaml/v4"
)
type Inner struct {
	Value string `yaml:"value"`
}
type Wrapper struct {
	Item Inner `yaml:"item"`
}
func (w *Wrapper) UnmarshalYAML(unmarshal func(any) error) error {
	var single Inner
	if err := unmarshal(&single); err != nil {
		// Standard Go idiom — wrapping with %w
		return fmt.Errorf("wrapper failed: %w", err)
	}
	return nil
}
type Root struct {
	Items []Wrapper `yaml:"items"`
}
func main() {
	done := make(chan struct{})
	go func() {
		data := []byte("items:\n  - not-an-object\n")
		var r Root
		err := yaml.Unmarshal(data, &r)
		if err != nil {
			// Previously triggered: fatal error: stack overflow
			_ = errors.Is(err, errors.New("test"))
		}
		close(done)
	}()
	select {
	case <-done:
		fmt.Println("Completed")
	case <-time.After(3 * time.Second):
		fmt.Println("TIMEOUT: stack overflow")
		os.Exit(1)
	}
}
EOF

# Run test
go mod tidy
go run .
```

Also note that this branch adds regression tests at the interface level and unit tests at the lib level.

Fixes #345 