### PR TITLE
Accept omitzero as an alias of omitempty

### DIFF
--- a/internal/libyaml/structmeta.go
+++ b/internal/libyaml/structmeta.go
@@ -157,7 +157,11 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		if len(fields) > 1 {
 			for _, flag := range fields[1:] {
 				switch flag {
-				case "omitempty":
+				case "omitempty", "omitzero":
+					// omitzero is Go 1.24's encoding/json flag. yaml's
+					// omitempty already drops zero values (including structs),
+					// so treat omitzero as the same to avoid panicking on
+					// structs that share tags with json.
 					info.OmitEmpty = true
 				case "flow":
 					info.Flow = true

--- a/omitzero_test.go
+++ b/omitzero_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The go-yaml Project Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml_test
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v4"
+)
+
+func TestUnmarshalOmitZeroFlag(t *testing.T) {
+	type T struct {
+		A string `yaml:"a,omitzero"`
+		B int    `yaml:"b,omitzero"`
+	}
+	var v T
+	if err := yaml.Unmarshal([]byte("a: hi\nb: 2\n"), &v); err != nil {
+		t.Fatal(err)
+	}
+	if v.A != "hi" || v.B != 2 {
+		t.Fatalf("got %+v", v)
+	}
+}
+
+func TestMarshalOmitZeroFlag(t *testing.T) {
+	type T struct {
+		A string `yaml:"a,omitzero"`
+		B int    `yaml:"b,omitzero"`
+	}
+	out, err := yaml.Marshal(T{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "{}\n" {
+		t.Fatalf("got %q", out)
+	}
+	out, err = yaml.Marshal(T{A: "hi", B: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "a: hi\nb: 2\n" {
+		t.Fatalf("got %q", out)
+	}
+}


### PR DESCRIPTION
Go 1.24 added `omitzero` for `encoding/json`. `getStructInfo` only knows `omitempty`, `flow`, and `inline`, so a struct that shares tags with json panics in `mappingStruct`:

```
panic: unsupported flag "omitzero" in tag "...,omitzero"
```

This library's `omitempty` already drops zero values (including structs), so treat `omitzero` as the same flag.

This is the same failure as the archived v3 tree ([go-yaml/yaml#1068](https://github.com/go-yaml/yaml/issues/1068)).

---

Maintainers' edits to the PR description 👇

Somehow related to #235