### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-commit-message.yaml
+++ b/.github/workflows/check-commit-message.yaml
@@ -7,7 +7,8 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   check-commit-message:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,13 +11,16 @@ on:
   schedule:
   - cron: 17 13 * * 3
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      actions: read
       # required for all workflows
       security-events: write
 

--- a/.github/workflows/files.yaml
+++ b/.github/workflows/files.yaml
@@ -9,7 +9,8 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   action-lint:

--- a/.github/workflows/forbid-merge-commits.yaml
+++ b/.github/workflows/forbid-merge-commits.yaml
@@ -7,7 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   forbid-merge-commits:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -9,7 +9,8 @@ on:
   pull_request:
     branches: [ main, v3, v2, v1 ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -27,7 +28,9 @@ jobs:
       with: {persist-credentials: false}
 
     - name: Run all unit tests w/ -cover, all YTS tests and go lint
-      run: make test lint v=1 cover=1 GO-VERSION=${{ matrix.go-version }}
+      run: make test lint v=1 cover=1 GO-VERSION="${MATRIX_GO_VERSION}"
+      env:
+        MATRIX_GO_VERSION: ${{ matrix.go-version }}
 
   test-cross-platform:
     name: Test on ${{ matrix.GOOS }}/${{ matrix.GOARCH }}


### PR DESCRIPTION
Apply hardening from zizmor (https://github.com/zizmorcore/zizmor);

    zizmor --fix=all --min-severity=medium --pedantic .

    warning[excessive-permissions]: overly broad permissions
      --> ./.github/workflows/check-commit-message.yaml:10:1
       |
    10 | permissions: read-all
       | ^^^^^^^^^^^^^^^^^^^^^ uses read-all permissions
       |
       = note: audit confidence → High

    warning[excessive-permissions]: overly broad permissions
      --> ./.github/workflows/codeql.yaml:14:1
       |
    14 | permissions: read-all
       | ^^^^^^^^^^^^^^^^^^^^^ uses read-all permissions
       |
       = note: audit confidence → High

    warning[excessive-permissions]: overly broad permissions
      --> ./.github/workflows/files.yaml:12:1
       |
    12 | permissions: read-all
       | ^^^^^^^^^^^^^^^^^^^^^ uses read-all permissions
       |
       = note: audit confidence → High

    warning[excessive-permissions]: overly broad permissions
      --> ./.github/workflows/forbid-merge-commits.yaml:10:1
       |
    10 | permissions: read-all
       | ^^^^^^^^^^^^^^^^^^^^^ uses read-all permissions
       |
       = note: audit confidence → High

    warning[excessive-permissions]: overly broad permissions
      --> ./.github/workflows/go.yaml:12:1
       |
    12 | permissions: read-all
       | ^^^^^^^^^^^^^^^^^^^^^ uses read-all permissions
       |
       = note: audit confidence → High

    warning[template-injection]: code injection via template expansion
      --> ./.github/workflows/go.yaml:30:54
       |
    30 |       run: make test lint v=1 cover=1 GO-VERSION=${{ matrix.go-version }}
       |       --- this run block                             ^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
       |
       = note: audit confidence → Medium
       = note: this finding has an auto-fix

    22 findings (16 ignored, 1 unsafe fixes): 0 informational, 0 low, 6 medium, 0 high

After this patch:

    zizmor --fix=all --min-severity=medium .
    INFO zizmor: 🌈 zizmor v1.26.1
    INFO audit: zizmor: 🌈 completed ./.github/dependabot.yaml
    INFO audit: zizmor: 🌈 completed ./.github/workflows/check-commit-message.yaml
    INFO audit: zizmor: 🌈 completed ./.github/workflows/codeql.yaml
    INFO audit: zizmor: 🌈 completed ./.github/workflows/files.yaml
    INFO audit: zizmor: 🌈 completed ./.github/workflows/forbid-merge-commits.yaml
    INFO audit: zizmor: 🌈 completed ./.github/workflows/go.yaml
    No findings to report. Good job! (1 ignored, 15 suppressed)
    No fixes available to apply.