### PR TITLE
Allow timestamp-tagged scalars to unmarshal into strings

### DIFF
--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -394,6 +394,10 @@ func (c *Constructor) constructTimestamp(n *Node, resolved any, out reflect.Valu
 			out.Set(resolvedv)
 			return true
 		}
+	case reflect.String:
+		// Allow timestamp values to be constructed as string.
+		out.SetString(n.Value)
+		return true
 	case reflect.Interface:
 		out.Set(reflect.ValueOf(resolved))
 		return true

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -556,6 +556,46 @@ var unmarshalTests = []struct {
 		"a: 2015-01-01",
 		map[string]any{"a": time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)},
 	},
+	{
+		// implicit timestamp tag into string.
+		"a: 2015-01-01",
+		map[string]string{"a": "2015-01-01"},
+	},
+	{
+		// implicit timestamp tag on quoted string into string.
+		"a: \"2015-01-01\"",
+		map[string]string{"a": "2015-01-01"},
+	},
+	{
+		// implicit timestamp tag with time and fraction into string.
+		"a: 2015-02-24T18:19:39.12Z",
+		map[string]string{"a": "2015-02-24T18:19:39.12Z"},
+	},
+	{
+		// implicit timestamp tag with time and fraction on quoted string into string.
+		"a: \"2015-02-24T18:19:39.12Z\"",
+		map[string]string{"a": "2015-02-24T18:19:39.12Z"},
+	},
+	{
+		// explicit timestamp tag on unquoted string into string.
+		"a: !!timestamp 2015-01-01",
+		map[string]string{"a": "2015-01-01"},
+	},
+	{
+		// explicit timestamp tag into string.
+		"a: !!timestamp \"2015-01-01\"",
+		map[string]string{"a": "2015-01-01"},
+	},
+	{
+		// explicit timestamp tag with time and fraction on unquoted string into string.
+		"a: !!timestamp 2015-02-24T18:19:39.12Z",
+		map[string]string{"a": "2015-02-24T18:19:39.12Z"},
+	},
+	{
+		// explicit timestamp tag with time and fraction into string.
+		"a: !!timestamp \"2015-02-24T18:19:39.12Z\"",
+		map[string]string{"a": "2015-02-24T18:19:39.12Z"},
+	},
 
 	// UTF-16-LE
 	{


### PR DESCRIPTION
constructTimestamp only handled time.Time and interface{} targets. A plain scalar resolving to the timestamp tag left a string field at its zero value instead of the raw text. This adds a string case that writes the scalar directly, the same fallback other scalar tags already have.


Fixes #376