### PR TITLE
Keep interior comments in empty flow collections

### DIFF
--- a/internal/libyaml/emitter.go
+++ b/internal/libyaml/emitter.go
@@ -602,6 +602,11 @@ func (emitter *Emitter) emitFlowSequenceItem(event *Event, first, trail bool) er
 				return err
 			}
 		}
+		// Interior comments of an empty flow sequence are held as HeadComment
+		// on START; write them after '[' and before ']'.
+		if err := emitter.processHeadComment(); err != nil {
+			return err
+		}
 		emitter.flow_level--
 		emitter.indent = emitter.indents[len(emitter.indents)-1]
 		emitter.indents = emitter.indents[:len(emitter.indents)-1]
@@ -1005,6 +1010,7 @@ func (emitter *Emitter) emitSequenceStart(event *Event) error {
 	} else {
 		emitter.state = EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE
 	}
+	emitter.holdEmptyFlowCollectionComment()
 	return nil
 }
 
@@ -1023,7 +1029,34 @@ func (emitter *Emitter) emitMappingStart(event *Event) error {
 	} else {
 		emitter.state = EMIT_BLOCK_MAPPING_FIRST_KEY_STATE
 	}
+	emitter.holdEmptyFlowCollectionComment()
 	return nil
+}
+
+// holdEmptyFlowCollectionComment keeps an interior comment of an otherwise-
+// empty flow collection from being flushed by the caller of emitNode.
+//
+// The parser attaches that comment as FootComment on the START event because
+// there is no key/value event to carry it. emitNode only switches state, so
+// the caller would write the foot comment before the matching END event
+// writes '{' or '['. Reclassify it as HeadComment so it is emitted inside
+// the collection after the opening indicator.
+func (emitter *Emitter) holdEmptyFlowCollectionComment() {
+	if len(emitter.FootComment) == 0 || len(emitter.HeadComment) != 0 {
+		return
+	}
+	var empty bool
+	switch emitter.events[emitter.events_head].Type {
+	case SEQUENCE_START_EVENT:
+		empty = emitter.checkEmptySequence()
+	case MAPPING_START_EVENT:
+		empty = emitter.checkEmptyMapping()
+	}
+	if !empty {
+		return
+	}
+	emitter.HeadComment = emitter.FootComment
+	emitter.FootComment = nil
 }
 
 // Check if the document content is an empty scalar.

--- a/internal/libyaml/testdata/emitter.yaml
+++ b/internal/libyaml/testdata/emitter.yaml
@@ -493,6 +493,112 @@
       - {foo: bar}
       # comment
 
+# Regression tests for https://github.com/yaml/go-yaml/issues/406: a comment
+# inside an otherwise-empty flow mapping/sequence is attached as a FootComment
+# on the START event. The emitter must keep it inside the brackets instead of
+# flushing it before the opening indicator is written.
+- roundtrip:
+    name: Comment in empty flow mapping as sequence item stays inside
+    yaml: |
+      ---
+      - {
+      # comment
+      }
+    want: |-
+      {
+        # comment
+      }
+
+- roundtrip:
+    name: Comment in empty flow sequence as sequence item stays inside
+    yaml: |
+      ---
+      - [
+      # comment
+      ]
+    want: |-
+      [
+        # comment
+      ]
+
+- roundtrip:
+    name: Comment in empty top-level flow mapping stays inside
+    yaml: |
+      ---
+      {
+      # comment
+      }
+    want: |-
+      {
+        # comment
+      }
+
+- roundtrip:
+    name: Comment in empty flow mapping as block value stays inside
+    yaml: |
+      ---
+      key:
+        {
+      # comment
+        }
+    want: |-
+      {
+        # comment
+      }
+
+# Empty flow collections with head and foot comments (roundtrip).
+- roundtrip:
+    name: Empty flow sequence with head and foot comments
+    yaml: |
+      # head comment
+      []
+      # foot comment
+    want: |-
+      # head comment
+      []
+      # foot comment
+
+- roundtrip:
+    name: Empty flow sequence with head, inner, and foot comments
+    yaml: |
+      # head comment
+      [
+        # inner comment
+      ]
+      # foot comment
+    want: |-
+      # head comment
+      [
+        # inner comment
+      ]
+      # foot comment
+
+- roundtrip:
+    name: Empty flow mapping with head and foot comments
+    yaml: |
+      # head comment
+      {}
+      # foot comment
+    want: |-
+      # head comment
+      {}
+      # foot comment
+
+- roundtrip:
+    name: Empty flow mapping with head, inner, and foot comments
+    yaml: |
+      # head comment
+      {
+        # inner comment
+      }
+      # foot comment
+    want: |-
+      # head comment
+      {
+        # inner comment
+      }
+      # foot comment
+
 # Regression tests for https://github.com/yaml/go-yaml/issues/337
 - roundtrip:
     name: Folded scalar preserves newlines


### PR DESCRIPTION
Empty flow collections were dropping interior comments (`FootComment` with empty content). Hold that comment as `HeadComment` so it survives emit.

Fixes #406