### PR TITLE
Treat code points above the BMP as printable

### DIFF
--- a/internal/libyaml/scanner.go
+++ b/internal/libyaml/scanner.go
@@ -627,7 +627,8 @@ func isPrintable(b []byte, i int) bool {
 		(b[i] == 0xEE) ||
 		(b[i] == 0xEF && // #xE000 <= . <= #xFFFD
 			!(b[i+1] == 0xBB && b[i+2] == 0xBF) && // && . != #xFEFF
-			!(b[i+1] == 0xBF && (b[i+2] == 0xBE || b[i+2] == 0xBF))))
+			!(b[i+1] == 0xBF && (b[i+2] == 0xBE || b[i+2] == 0xBF))) ||
+		(b[i] >= 0xF0 && b[i] <= 0xF4)) // #x10000 <= . <= #x10FFFF
 }
 
 // Check if the character at the specified position is NUL.

--- a/internal/libyaml/testdata/scanner.yaml
+++ b/internal/libyaml/testdata/scanner.yaml
@@ -675,6 +675,21 @@
     data: [0xC2, 0xA0]
 
 - char-predicate:
+    name: Is printable - U+10000 (lowest 4 byte sequence)
+    func: isPrintable
+    data: [0xF0, 0x90, 0x80, 0x80]
+
+- char-predicate:
+    name: Is printable - U+1F6A7 (astral plane emoji)
+    func: isPrintable
+    data: [0xF0, 0x9F, 0x9A, 0xA7]
+
+- char-predicate:
+    name: Is printable - U+10FFFF (highest code point)
+    func: isPrintable
+    data: [0xF4, 0x8F, 0xBF, 0xBF]
+
+- char-predicate:
     name: Is printable - null
     func: isPrintable
     data: [0x00]

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -3018,6 +3018,54 @@ func TestScalarStyleWithTabs(t *testing.T) {
 	}
 }
 
+// Code points above the BMP are printable per the YAML spec, so they are
+// emitted as-is and do not stop a multiline scalar using literal style.
+func TestScalarStyleAboveBMP(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+		desc     string
+	}{
+		{
+			"a\U0001F6A7b",
+			"a\U0001F6A7b\n",
+			"Astral plane emoji stays unescaped",
+		},
+		{
+			"\U00010000",
+			"\U00010000\n",
+			"Lowest code point needing four bytes",
+		},
+		{
+			"\U0010FFFF",
+			"\U0010FFFF\n",
+			"Highest code point",
+		},
+		{
+			"one\n\U0001F6A7\ntwo\n",
+			"|\n    one\n    \U0001F6A7\n    two\n",
+			"Multiline with astral plane emoji uses literal style",
+		},
+		{
+			"one\n✅\ntwo\n",
+			"|\n    one\n    ✅\n    two\n",
+			"Multiline with BMP symbol uses literal style",
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("test_%d_%s", i, testCase.desc), func(t *testing.T) {
+			data, err := yaml.Marshal(testCase.input)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, string(data))
+
+			var roundTripped string
+			assert.NoError(t, yaml.Unmarshal(data, &roundTripped))
+			assert.Equal(t, testCase.input, roundTripped)
+		})
+	}
+}
+
 func TestUnicodeWhitespaceHandling(t *testing.T) {
 	// Test cases for Unicode whitespace characters that should be properly handled
 	// by the shouldUseLiteralStyle function using unicode.IsSpace()


### PR DESCRIPTION
Relates to #354.

### The problem

`isPrintable` walks the UTF-8 lead byte ranges up to `0xEF` but has no case for `0xF0`-`0xF4`, so every code point above U+FFFF is reported as unprintable. Two things follow from that in `yaml_emitter_analyze_scalar`: the character is escaped in double quoted style, and `special_characters` clears `block_allowed`, so a multiline string containing one can no longer use literal style.

```go
data, _ := yaml.Marshal(map[string]string{"desc": "one\n\U0001F6A7\ntwo\n"})
```

before:

```yaml
desc: "one\n\U0001F6A7\ntwo\n"
```

after:

```yaml
desc: |
    one
    🚧
    two
```

A BMP symbol such as ✅ (U+2705) already produced the literal block, which is what makes it look as though only "some" characters are affected - the dividing line is exactly whether the character needs four bytes in UTF-8.

### The fix

`c-printable` in the spec is:

```
[1] c-printable ::= #x9 | #xA | #xD | [#x20-#x7E]        /* 8 bit */
                  | #x85 | [#xA0-#xD7FF] | [#xE000-#xFFFD] /* 16 bit */
                  | [#x10000-#x10FFFF]                     /* 32 bit */
```

The last line is the missing one, and `[#x10000-#x10FFFF]` is exactly the set encoded by lead bytes `0xF0`-`0xF4`, so it is one more case in the existing chain. This mirrors how the other ranges are matched on the lead byte, and needs no lookahead, so it doesn't add any new indexing beyond the end of the buffer.

Worth noting for the discussion in #354: no emoji-specific handling is needed for this. ZWJ (U+200D), variation selectors (U+FE0F) and the skin tone modifiers are already printable via the existing ranges - the sequences in that thread were rendering badly only because their base characters live above the BMP. Anything that is a valid code point above U+FFFF is printable, so there is nothing to keep in step with new Unicode releases.

### Tests

- `TestScalarStyleAboveBMP` in `yaml_test.go` covers U+10000, U+10FFFF and an astral plane emoji inline, plus multiline scalars with an astral and a BMP character, and round trips each one.
- Three `isPrintable` cases in `internal/libyaml/testdata/scanner.yaml` for the boundaries.

All of the new tests fail without the change. `go test ./...` passes, including the `yaml-test-suite` conformance run (`go test ./yts/...`) after `make get-test-data`.

The only failure I see locally is `cmd/go-yaml`'s `TestCLI`, which fails the same way on an unmodified checkout here - it shells out with a path that loses its separators on Windows - so it looks unrelated to this change.
