### PR TITLE
Fix block scalar indentation indicator

### DIFF
--- a/internal/libyaml/emitter.go
+++ b/internal/libyaml/emitter.go
@@ -1989,7 +1989,18 @@ func (emitter *Emitter) writeBlockScalarHints(value []byte) error {
 		// https://github.com/yaml/go-yaml/issues/65
 		// isLineBreak(value, 0) removed as the linebreak will only
 		// write the indentation value.
-		indent_hint := []byte{'0' + byte(emitter.BestIndent)}
+		// The indentation indicator is relative to the indentation of the
+		// parent node, and this emitter does not always indent by BestIndent
+		// (a block sequence item only adds 2), so use the actual difference.
+		parent_indent := 0
+		if len(emitter.indents) > 0 && emitter.indents[len(emitter.indents)-1] > 0 {
+			parent_indent = emitter.indents[len(emitter.indents)-1]
+		}
+		indent := emitter.indent - parent_indent
+		if indent < 1 || indent > 9 {
+			indent = emitter.BestIndent
+		}
+		indent_hint := []byte{'0' + byte(indent)}
 		if err := emitter.writeIndicator(indent_hint, false, false, false); err != nil {
 			return err
 		}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -2739,6 +2739,42 @@ func TestSetIndent(t *testing.T) {
 	assert.Equal(t, "a:\n        b:\n                c: d\n", buf.String())
 }
 
+// A block scalar whose content starts with a space needs an explicit
+// indentation indicator, and that indicator is relative to the indentation of
+// the parent node.
+// See https://github.com/go-yaml/yaml/issues/1071
+func TestBlockScalarIndentIndicatorRoundTrip(t *testing.T) {
+	type params struct {
+		Description string `yaml:"description"`
+	}
+	type spec struct {
+		Parameters []params `yaml:"parameters"`
+	}
+
+	for _, indent := range []int{0, 1, 2, 3, 4, 8} {
+		for _, description := range []string{
+			"  a\nb",
+			"     a\nb",
+			" a\n      b",
+		} {
+			in := spec{Parameters: []params{{Description: description}}}
+
+			var buf bytes.Buffer
+			enc := yaml.NewEncoder(&buf)
+			if indent > 0 {
+				enc.SetIndent(indent)
+			}
+			assert.NoError(t, enc.Encode(&in))
+			assert.NoError(t, enc.Close())
+
+			var out spec
+			err := yaml.Unmarshal(buf.Bytes(), &out)
+			assert.NoErrorf(t, err, "indent %d, encoded as:\n%s", indent, buf.String())
+			assert.DeepEqualf(t, in, out, "indent %d, encoded as:\n%s", indent, buf.String())
+		}
+	}
+}
+
 func TestSortedOutput(t *testing.T) {
 	order := []any{
 		false,


### PR DESCRIPTION
## Problem

Reported against the archived v3 repo as [go-yaml/yaml#1071](https://github.com/go-yaml/yaml/issues/1071), and still present in v4.

Marshalling a string whose first line starts with a space, inside a block sequence item, produces a document that cannot be parsed back:

```go
type Params struct {
	Description string `yaml:"description"`
}
type Spec struct {
	Parameters []Params `yaml:"parameters"`
}

spec := Spec{Parameters: []Params{{Description: "  a\nb"}}}
out, _ := yaml.Marshal(&spec)
var got Spec
err := yaml.Unmarshal(out, &got)
```

Before this change `out` is:

```yaml
parameters:
    - description: |4-
          a
        b
```

and `Unmarshal` fails with `did not find expected key`.

## Cause

`writeBlockScalarHints` always emitted `BestIndent` as the explicit indentation indicator. Per the YAML spec that indicator is the scalar's indentation *relative to its parent node*, so `BestIndent` is only right when the scalar is indented exactly `BestIndent` columns past its parent.

This emitter does not always do that: `increaseIndent` adds only 2 columns for the content of a block sequence item (the width of the `- ` indicator). In the example above the scalar sits 2 columns past its parent, but the emitted indicator says 4, so the parser looks for content at the wrong column.

## Fix

Derive the indicator from the actual difference between the scalar's indentation and its parent's indentation. The result is now:

```yaml
parameters:
    - description: |2-
          a
        b
```

which round-trips. `BestIndent` is kept as a fallback if the difference ever falls outside the 1-9 range an indicator can express.

## Tests

Added `TestBlockScalarIndentIndicatorRoundTrip` in `yaml_test.go`, covering several leading-space values across indent settings 0/1/2/3/4/8.

`make test` passes (`ALL TESTS PASS`; yaml-test-suite at `PASS: 1383 / FAIL: 225 (known: 225)`, unchanged), as do `make fmt` and `make lint` (`0 issues.`).

## Note

I found this issue while working through open reports as part of Anthropic's "Claude for Open Source" program, and used Claude Code while diagnosing and preparing the change. I have reviewed and verified everything here myself, and I am happy to iterate on the approach or the naming if you would prefer something different. If unsolicited AI-assisted contributions are not welcome here, please just close this and accept my apologies for the noise.

---

Maintainers' edits

Fixes https://github.com/yaml/go-yaml/issues/399