### PR TITLE
Add UnmarshalerWithContext on the v3 line

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -16,6 +16,7 @@
 package yaml
 
 import (
+	"context"
 	"encoding"
 	"encoding/base64"
 	"fmt"
@@ -325,6 +326,12 @@ type decoder struct {
 	aliasDepth  int
 
 	mergedFields map[interface{}]bool
+
+	// ctx is handed to types implementing UnmarshalerWithContext.
+	// UnmarshalYAML is given a node and nothing else, so a type needing state
+	// belonging to the decode rather than to its own node has no other way to
+	// reach it. Nil means no context was supplied.
+	ctx context.Context
 }
 
 var (
@@ -364,6 +371,24 @@ func (d *decoder) terror(n *Node, tag string, out reflect.Value) {
 
 func (d *decoder) callUnmarshaler(n *Node, u Unmarshaler) (good bool) {
 	err := u.UnmarshalYAML(n)
+	if e, ok := err.(*TypeError); ok {
+		d.terrors = append(d.terrors, e.Errors...)
+		return false
+	}
+	if err != nil {
+		fail(err)
+	}
+	return true
+}
+
+// callUnmarshalerWithContext invokes the context-aware UnmarshalYAML method,
+// handling errors exactly as callUnmarshaler does.
+func (d *decoder) callUnmarshalerWithContext(n *Node, u UnmarshalerWithContext) (good bool) {
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	err := u.UnmarshalYAML(ctx, n)
 	if e, ok := err.(*TypeError); ok {
 		d.terrors = append(d.terrors, e.Errors...)
 		return false
@@ -419,6 +444,12 @@ func (d *decoder) prepare(n *Node, out reflect.Value) (newout reflect.Value, unm
 		}
 		if out.CanAddr() {
 			outi := out.Addr().Interface()
+			// The context-aware form wins, so a type implementing both is
+			// given the richer one.
+			if u, ok := outi.(UnmarshalerWithContext); ok {
+				good = d.callUnmarshalerWithContext(n, u)
+				return out, true, good
+			}
 			if u, ok := outi.(Unmarshaler); ok {
 				good = d.callUnmarshaler(n, u)
 				return out, true, good

--- a/decode_context_test.go
+++ b/decode_context_test.go
@@ -1,0 +1,73 @@
+package yaml_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+type ctxKey struct{}
+
+// withCtx records the context it was decoded with, and the value it found.
+type withCtx struct {
+	Name string
+	seen string
+}
+
+func (w *withCtx) UnmarshalYAML(ctx context.Context, n *yaml.Node) error {
+	type bis withCtx
+	if err := n.Decode((*bis)(w)); err != nil {
+		return err
+	}
+	if v, ok := ctx.Value(ctxKey{}).(string); ok {
+		w.seen = v
+	}
+	return nil
+}
+
+func TestUnmarshalWithContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxKey{}, "from-caller")
+	var w withCtx
+	if err := yaml.UnmarshalWithContext(ctx, []byte("name: n\n"), &w); err != nil {
+		t.Fatal(err)
+	}
+	if w.Name != "n" || w.seen != "from-caller" {
+		t.Fatalf("got name=%q seen=%q", w.Name, w.seen)
+	}
+}
+
+// Unmarshal still works on a type implementing only the context form; it just
+// receives a background context.
+func TestUnmarshalWithoutContext(t *testing.T) {
+	var w withCtx
+	if err := yaml.Unmarshal([]byte("name: n\n"), &w); err != nil {
+		t.Fatal(err)
+	}
+	if w.Name != "n" || w.seen != "" {
+		t.Fatalf("got name=%q seen=%q", w.Name, w.seen)
+	}
+}
+
+// Each decode sees its own context, with no state shared between them.
+func TestUnmarshalWithContextConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		want := string(rune('a' + i%26))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx := context.WithValue(context.Background(), ctxKey{}, want)
+			var w withCtx
+			if err := yaml.UnmarshalWithContext(ctx, []byte("name: n\n"), &w); err != nil {
+				t.Error(err)
+				return
+			}
+			if w.seen != want {
+				t.Errorf("got %q, want %q", w.seen, want)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/yaml.go
+++ b/yaml.go
@@ -21,6 +21,7 @@
 package yaml
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -34,6 +35,13 @@ import (
 // behavior when being unmarshaled from a YAML document.
 type Unmarshaler interface {
 	UnmarshalYAML(value *Node) error
+}
+
+// UnmarshalerWithContext is Unmarshaler with a context, for a type that needs
+// state belonging to the decode rather than to its own node. A type
+// implementing both is given this one.
+type UnmarshalerWithContext interface {
+	UnmarshalYAML(ctx context.Context, value *Node) error
 }
 
 type obsoleteUnmarshaler interface {
@@ -87,10 +95,28 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, false)
 }
 
+// UnmarshalWithContext unmarshals like Unmarshal, handing ctx to any value
+// implementing UnmarshalerWithContext.
+func UnmarshalWithContext(ctx context.Context, in []byte, out interface{}) (err error) {
+	return unmarshalContext(ctx, in, out, false)
+}
+
 // A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
 	parser      *parser
 	knownFields bool
+	// ctx is set only by DecodeWithContext, for the decoder to hand to values
+	// implementing UnmarshalerWithContext.
+	ctx context.Context
+}
+
+// DecodeWithContext decodes like Decode, handing ctx to any value
+// implementing UnmarshalerWithContext.
+func (dec *Decoder) DecodeWithContext(ctx context.Context, v interface{}) error {
+	prev := dec.ctx
+	dec.ctx = ctx
+	defer func() { dec.ctx = prev }()
+	return dec.Decode(v)
 }
 
 // NewDecoder returns a new decoder that reads from r.
@@ -117,6 +143,7 @@ func (dec *Decoder) KnownFields(enable bool) {
 func (dec *Decoder) Decode(v interface{}) (err error) {
 	d := newDecoder()
 	d.knownFields = dec.knownFields
+	d.ctx = dec.ctx
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {
@@ -145,6 +172,45 @@ func (n *Node) Decode(v interface{}) (err error) {
 		out = out.Elem()
 	}
 	d.unmarshal(n, out)
+	if len(d.terrors) > 0 {
+		return &TypeError{d.terrors}
+	}
+	return nil
+}
+
+// DecodeWithContext decodes like Decode, handing ctx to any value
+// implementing UnmarshalerWithContext.
+func (n *Node) DecodeWithContext(ctx context.Context, v interface{}) (err error) {
+	d := newDecoder()
+	d.ctx = ctx
+	defer handleErr(&err)
+	out := reflect.ValueOf(v)
+	if out.Kind() == reflect.Ptr && !out.IsNil() {
+		out = out.Elem()
+	}
+	d.unmarshal(n, out)
+	if len(d.terrors) > 0 {
+		return &TypeError{d.terrors}
+	}
+	return nil
+}
+
+// unmarshalContext is unmarshal with a context for the decoder to hand to
+// values implementing UnmarshalerWithContext.
+func unmarshalContext(ctx context.Context, in []byte, out interface{}, strict bool) (err error) {
+	defer handleErr(&err)
+	d := newDecoder()
+	d.ctx = ctx
+	p := newParser(in)
+	defer p.destroy()
+	node := p.parse()
+	if node != nil {
+		v := reflect.ValueOf(out)
+		if v.Kind() == reflect.Ptr && !v.IsNil() {
+			v = v.Elem()
+		}
+		d.unmarshal(node, v)
+	}
 	if len(d.terrors) > 0 {
 		return &TypeError{d.terrors}
 	}


### PR DESCRIPTION
Closes #187 on the v3 line. Carries forward the unmarshal half of #186.

A type implementing `UnmarshalerWithContext` receives the context its decode was started with:

```go
type UnmarshalerWithContext interface {
	UnmarshalYAML(ctx context.Context, value *Node) error
}
```

with `UnmarshalWithContext`, `Decoder.DecodeWithContext` and `Node.DecodeWithContext` to supply it. A type implementing both interfaces gets this one. A type implementing neither is untouched, and `Unmarshal` on a context-only type passes `context.Background()`.

## On the open design question in #187

The discussion there stalled on whether this should be an option rather than new interfaces, so this PR takes a position and I am happy to be overruled on it.

An option would mean holding a `context.Context` in the options struct, which is the pattern the Go standard library and vet checks steer away from, and which @ccoVeille raised in the thread. What this PR does instead keeps the context as a first argument at every public entry point, and the decoder holds it only for the length of a single call:

```go
func (dec *Decoder) DecodeWithContext(ctx context.Context, v interface{}) error {
	prev := dec.ctx
	dec.ctx = ctx
	defer func() { dec.ctx = prev }()
	return dec.Decode(v)
}
```

So it is not stored across calls, and nothing about one decode reaches another. If you would still prefer the option shape, say so and I will rework it; the dispatch and the plumbing are the same either way, and only the entry points change.

## Why v3 and not main

#186 targets `main`, which is now `v4` and still at `rc`. The released line is `v3.0.5`, so a consumer that cannot take a release candidate cannot use this until v4 ships.

I have the same change ported to the current `main` layout as well, where the restructure into `internal/libyaml` is what left #186 conflicting. Happy to open that as a separate PR, or to fold this into a refresh of #186, whichever you prefer. I did not want to push at #186 uninvited.

## Tests

`decode_context_test.go` covers the context reaching an unmarshaler, `Unmarshal` on a context-only type getting a background context, and twenty concurrent decodes each asserting it observed its **own** context. The existing suite passes under `-race`.
