### PR TITLE
Validate implicit document endings

### DIFF
--- a/internal/libyaml/parser.go
+++ b/internal/libyaml/parser.go
@@ -595,10 +595,18 @@ func (parser *Parser) parseDocumentEnd(event *Event) error {
 	end_mark := token.StartMark
 
 	implicit := true
-	if token.Type == DOCUMENT_END_TOKEN {
+	switch token.Type {
+	case DOCUMENT_END_TOKEN:
 		end_mark = token.EndMark
 		parser.skipToken()
 		implicit = false
+	case VERSION_DIRECTIVE_TOKEN, TAG_DIRECTIVE_TOKEN,
+		DOCUMENT_START_TOKEN, STREAM_END_TOKEN:
+		// Document ended properly.
+		// https://github.com/yaml/go-yaml/pull/410
+	default:
+		return formatParserError(
+			"did not find expected <document start>", token.StartMark)
 	}
 
 	parser.tag_directives = parser.tag_directives[:0]

--- a/testdata/unmarshal_errors.yaml
+++ b/testdata/unmarshal_errors.yaml
@@ -129,6 +129,13 @@
     want: "go-yaml load error in scanner (while scanning a simple key) at L3.C1-L4.C1: could not find expected ':'"
 
 - unmarshal-error:
+    name: Unseparated content after implicit document (Issue 410)
+    yaml: |2
+       name: test
+      value: 2
+    want: 'go-yaml load error in parser at L2.C1: did not find expected <document start>'
+
+- unmarshal-error:
     name: Missing colon after comment and list (Issue 665)
     yaml: |
       #

--- a/yts/known-failing-tests
+++ b/yts/known-failing-tests
@@ -14,7 +14,6 @@ TestYAMLSuite/3HFZ/LoadTest
 TestYAMLSuite/3UYS/EventComparisonTest
 TestYAMLSuite/3UYS/LoadTest
 TestYAMLSuite/4FJ6/LoadTest
-TestYAMLSuite/4H7K/LoadTest
 TestYAMLSuite/4MUZ-00/EventComparisonTest
 TestYAMLSuite/4MUZ-00/LoadTest
 TestYAMLSuite/4MUZ-01/EventComparisonTest
@@ -79,7 +78,6 @@ TestYAMLSuite/AVM7/JSONComparisonTest
 TestYAMLSuite/AZ63/JSONComparisonTest
 TestYAMLSuite/BEC7/EventComparisonTest
 TestYAMLSuite/BEC7/LoadTest
-TestYAMLSuite/BS4K/LoadTest
 TestYAMLSuite/C4HZ/EventComparisonTest
 TestYAMLSuite/C4HZ/JSONComparisonTest
 TestYAMLSuite/CFD4/EventComparisonTest
@@ -128,7 +126,6 @@ TestYAMLSuite/K3WX/LoadTest
 TestYAMLSuite/K4SU/JSONComparisonTest
 TestYAMLSuite/KK5P/LoadTest
 TestYAMLSuite/KMK3/JSONComparisonTest
-TestYAMLSuite/KS4U/LoadTest
 TestYAMLSuite/KSS4/JSONComparisonTest
 TestYAMLSuite/L24T-01/EventComparisonTest
 TestYAMLSuite/L24T-01/JSONComparisonTest


### PR DESCRIPTION
Reject an implicit document end when the following token cannot start a properly separated document or end the stream.

Add data-driven coverage for issue 410 and update YAML Test Suite expectations for newly passing load cases.

Fixes #410