### PR TITLE
Fix block scalar indentation indicator

### DIFF
--- a/internal/libyaml/emitter.go
+++ b/internal/libyaml/emitter.go
@@ -1985,10 +1985,16 @@ func (emitter *Emitter) writeDoubleQuotedScalar(value []byte, allow_breaks bool)
 // writeBlockScalarHints writes the indentation and chomping indicators for
 // block scalars.
 func (emitter *Emitter) writeBlockScalarHints(value []byte) error {
-	if isSpace(value, 0) {
-		// https://github.com/yaml/go-yaml/issues/65
-		// isLineBreak(value, 0) removed as the linebreak will only
-		// write the indentation value.
+	// A parser infers a block scalar's indentation from its first non-empty
+	// line, so an explicit indentation indicator is needed whenever that line
+	// begins with a space. Leading line breaks only produce empty lines, which
+	// carry no indentation of their own, so skip past them first.
+	// https://github.com/yaml/go-yaml/issues/65
+	i := 0
+	for i < len(value) && isLineBreak(value, i) {
+		i += width(value[i])
+	}
+	if i < len(value) && isSpace(value, i) {
 		indent_hint := []byte{'0' + byte(emitter.BestIndent)}
 		if err := emitter.writeIndicator(indent_hint, false, false, false); err != nil {
 			return err

--- a/internal/libyaml/testdata/emitter.yaml
+++ b/internal/libyaml/testdata/emitter.yaml
@@ -521,6 +521,52 @@
 
           indented tail
 
+
+# Regression tests for block scalars whose first non-empty line is indented.
+# Without an explicit indentation indicator the output does not parse back.
+- roundtrip:
+    name: Literal scalar with leading empty lines and indented content
+    yaml: |
+      key: |2
+
+
+           more indented
+          regular
+    want: |
+      key: |2
+
+
+           more indented
+          regular
+
+- roundtrip:
+    name: Folded scalar with leading empty lines and indented content
+    yaml: |
+      key: >2
+
+
+           more indented
+          regular
+    want: |
+      key: >2
+
+
+           more indented
+          regular
+
+- roundtrip:
+    name: Literal scalar with a leading empty line and indented content
+    yaml: |
+      key: |2
+
+          indented
+        regular
+    want: |
+      key: |2
+
+          indented
+        regular
+
 # Writer test
 - emit-writer:
     name: Writer

--- a/testdata/encode.yaml
+++ b/testdata/encode.yaml
@@ -986,3 +986,49 @@
     want: |
       v: hello
 
+# Regression tests for block scalars whose first non-empty line is indented.
+# Without an explicit indentation indicator the output does not parse back.
+- encode:
+    name: block scalar with leading empty lines and indented content
+    data:
+      v: "\n\n more indented\nregular\n"
+    type: map[string]string
+    want: |
+      v: |4
+
+
+           more indented
+          regular
+
+- encode:
+    name: block scalar with a leading empty line and indented content
+    data:
+      v: "\n  indented\nplain\n"
+    type: map[string]string
+    want: |
+      v: |4
+
+            indented
+          plain
+
+- encode:
+    name: block scalar with an indented first line
+    data:
+      v: " first indented\nregular\n"
+    type: map[string]string
+    want: |
+      v: |4
+           first indented
+          regular
+
+- encode:
+    name: block scalar with a leading empty line and unindented content
+    data:
+      v: "\nno indent\nhere\n"
+    type: map[string]string
+    want: |
+      v: |
+
+          no indent
+          here
+


### PR DESCRIPTION
`Marshal` can emit a block scalar that `Unmarshal` cannot read back:

```go
in := map[string]string{"b": "\n\n more indented\nregular\n"}
out, _ := yaml.Marshal(in)
// b: |
//
//
//      more indented
//     regular

var back map[string]string
err := yaml.Unmarshal(out, &back)
// go-yaml load error in parser (while parsing a block mapping):
// did not find expected key
```

No explicit style is needed to trigger this — the emitter chooses the literal style itself. The same value with `LiteralStyle` or `FoldedStyle` set explicitly fails the same way, and so does the equivalent document read from a file, which is how I found it: `yaml-test-suite` case `F6MC` ("More indented lines at the beginning of folded block scalars") does not survive a decode/encode/decode cycle through this library.

### Cause

A parser infers a block scalar's indentation from its first non-empty line, so an explicit indentation indicator is required whenever that line begins with a space. `writeBlockScalarHints` only tested the very first byte:

```go
if isSpace(value, 0) {
```

When the scalar starts with empty lines that byte is a line break, so the indicator was omitted. The parser then took its indentation from `     more indented` and treated the following, less-indented `    regular` as the end of the scalar.

### Fix

Skip over leading line breaks before testing for a space. Empty lines carry no indentation of their own, so this preserves the behaviour from #65: a scalar whose first non-empty line is *not* indented still gets no indicator, e.g. `"\nno indent\nhere\n"` still emits as `|` with no indicator.

### Tests

Following the pattern used for the #337 regressions, cases were added in two places:

- `internal/libyaml/testdata/emitter.yaml` — three `roundtrip` cases (`|2`, `>2`, and a single leading empty line). On `main` the emitter drops the `2`, turning `key: |2` into `key: |`.
- `testdata/encode.yaml` — four `encode` cases covering leading empty lines, an indented first line, and the unindented case that must keep no indicator.

### Verification

`make check` is green and matches an unmodified `main` on the same machine:

```
golangci-lint fmt ./...   (no changes)
go mod tidy               (no changes)
golangci-lint run ./...   0 issues.
go test . ./internal/... ./cmd/...   all pass
util/yaml-test-suite all  PASS: 1383   FAIL: 225 (known: 225)
shellcheck                ALL SHELL FILES PASS
```

The yaml-test-suite pass/fail split is identical to the recorded baseline, so nothing there changed either way.

I also ran a decode/encode/decode sweep over the 229 yaml-test-suite documents this library can read. On `main` three of them fail to parse back: `4QFQ`, `F6MC`, `P2AD`. With this change `F6MC` passes and the other two are unaffected.

`4QFQ` and `P2AD` are a separate bug in the same function: the indicator is written as `emitter.BestIndent` rather than the indentation actually used for the scalar's content, which is wrong once the scalar is nested in a sequence (`- |4` followed by content indented by three). I left that alone here to keep this change small, and I'm happy to open a follow-up if you'd like it fixed.

---

Maintainers' edits

Fixes https://github.com/yaml/go-yaml/issues/399