### PR TITLE
Fixes indexing bug in emitter

### DIFF
--- a/internal/libyaml/emitter.go
+++ b/internal/libyaml/emitter.go
@@ -2086,11 +2086,11 @@ func (emitter *Emitter) writeFoldedScalar(value []byte) error {
 	for i := 0; i < len(value); {
 		if isLineBreak(value, i) {
 			if !breaks && !leading_spaces && value[i] == '\n' {
-				k := 0
-				for isLineBreak(value, k) {
+				k := i
+				for k < len(value) && isLineBreak(value, k) {
 					k += width(value[k])
 				}
-				if !isBlankOrZero(value, k) {
+				if k < len(value) && !isBlankOrZero(value, k) {
 					if err := emitter.putLineBreak(); err != nil {
 						return err
 					}

--- a/internal/libyaml/emitter_test.go
+++ b/internal/libyaml/emitter_test.go
@@ -28,6 +28,60 @@ func TestEmitter(t *testing.T) {
 	})
 }
 
+func emitFoldedScalar(t *testing.T, value string) string {
+	t.Helper()
+
+	events := []Event{
+		NewStreamStartEvent(UTF8_ENCODING),
+		NewDocumentStartEvent(nil, nil, true),
+		NewScalarEvent(nil, nil, []byte(value), true, true, FOLDED_SCALAR_STYLE),
+		NewDocumentEndEvent(true),
+		NewStreamEndEvent(),
+	}
+
+	emitter := NewEmitter()
+	emitter.SetIndent(2)
+	var output []byte
+	emitter.SetOutputString(&output)
+	for i := range events {
+		err := emitter.Emit(&events[i])
+		assert.NoErrorf(t, err, "Emit() error: %v", err)
+	}
+	return string(output)
+}
+
+func TestEmitFoldedScalarNoExtraNewline(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "heading then more-indented block",
+			value: "Heading:\n\n  * first item\n  * second item\n",
+			want:  ">\n  Heading:\n\n    * first item\n    * second item\n",
+		},
+		{
+			name:  "single newline between plain lines",
+			value: "one\ntwo\n",
+			want:  ">\n  one\n\n  two\n",
+		},
+		{
+			name:  "trailing more-indented block",
+			value: "intro\n\n  indented tail\n",
+			want:  ">\n  intro\n\n    indented tail\n",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := emitFoldedScalar(t, tc.value)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func runEmitWriterTest(t *testing.T, tc TestCase) {
 	t.Helper()
 

--- a/internal/libyaml/emitter_test.go
+++ b/internal/libyaml/emitter_test.go
@@ -28,28 +28,6 @@ func TestEmitter(t *testing.T) {
 	})
 }
 
-func emitFoldedScalar(t *testing.T, value string) string {
-	t.Helper()
-
-	events := []Event{
-		NewStreamStartEvent(UTF8_ENCODING),
-		NewDocumentStartEvent(nil, nil, true),
-		NewScalarEvent(nil, nil, []byte(value), true, true, FOLDED_SCALAR_STYLE),
-		NewDocumentEndEvent(true),
-		NewStreamEndEvent(),
-	}
-
-	emitter := NewEmitter()
-	emitter.SetIndent(2)
-	var output []byte
-	emitter.SetOutputString(&output)
-	for i := range events {
-		err := emitter.Emit(&events[i])
-		assert.NoErrorf(t, err, "Emit() error: %v", err)
-	}
-	return string(output)
-}
-
 func TestEmitFoldedScalarNoExtraNewline(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -76,8 +54,23 @@ func TestEmitFoldedScalarNoExtraNewline(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got := emitFoldedScalar(t, tc.value)
-			assert.Equal(t, tc.want, got)
+			events := []Event{
+				NewStreamStartEvent(UTF8_ENCODING),
+				NewDocumentStartEvent(nil, nil, true),
+				NewScalarEvent(nil, nil, []byte(tc.value), true, true, FOLDED_SCALAR_STYLE),
+				NewDocumentEndEvent(true),
+				NewStreamEndEvent(),
+			}
+
+			emitter := NewEmitter()
+			emitter.SetIndent(2)
+			var output []byte
+			emitter.SetOutputString(&output)
+			for i := range events {
+				err := emitter.Emit(&events[i])
+				assert.NoErrorf(t, err, "Emit() error: %v", err)
+			}
+			assert.Equal(t, tc.want, string(output))
 		})
 	}
 }

--- a/internal/libyaml/testdata/emitter.yaml
+++ b/internal/libyaml/testdata/emitter.yaml
@@ -479,6 +479,48 @@
     - value
     - item1
 
+# Regression tests for https://github.com/yaml/go-yaml/issues/337
+- roundtrip:
+    name: Folded scalar preserves newlines
+    yaml: |
+      key: >
+        Heading:
+
+          * first item
+          * second item
+    want: |
+      key: >
+        Heading:
+
+          * first item
+          * second item
+
+- roundtrip:
+    name: Folded scalar single newline between plain lines
+    yaml: |
+      key: >
+        one
+
+        two
+    want: |
+      key: >
+        one
+
+        two
+
+- roundtrip:
+    name: Folded scalar trailing more-indented block
+    yaml: |
+      key: >
+        intro
+
+          indented tail
+    want: |
+      key: >
+        intro
+
+          indented tail
+
 # Writer test
 - emit-writer:
     name: Writer

--- a/node_test.go
+++ b/node_test.go
@@ -300,6 +300,72 @@ func TestNodeOmitEmpty(t *testing.T) {
 	assert.ErrorMatches(t, "go-yaml dump error in serializer: cannot represent node with unknown kind 0", err)
 }
 
+func nodeRoundTrip(t *testing.T, src []byte, indent int) []byte {
+	t.Helper()
+
+	var n yaml.Node
+	if err := yaml.Unmarshal(src, &n); err != nil {
+		t.Fatalf("Unmarshal into Node: %v", err)
+	}
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(indent)
+	if err := enc.Encode(&n); err != nil {
+		t.Fatalf("Encode Node: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("Close encoder: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestNodeFoldedScalarRoundtripStable(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "folded heading then more-indented block",
+			src:  "key: >\n  Heading:\n\n    * first item\n    * second item\n",
+		},
+		{
+			name: "folded single newline between plain lines",
+			src:  "key: >\n  one\n\n  two\n",
+		},
+		{
+			name: "folded single line",
+			src:  "key: >\n  just one line\n",
+		},
+		{
+			name: "literal control",
+			src:  "key: |\n  Heading:\n\n    * first item\n    * second item\n",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var first map[string]string
+			if err := yaml.Unmarshal([]byte(tc.src), &first); err != nil {
+				t.Fatalf("Unmarshal source: %v", err)
+			}
+			want := first["key"]
+
+			current := []byte(tc.src)
+			for round := 0; round < 4; round++ {
+				var m map[string]string
+				if err := yaml.Unmarshal(current, &m); err != nil {
+					t.Fatalf("round %d: Unmarshal: %v", round, err)
+				}
+				if m["key"] != want {
+					t.Fatalf("round %d: decoded value drifted: want %q, got %q", round, want, m["key"])
+				}
+				current = nodeRoundTrip(t, current, 2)
+			}
+		})
+	}
+}
+
 // NodeInfo represents the information about a YAML node in a test-friendly format
 type NodeInfo struct {
 	Kind    string      `yaml:"kind"`

--- a/node_test.go
+++ b/node_test.go
@@ -313,9 +313,7 @@ func nodeRoundTrip(t *testing.T, src []byte, indent int) []byte {
 	if err := enc.Encode(&n); err != nil {
 		t.Fatalf("Encode Node: %v", err)
 	}
-	if err := enc.Close(); err != nil {
-		t.Fatalf("Close encoder: %v", err)
-	}
+	assert.NoError(t, enc.Close())
 	return buf.Bytes()
 }
 
@@ -357,9 +355,7 @@ func TestNodeFoldedScalarRoundtripStable(t *testing.T) {
 				if err := yaml.Unmarshal(current, &m); err != nil {
 					t.Fatalf("round %d: Unmarshal: %v", round, err)
 				}
-				if m["key"] != want {
-					t.Fatalf("round %d: decoded value drifted: want %q, got %q", round, want, m["key"])
-				}
+				assert.Equal(t, want, m["key"])
 				current = nodeRoundTrip(t, current, 2)
 			}
 		})


### PR DESCRIPTION
This fixes #337 by addressing an indexing bug in how the emitter was adding newlines to folded block scalars, starting at index 0 instead of at the current index in the byte stream. It also adds a boundary to the lookahead so that we don't end up out of bounds. It then tests the boy-howdy out of the fix with unit, regression, and data-driven tests.

To test:
```sh
# Setup
git clone --depth 1 --branch issue337 https://github.com/colinjlacy/go-yaml.git /tmp/go-yaml
mkdir /tmp/repro && cd /tmp/repro
go mod init repro
go mod edit -replace go.yaml.in/yaml/v4=/tmp/go-yaml

# Test file
cat > main.go <<'EOF'
package main

import (
  "bytes"
  "fmt"

  "go.yaml.in/yaml/v4"
)

const src = `key: >
  Heading:

    * first item
    * second item
`

func main() {
  current := []byte(src)
  for i := 0; i <= 3; i++ {
    var m map[string]string
    if err := yaml.Unmarshal(current, &m); err != nil {
      panic(err)
    }
    fmt.Printf("round %d: decoded (%d bytes): %q\n", i, len(m["key"]), m["key"])

    var n yaml.Node
    if err := yaml.Unmarshal(current, &n); err != nil {
      panic(err)
    }
    var buf bytes.Buffer
    enc := yaml.NewEncoder(&buf)
    enc.SetIndent(2)
    if err := enc.Encode(&n); err != nil {
      panic(err)
    }
    if err := enc.Close(); err != nil {
      panic(err)
    }
    current = buf.Bytes()
  }
}
EOF

# Run test
go mod tidy
go run .
```