### PR TITLE
Quote multiline scalars that start with tabs

### DIFF
--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -250,6 +250,10 @@ func shouldUseLiteralStyle(s string) bool {
 	if !strings.Contains(s, "\n") || len(s) < 2 {
 		return false
 	}
+	withoutLeadingBreaks := strings.TrimLeft(s, "\r\n\u0085\u2028\u2029")
+	if strings.HasPrefix(withoutLeadingBreaks, "\t") {
+		return false
+	}
 	// Must contain at least one non-whitespace character
 	for _, r := range s {
 		if !unicode.IsSpace(r) {

--- a/internal/libyaml/serializer.go
+++ b/internal/libyaml/serializer.go
@@ -215,8 +215,10 @@ func (s *Serializer) node(node *Node, tail string) {
 			style = LITERAL_SCALAR_STYLE
 		case node.Style&FoldedStyle != 0:
 			style = FOLDED_SCALAR_STYLE
-		case strings.Contains(value, "\n"):
+		case shouldUseLiteralStyle(value):
 			style = LITERAL_SCALAR_STYLE
+		case strings.Contains(value, "\n"):
+			style = DOUBLE_QUOTED_SCALAR_STYLE
 		case forceQuoting:
 			style = s.quotePreference.ScalarStyle()
 		}

--- a/internal/libyaml/testdata/node.yaml
+++ b/internal/libyaml/testdata/node.yaml
@@ -298,6 +298,21 @@
   from: "hello\nworld"
   want: true
 
+- name: shouldUseLiteralStyle with leading tab
+  type: should-literal
+  from: "\tcontent\nnext"
+  want: false
+
+- name: shouldUseLiteralStyle with leading break then tab
+  type: should-literal
+  from: "\n\tcontent\nnext"
+  want: false
+
+- name: shouldUseLiteralStyle with tab on later line
+  type: should-literal
+  from: "first\n\tsecond"
+  want: true
+
 - name: shouldUseLiteralStyle with single char
   type: should-literal
   from: "a"

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -2984,28 +2984,38 @@ func TestScalarStyleWithTabs(t *testing.T) {
 		},
 		{
 			"\tThis starts with tab\nand is long enough\nfor literal style",
-			"|-\n    \tThis starts with tab\n    and is long enough\n    for literal style\n",
+			"\"\\tThis starts with tab\\nand is long enough\\nfor literal style\"\n",
 			"Multiline starting with tab",
 		},
 		{
 			"\tB\n\tC\n",
-			"|\n    \tB\n    \tC\n",
+			"\"\\tB\\n\\tC\\n\"\n",
 			"Tab B newline tab C newline",
 		},
 		{
 			"\ta\n",
-			"|\n    \ta\n",
+			"\"\\ta\\n\"\n",
 			"Tab + char + newline",
 		},
 		{
 			"\thello\n",
-			"|\n    \thello\n",
+			"\"\\thello\\n\"\n",
 			"Tab + text + newline",
 		},
 		{
 			"\t\nhello",
-			"|-\n    \t\n    hello\n",
+			"\"\\t\\nhello\"\n",
 			"Tab + newline + text",
+		},
+		{
+			"\n\tthis\nnext",
+			"\"\\n\\tthis\\nnext\"\n",
+			"Tab after initial newline",
+		},
+		{
+			"first\n\tsecond",
+			"|-\n    first\n    \tsecond\n",
+			"Tab after content line",
 		},
 	}
 
@@ -3015,6 +3025,53 @@ func TestScalarStyleWithTabs(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expected, string(data))
 		})
+	}
+}
+
+func TestLeadingTabScalarRoundTrip(t *testing.T) {
+	testCases := []struct {
+		value      string
+		mapYAML    string
+		scalarYAML string
+	}{
+		{
+			"\tthis\nis\nmultiline",
+			"text: \"\\tthis\\nis\\nmultiline\"\n",
+			"\"\\tthis\\nis\\nmultiline\"\n",
+		},
+		{
+			"\n\tthis\nnext",
+			"text: \"\\n\\tthis\\nnext\"\n",
+			"\"\\n\\tthis\\nnext\"\n",
+		},
+		{
+			"first\n\tsecond",
+			"text: |-\n    first\n    \tsecond\n",
+			"|-\n    first\n    \tsecond\n",
+		},
+	}
+
+	for _, testCase := range testCases {
+		wantMap := map[string]string{"text": testCase.value}
+		data, err := yaml.Marshal(wantMap)
+		assert.NoError(t, err)
+		assert.Equal(t, testCase.mapYAML, string(data))
+
+		var gotMap map[string]string
+		err = yaml.Unmarshal(data, &gotMap)
+		assert.NoError(t, err)
+		assert.DeepEqual(t, wantMap, gotMap)
+
+		var node yaml.Node
+		node.SetString(testCase.value)
+		data, err = yaml.Marshal(&node)
+		assert.NoError(t, err)
+		assert.Equal(t, testCase.scalarYAML, string(data))
+
+		var gotScalar string
+		err = yaml.Unmarshal(data, &gotScalar)
+		assert.NoError(t, err)
+		assert.Equal(t, testCase.value, gotScalar)
 	}
 }
 


### PR DESCRIPTION
Fixes #383.

Multiline values whose first content character is a tab are now emitted as double-quoted scalars, so output from Marshal can be read back by Unmarshal. The same selection is used for unstyled Nodes created with SetString.

Tabs on later lines continue to use literal style. Tests cover direct leading tabs, initial line breaks, map values, and Nodes.