### PR TITLE
Fix superfluous comma in flow style mappings

### DIFF
--- a/internal/libyaml/emitter.go
+++ b/internal/libyaml/emitter.go
@@ -680,9 +680,9 @@ func (emitter *Emitter) emitFlowMappingKey(event *Event, first, trail bool) erro
 	}
 
 	if event.Type == MAPPING_END_EVENT {
-		if (emitter.canonical ||
-			len(emitter.HeadComment)+len(emitter.FootComment)+len(emitter.TailComment) > 0) &&
-			!first && !trail {
+		// Pending comments never require a separator here: foot comments are
+		// written after '}' and head/tail comments always start on a new line.
+		if emitter.canonical && !first && !trail {
 			if err := emitter.writeIndicator([]byte{','}, false, false, false); err != nil {
 				return err
 			}

--- a/internal/libyaml/testdata/emitter.yaml
+++ b/internal/libyaml/testdata/emitter.yaml
@@ -479,6 +479,20 @@
     - value
     - item1
 
+# Regression test for https://github.com/google/yamlfmt/issues/110: a foot
+# comment attached to a flow mapping must not add a superfluous trailing
+# comma before the closing '}'.
+- roundtrip:
+    name: Flow mapping with foot comment has no superfluous comma
+    yaml: |
+      ---
+      - {foo: bar}
+      # comment
+    want: |
+      ---
+      - {foo: bar}
+      # comment
+
 # Regression tests for https://github.com/yaml/go-yaml/issues/337
 - roundtrip:
     name: Folded scalar preserves newlines


### PR DESCRIPTION
The flow-mapping MAPPING_END branch of the emitter wrote a separator comma whenever a comment buffer was non-empty, matching yaml.v3's original logic. Comments on or below a flow mapping attach to the mapping and arrive with the FLOW_MAPPING_END event, producing output like "- {foo: bar,}".

Interior flow-map comments always flow through the TRAIL path, so a comma is never legitimately needed at MAPPING_END. Align with the flow-sequence END branch, which writes the comma only in canonical mode.

Fixes #405 

- #405 

> [!NOTE]
> This code is borrowed from @sidsri14 and https://github.com/google/yamlfmt/pull/323/changes