### PR TITLE
Honor quote preference for legacy-quoted scalars

### DIFF
--- a/internal/libyaml/representer.go
+++ b/internal/libyaml/representer.go
@@ -289,6 +289,10 @@ func (r *Representer) stringv(tag string, in reflect.Value) *Node {
 	case needsQuoting:
 		// Force quoting for YAML 1.1 compatibility values
 		style = SingleQuotedStyle
+		// and honor the configured quote preference.
+		if r.quotePreference.ScalarStyle() == DOUBLE_QUOTED_SCALAR_STYLE {
+			style = DoubleQuotedStyle
+		}
 	default:
 		// Plain style by default - Desolver will add quotes if type mismatch
 		style = 0

--- a/testdata/encode.yaml
+++ b/testdata/encode.yaml
@@ -315,7 +315,7 @@
       a: '1:1'
     type: map[string]string
     want: |
-      a: '1:1'
+      a: "1:1"
 
 - encode:
     name: null byte in string
@@ -396,7 +396,7 @@
       '<<': []
     type: map[string]any
     want: |
-      '<<': []
+      "<<": []
 
 - encode:
     name: merge key as value
@@ -404,7 +404,7 @@
       foo: '<<'
     type: map[string]any
     want: |
-      foo: '<<'
+      foo: "<<"
 
 # Long strings
 - encode:
@@ -509,7 +509,7 @@
       a: off
     type: testStructA_String
     want: |
-      a: 'off'
+      a: "off"
 
 # Struct tests with yaml tags
 - encode:
@@ -801,6 +801,26 @@
     want: |
       v: '-'
 
+- encode-opts:
+    name: QuoteSingle - string "off" (YAML 1.1 bool, representer path)
+    data:
+      v: 'off'
+    type: map[string]string
+    opts:
+      required-quotes: single
+    want: |
+      v: 'off'
+
+- encode-opts:
+    name: QuoteSingle - merge key "<<" (representer path)
+    data:
+      '<<': []
+    type: map[string]any
+    opts:
+      required-quotes: single
+    want: |
+      '<<': []
+
 # WithQuotePreference tests - QuoteDouble
 - encode-opts:
     name: QuoteDouble - string "true"
@@ -882,6 +902,26 @@
     want: |
       v: "-"
 
+- encode-opts:
+    name: QuoteDouble - string "off" (YAML 1.1 bool, representer path)
+    data:
+      v: 'off'
+    type: map[string]string
+    opts:
+      required-quotes: double
+    want: |
+      v: "off"
+
+- encode-opts:
+    name: QuoteDouble - merge key "<<" (representer path)
+    data:
+      '<<': []
+    type: map[string]any
+    opts:
+      required-quotes: double
+    want: |
+      "<<": []
+
 # WithQuotePreference tests - QuoteLegacy (v3 behavior)
 # Legacy: bool-like strings (representer) → double quotes
 # Legacy: whitespace strings (emitter) → single quotes
@@ -924,6 +964,16 @@
       required-quotes: legacy
     want: |
       v: "123"
+
+- encode-opts:
+    name: QuoteLegacy - string "off" (YAML 1.1 bool, double from representer)
+    data:
+      v: 'off'
+    type: map[string]string
+    opts:
+      required-quotes: legacy
+    want: |
+      v: "off"
 
 - encode-opts:
     name: QuoteLegacy - leading whitespace (single from emitter)


### PR DESCRIPTION
`stringv()` method of `Representer` hardcoded single-quote style whenever a string needed quoting to avoid being misread as an old-style bool, base60 float, or merge key, bypassing the configured QuotePreference entirely. `Marshal()` always requests `WithV3Defaults()` (`QuoteLegacy`) for backward compatibility with the legacy encoder, so every caller of plain `Marshal()` silently got single-quoted output no matter what preference it asked for.
