### PR TITLE
Fix Marshal mutating *Node input #371

### DIFF
--- a/internal/libyaml/representer.go
+++ b/internal/libyaml/representer.go
@@ -55,8 +55,10 @@ func (r *Representer) Represent(tag string, in reflect.Value) *Node {
 		node, _ = in.Interface().(*Node)
 	}
 	if node != nil && node.Kind == DocumentNode {
-		// Already a document node, return as-is
-		return node
+		// Deep-copy the user-supplied document so downstream stages (the
+		// desolver in particular) never mutate the caller's node tree.
+		// Marshal must treat its input as read-only.
+		return deepCopyNode(node, map[*Node]*Node{})
 	} else {
 		// Wrap the represented value in a document node
 		contentNode := r.represent(tag, in)
@@ -65,6 +67,52 @@ func (r *Representer) Represent(tag string, in reflect.Value) *Node {
 			Content: []*Node{contentNode},
 		}
 	}
+}
+
+// deepCopyNode returns a deep copy of n so that a caller passing a *Node to
+// Marshal is not mutated by later pipeline stages. The seen map preserves
+// shared node identity and prevents infinite recursion on cyclic anchor and
+// alias graphs.
+func deepCopyNode(n *Node, seen map[*Node]*Node) *Node {
+	if n == nil {
+		return nil
+	}
+	if c, ok := seen[n]; ok {
+		return c
+	}
+	c := &Node{
+		Kind:        n.Kind,
+		Style:       n.Style,
+		Tag:         n.Tag,
+		Value:       n.Value,
+		Anchor:      n.Anchor,
+		HeadComment: n.HeadComment,
+		LineComment: n.LineComment,
+		FootComment: n.FootComment,
+		Line:        n.Line,
+		Column:      n.Column,
+	}
+	seen[n] = c
+	c.Alias = deepCopyNode(n.Alias, seen)
+	if n.Content != nil {
+		c.Content = make([]*Node, len(n.Content))
+		for i, child := range n.Content {
+			c.Content[i] = deepCopyNode(child, seen)
+		}
+	}
+	if n.Stream != nil {
+		s := &Stream{Encoding: n.Stream.Encoding}
+		if n.Stream.Version != nil {
+			v := *n.Stream.Version
+			s.Version = &v
+		}
+		if n.Stream.TagDirectives != nil {
+			s.TagDirectives = make([]StreamTagDirective, len(n.Stream.TagDirectives))
+			copy(s.TagDirectives, n.Stream.TagDirectives)
+		}
+		c.Stream = s
+	}
+	return c
 }
 
 // From http://yaml.org/type/float.html, except the regular expression there
@@ -397,10 +445,11 @@ func (r *Representer) nilv() *Node {
 	}
 }
 
-// nodev returns a node value as-is without conversion.
+// nodev returns a deep copy of a node value. Copying ensures the caller's
+// node tree is never mutated by later pipeline stages, whether the *Node is
+// passed to Marshal directly or nested inside a struct, map, or slice.
 func (r *Representer) nodev(in reflect.Value) *Node {
-	// Return the node as-is - no conversion needed
-	return in.Interface().(*Node)
+	return deepCopyNode(in.Interface().(*Node), map[*Node]*Node{})
 }
 
 // Len returns the number of keys in the list.

--- a/node_test.go
+++ b/node_test.go
@@ -784,3 +784,21 @@ func TestNodeDumpInvalidOptions(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.ErrorMatches(t, ".*indent must be.*", err)
 }
+
+func TestMarshalDoesNotMutateNode(t *testing.T) {
+	const data = "type: array\nlimit: 5\n"
+
+	var node yaml.Node
+	assert.NoError(t, yaml.Unmarshal([]byte(data), &node))
+
+	// An independent decode of the same input is the read-only baseline.
+	var want yaml.Node
+	assert.NoError(t, yaml.Unmarshal([]byte(data), &want))
+
+	_, err := yaml.Marshal(&node)
+	assert.NoError(t, err)
+
+	// Marshal must treat its input as read-only: the resolved tags
+	// (!!map, !!str, !!int) decoded into node must survive unchanged.
+	assert.DeepEqual(t, &want, &node)
+}


### PR DESCRIPTION
Fixes #371.

`Marshal` is documented to treat its input as read-only, but passing a
`*Node` leaves the caller's tree with every resolvable tag stripped:

```go
var node yaml.Node
yaml.Unmarshal([]byte("type: array\nlimit: 5\n"), &node)
yaml.Marshal(&node)
// node.Content[0].Tag is now "" (was "!!map"), and so on for the
// !!str / !!int children.
```

### Cause

The representer hands a user-supplied `*Node` straight into the rest of
the dump pipeline: `Represent` returns a document node as-is, and
`nodev` returns nested `*Node` values as-is. The desolver then clears
inferable tags (`!!str`, `!!int`, `!!map`, ...) **in place** to keep the
output clean, so the mutation lands on the caller's own node.

### Fix

Deep-copy the user-supplied node in the representer before it enters the
pipeline. A `deepCopyNode` helper copies `Content`, `Alias`, and
`Stream`, using a `seen` map so shared anchors keep their identity and
cyclic alias graphs don't recurse forever. It's wired at both `*Node`
entry points: the document-node branch in `Represent` and `nodev` (which
also covers `*Node` values nested inside a struct, map, or slice).

Only `*Node` inputs pay the copy cost; representer-built trees (from
maps, structs, slices) are already fresh and untouched.

### Verification

- `go test . -run TestMarshalDoesNotMutateNode` passes with the fix and
  fails without it (tags wiped on the input node).
- `go test ./...`: main, internal, and cmd suites green; the
  yaml-test-suite results are unchanged at 1383 pass / 225 known-fail.