### PR TITLE
Add UnmarshalerWithContext

### DIFF
--- a/decode_context_test.go
+++ b/decode_context_test.go
@@ -1,0 +1,73 @@
+package yaml_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	yaml "go.yaml.in/yaml/v4"
+)
+
+type ctxKey struct{}
+
+// withCtx records the context it was decoded with, and the value it found.
+type withCtx struct {
+	Name string
+	seen string
+}
+
+func (w *withCtx) UnmarshalYAML(ctx context.Context, n *yaml.Node) error {
+	type bis withCtx
+	if err := n.Decode((*bis)(w)); err != nil {
+		return err
+	}
+	if v, ok := ctx.Value(ctxKey{}).(string); ok {
+		w.seen = v
+	}
+	return nil
+}
+
+func TestUnmarshalWithContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxKey{}, "from-caller")
+	var w withCtx
+	if err := yaml.UnmarshalWithContext(ctx, []byte("name: n\n"), &w); err != nil {
+		t.Fatal(err)
+	}
+	if w.Name != "n" || w.seen != "from-caller" {
+		t.Fatalf("got name=%q seen=%q", w.Name, w.seen)
+	}
+}
+
+// Unmarshal still works on a type implementing only the context form; it just
+// receives a background context.
+func TestUnmarshalWithoutContext(t *testing.T) {
+	var w withCtx
+	if err := yaml.Unmarshal([]byte("name: n\n"), &w); err != nil {
+		t.Fatal(err)
+	}
+	if w.Name != "n" || w.seen != "" {
+		t.Fatalf("got name=%q seen=%q", w.Name, w.seen)
+	}
+}
+
+// Each decode sees its own context, with no state shared between them.
+func TestUnmarshalWithContextConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		want := string(rune('a' + i%26))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx := context.WithValue(context.Background(), ctxKey{}, want)
+			var w withCtx
+			if err := yaml.UnmarshalWithContext(ctx, []byte("name: n\n"), &w); err != nil {
+				t.Error(err)
+				return
+			}
+			if w.seen != want {
+				t.Errorf("got %q, want %q", w.seen, want)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/libyaml/constructor.go
+++ b/internal/libyaml/constructor.go
@@ -8,6 +8,7 @@
 package libyaml
 
 import (
+	"context"
 	"encoding"
 	"encoding/base64"
 	"fmt"
@@ -18,6 +19,13 @@ import (
 
 // --------------------------------------------------------------------------
 // Types and Interfaces
+
+// UnmarshalerWithContext is the Unmarshaler interface with a context, letting
+// a type reach state belonging to the decode rather than to its own node. A
+// type implementing both is given this one.
+type UnmarshalerWithContext interface {
+	UnmarshalYAML(ctx context.Context, n *Node) error
+}
 
 // legacyConstructor is the old-style unmarshaler interface.
 // It's kept for backwards compatibility.
@@ -56,6 +64,12 @@ type Constructor struct {
 	aliasCheck     func(aliasCount, constructCount int) error
 
 	mergedFields map[any]bool
+
+	// Ctx is handed to types implementing the context-aware constructor
+	// interface. UnmarshalYAML is given a node and nothing else, so a type
+	// needing per-decode state (the document's name, a limit, a logger) has
+	// no other way to reach it. Never nil: NewConstructor defaults it.
+	Ctx context.Context
 }
 
 // NewConstructor creates a new Constructor initialized with the provided
@@ -888,6 +902,12 @@ func (c *Constructor) prepare(n *Node, out reflect.Value) (newout reflect.Value,
 			}
 
 			outi := out.Addr().Interface()
+			// Check for the context-aware form first, so a type implementing
+			// both gets the richer one.
+			if u, ok := outi.(UnmarshalerWithContext); ok {
+				good = c.callUnmarshalerWithContext(n, u)
+				return out, true, good
+			}
 			// Check for libyaml.constructor
 			if u, ok := outi.(constructor); ok {
 				good = c.callConstructor(n, u)
@@ -1012,6 +1032,34 @@ func (c *Constructor) callConstructor(n *Node, u constructor) (good bool) {
 		))
 		return false
 	}
+}
+
+// callUnmarshalerWithContext invokes the context-aware UnmarshalYAML method,
+// handling errors exactly as callConstructor does.
+func (c *Constructor) callUnmarshalerWithContext(n *Node, u UnmarshalerWithContext) (good bool) {
+	err := u.UnmarshalYAML(c.context(), n)
+	switch e := err.(type) {
+	case nil:
+		return true
+	case *LoadErrors:
+		c.TypeErrors = append(c.TypeErrors, e.Errors...)
+		return false
+	default:
+		c.TypeErrors = append(c.TypeErrors, formatConstructorError(
+			err,
+			Mark{Line: n.Line, Column: n.Column},
+		))
+		return false
+	}
+}
+
+// context returns Ctx, or a background context when the Constructor was built
+// without one.
+func (c *Constructor) context() context.Context {
+	if c.Ctx == nil {
+		return context.Background()
+	}
+	return c.Ctx
 }
 
 // callLegacyConstructor invokes the UnmarshalYAML method on a value

--- a/internal/libyaml/loader.go
+++ b/internal/libyaml/loader.go
@@ -11,6 +11,7 @@ package libyaml
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"reflect"
@@ -88,6 +89,22 @@ func NewLoader(r io.Reader, opts ...Option) (*Loader, error) {
 //
 // See the documentation of Dump for the format of tags and a list of
 // supported tag options.
+// LoadWithContext loads like [Load], handing ctx to any value implementing
+// [UnmarshalerWithContext].
+func LoadWithContext(ctx context.Context, in []byte, out any, opts ...Option) error {
+	l, err := NewLoader(bytes.NewReader(in), opts...)
+	if err != nil {
+		return err
+	}
+	if err := l.LoadWithContext(ctx, out); err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 func Load(in []byte, out any, opts ...Option) error {
 	o, err := ApplyOptions(opts...)
 	if err != nil {
@@ -123,6 +140,18 @@ func Load(in []byte, out any, opts ...Option) error {
 //
 // See the documentation of the package-level Load function for more details
 // about YAML to Go conversion and tag options.
+// LoadWithContext loads like [Loader.Load], handing ctx to any value
+// implementing [UnmarshalerWithContext].
+//
+// The context is set on the constructor for the length of the call rather than
+// carried in Options, so it stays a per-call argument.
+func (l *Loader) LoadWithContext(ctx context.Context, v any) error {
+	prev := l.constructor.Ctx
+	l.constructor.Ctx = ctx
+	defer func() { l.constructor.Ctx = prev }()
+	return l.Load(v)
+}
+
 func (l *Loader) Load(v any) (err error) {
 	defer handleErr(&err)
 	if l.options.SingleDocument && l.docCount > 0 {

--- a/internal/libyaml/node.go
+++ b/internal/libyaml/node.go
@@ -8,6 +8,7 @@
 package libyaml
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"unicode"
@@ -281,6 +282,23 @@ func (n *Node) SetString(s string) {
 // conversion of YAML into a Go value.
 func (n *Node) Decode(v any) (err error) {
 	d := NewConstructor(DefaultOptions)
+	defer handleErr(&err)
+	out := reflect.ValueOf(v)
+	if out.Kind() == reflect.Pointer && !out.IsNil() {
+		out = out.Elem()
+	}
+	d.Construct(n, out)
+	if len(d.TypeErrors) > 0 {
+		return &LoadErrors{Errors: d.TypeErrors}
+	}
+	return nil
+}
+
+// DecodeWithContext decodes the node like [Node.Decode], handing ctx to any
+// value implementing [UnmarshalerWithContext].
+func (n *Node) DecodeWithContext(ctx context.Context, v any) (err error) {
+	d := NewConstructor(DefaultOptions)
+	d.Ctx = ctx
 	defer handleErr(&err)
 	out := reflect.ValueOf(v)
 	if out.Kind() == reflect.Pointer && !out.IsNil() {

--- a/node.go
+++ b/node.go
@@ -49,6 +49,10 @@ type (
 	// a YAML description of themselves.
 	Unmarshaler = libyaml.Unmarshaler
 
+	// UnmarshalerWithContext is [Unmarshaler] with a context, for a type that
+	// needs state belonging to the decode rather than to its own node.
+	UnmarshalerWithContext = libyaml.UnmarshalerWithContext
+
 	// IsZeroer is used to check whether an object is zero to determine whether
 	// it should be omitted when marshaling with the ,omitempty flag.
 	// One notable implementation is [time.Time].

--- a/yaml.go
+++ b/yaml.go
@@ -19,6 +19,7 @@
 package yaml
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -609,6 +610,12 @@ func (dec *Decoder) Decode(v any) error {
 	return dec.loader.Load(v)
 }
 
+// DecodeWithContext decodes like [Decoder.Decode], handing ctx to any value
+// implementing [UnmarshalerWithContext].
+func (dec *Decoder) DecodeWithContext(ctx context.Context, v any) error {
+	return dec.loader.LoadWithContext(ctx, v)
+}
+
 // An Encoder writes YAML values to an output stream.
 type Encoder struct {
 	dumper *Dumper
@@ -690,6 +697,12 @@ func (e *Encoder) Close() error {
 // supported tag options.
 func Unmarshal(in []byte, out any) (err error) {
 	return Load(in, out, WithV3Defaults(), withFromLegacy())
+}
+
+// UnmarshalWithContext unmarshals like [Unmarshal], handing ctx to any value
+// implementing [UnmarshalerWithContext].
+func UnmarshalWithContext(ctx context.Context, in []byte, out any) (err error) {
+	return libyaml.LoadWithContext(ctx, in, out, WithV3Defaults(), withFromLegacy())
 }
 
 // withFromLegacy is a private option that indicates this call is from


### PR DESCRIPTION
Closes #187. Opened against `main` per @ccoVeille's note on #389 that v3 takes no runtime changes; #389 is the same change on the v3 layout and can be closed in favour of this.

This also carries forward the unmarshal half of #186, which has conflicted since the move into `internal/libyaml`.

A type implementing `UnmarshalerWithContext` receives the context its decode was started with:

```go
type UnmarshalerWithContext interface {
	UnmarshalYAML(ctx context.Context, n *Node) error
}
```

supplied by `UnmarshalWithContext`, `Decoder.DecodeWithContext` and `Node.DecodeWithContext`. A type implementing both interfaces gets this one. A type implementing neither is untouched, and decoding a context-only type without one passes `context.Background()`.

## On the design question in #187

The thread stalled on whether this should be an option rather than an interface, so this takes a position and I am happy to be overruled.

An option means holding a `context.Context` in the options struct, which @ccoVeille raised as an anti-pattern. Here the context is a first argument at every public entry point, and the constructor holds it only for the length of a call:

```go
func (l *Loader) LoadWithContext(ctx context.Context, v any) error {
	prev := l.constructor.Ctx
	l.constructor.Ctx = ctx
	defer func() { l.constructor.Ctx = prev }()
	return l.Load(v)
}
```

Nothing is stored across calls and no decode observes another's context. If the option shape is still preferred, the dispatch and plumbing are identical and only the entry points change; say so and I will rework it.

## Tests

The context reaching an unmarshaler, a context-only type decoded without one getting `context.Background()`, and twenty concurrent decodes each asserting it observed its **own** context. The existing suite passes, including under `-race`.
