### PR TITLE
[v3] backport CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,51 @@
+# Copyright 2025 The go-yaml Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: CodeQL Advanced
+
+on:
+  push:
+    branches: [ main, v3, v2, v1 ]
+  pull_request:
+    branches: [ main, v3, v2, v1 ]
+  schedule:
+  - cron: 17 13 * * 3
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: go
+          build-mode: autobuild
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      with:
+        persist-credentials: false
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      # yamllint disable-line rule:line-length
+      uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463  # v4.36.1
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL Analysis
+      # yamllint disable-line rule:line-length
+      uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463  # v4.36.1
+      with:
+        category: /language:${{matrix.language}}


### PR DESCRIPTION
- relates to https://github.com/yaml/go-yaml/pull/347#issuecomment-4441572439


This workflow is marked as required in CI but wasn't present in the v3 branch, causing PRs to stall. This adds a copy of the CodeQL workflow taken from main at commit 1c17b9cee72bf81ae73a8be50fbd7dd3a9985125;

    curl -fsSL -o ./.github/workflows/codeql.yaml https://raw.githubusercontent.com/yaml/go-yaml/1c17b9cee72bf81ae73a8be50fbd7dd3a9985125/.github/workflows/codeql.yaml
    git add ./.github/workflows/codeql.yam